### PR TITLE
Update compile_fos_kernel.rst

### DIFF
--- a/reference/compile_fos_kernel.rst
+++ b/reference/compile_fos_kernel.rst
@@ -13,8 +13,8 @@ To be able to build the kernel from source you need tools to checkout and compil
 
 ::
 
-    debian/ubuntu# sudo apt install git build-essential
-    fedora/centos# sudo yum install git gcc gcc-c++ make
+    debian/ubuntu# sudo apt install git build-essential flex bison libelf-dev
+    fedora/centos# sudo yum install git gcc gcc-c++ make flex bison libelf-dev
 
 
 Build script

--- a/reference/compile_fos_kernel.rst
+++ b/reference/compile_fos_kernel.rst
@@ -14,7 +14,7 @@ To be able to build the kernel from source you need tools to checkout and compil
 ::
 
     debian/ubuntu# sudo apt install git build-essential flex bison libelf-dev
-    fedora/centos# sudo yum install git gcc gcc-c++ make flex bison libelf-dev
+    fedora/centos# sudo yum install git gcc gcc-c++ make flex bison elfutils-libelf-devel 
 
 
 Build script


### PR DESCRIPTION
`flex`, `bison` and `libelf-dev` were also needed on my Ubuntu 22.10.