### PR TITLE
docs(web): document CSV (All) full export and table scroll mode

### DIFF
--- a/docs/kb/reference/csv_import_export.md
+++ b/docs/kb/reference/csv_import_export.md
@@ -37,6 +37,7 @@ as CSV files from each object's **Import** / **Export** page.
 
 ## Table of contents
 
+- [Exporting](#exporting)
 - [Header row vs. positional](#header-row-vs-positional)
 - [General format rules](#general-format-rules)
 - [The associations column](#the-associations-column)
@@ -51,6 +52,32 @@ as CSV files from each object's **Import** / **Export** page.
   - [Storage Group](#storage-group)
   - [Storage Node](#storage-node)
 - [Plugin extensibility](#plugin-extensibility)
+
+---
+
+## Exporting
+
+Each object type has an **Export** page (for example *Hosts
+:octicons-arrow-right-24: Export Hosts*) with a row of buttons above the table:
+
+- **CSV (All)** — the recommended way to get a complete, import‑ready file. It
+  exports **every** item that matches the current search, server‑side, as a CSV
+  download — not just the rows visible on screen. The file always begins with a
+  header row of column names, so it re‑imports **by name** with no reordering.
+- **Copy**, **Excel**, **Print** — these act only on the rows **currently loaded
+  in the browser** (the on‑screen page, or what you have scrolled through). They
+  are handy for quick, partial grabs rather than a full export.
+- **Column Visibility** — show/hide columns in the on‑screen table. It does not
+  change the **CSV (All)** output, which always contains the full canonical
+  column set for the class (the per‑class layouts below).
+
+>[!tip]
+>Type in the table's **search box first** to scope the export. **CSV (All)**
+>honours the active search, so you can export just the matching subset — for
+>example, every host whose name contains `lab`.
+
+The exported columns — and the optional trailing `associations` column — are
+described per class below.
 
 ---
 

--- a/docs/management/web/config.md
+++ b/docs/management/web/config.md
@@ -19,6 +19,26 @@ much more content is needed here
 
 ## Other Settings
 
+## Table display mode (infinite scroll vs. paging)
+
+The management list and export tables (Hosts, Images, Snapins, and so on) can
+page through records in one of two ways, controlled by a single install‑wide
+setting:
+
+> Other Settings :octicons-arrow-right-24: FOG Settings :octicons-arrow-right-24: FOG View Settings :octicons-arrow-right-24: FOG_TABLE_SCROLL_MODE
+
+- **infinite** *(default)* — virtual scroll: rows load in chunks as you scroll
+  and there is no page‑number bar. Best for quickly skimming large lists.
+- **paged** — the classic page‑number pager with a per‑page length selector.
+
+The setting applies to every management table on the next page load. Choose
+**paged** if you prefer page numbers, or if infinite scroll doesn't suit your
+browser or workflow.
+
+>[!note]
+>A few tables — such as the FOG Settings table itself — always use paging
+>regardless of this setting, because they are grouped and search‑driven.
+
 ## Boot Image Key Map
 
 It is possible to change the keymap or keyboard layout of the linux boot


### PR DESCRIPTION
## What

Documents two web-UI changes shipping in 1.6:

1. **CSV (All) full export.** New `Exporting` section in
   `docs/kb/reference/csv_import_export.md` explaining that **CSV (All)** is a
   server-side export of *every* item matching the current search (not just the
   on-screen rows), that it emits a header row so it re-imports by name, and how
   it differs from the Copy/Excel/Print buttons (which act on loaded rows only)
   and Column Visibility (on-screen only).

2. **Table display mode.** New section in `docs/management/web/config.md`
   documenting the install-wide `FOG_TABLE_SCROLL_MODE` setting
   (**infinite** = virtual scroll, default; **paged** = classic pager) under
   *FOG View Settings*, and noting that grouped/search-driven tables (e.g. the
   FOG Settings table) always use paging.

## Why

These features are new in the FOG 1.6 web UI and weren't documented. The CSV
section extends the existing import/export reference; the scroll-mode section
fills part of the config page that was marked "much more content is needed."

## Notes

- Docs only — no code changes.
- Markdown matches the repo's existing style (frontmatter, `:octicons-*:`
  arrows, `>[!note]`/`>[!tip]` callouts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
