### PR TITLE
Update requirements.md to show that RHEL 10 is not supported

### DIFF
--- a/docs/installation/server/requirements.md
+++ b/docs/installation/server/requirements.md
@@ -34,7 +34,7 @@ list is by no means an absolute list to follow, though.
 -   Ubuntu 16 or higher
 -   Debian 8 or higher
 -   CentOS 7 or higher
--   Red Hat 6, 7, 8, or 9
+-   Red Hat 6 or higher (RHEL 10+ requires separate DHCP server, See [ISC-DHCP is deprecated](https://github.com/FOGProject/fogproject/issues/730) )
 -   Fedora 22 or higher
 -   Any version of Arch.
 

--- a/docs/installation/server/requirements.md
+++ b/docs/installation/server/requirements.md
@@ -34,7 +34,7 @@ list is by no means an absolute list to follow, though.
 -   Ubuntu 16 or higher
 -   Debian 8 or higher
 -   CentOS 7 or higher
--   Red Hat 6 or higher
+-   Red Hat 6, 7, 8, or 9
 -   Fedora 22 or higher
 -   Any version of Arch.
 


### PR DESCRIPTION
RHEL 10 does not have dhcp-server available as it is end of life. See [this issue](https://github.com/FOGProject/fogproject/issues/730). The documentation currently says RHEL 6 or higher is supported when only RHEL 6-9 is supported at the current time.