### PR TITLE
docs: remove Pandoc {=html} artifacts; clarify client URL placeholder

### DIFF
--- a/docs/kb/customization/advanced-boot-menu.md
+++ b/docs/kb/customization/advanced-boot-menu.md
@@ -208,7 +208,3 @@ menu generation part of the advanced menu setup.
 
 additional information about ipxe boot menu creation can be found at
 <http://ipxe.org/>
-
-```{=html}
-<hr>
-```

--- a/docs/kb/how-tos/bios-and-uefi-co-existence.md
+++ b/docs/kb/how-tos/bios-and-uefi-co-existence.md
@@ -283,7 +283,7 @@ this, exactly, because it\'s case sensitive:
 As you type this in, the ID and Binary fields will auto-update. When
 done, click Ok, ok, ok to finish this part of the procedure.
 
-`<font color="red">`{=html}**NOTE:**`</font>`{=html} There are many
+<font color="red">**NOTE:**</font> There are many
 other UEFI architectures besides just \"PXEClient:Arch:00007\".
 
 \"PXEClient:Arch:00002\" and \"PXEClient:Arch:00006\" both should get
@@ -418,14 +418,14 @@ For example, This line would (incorrectly) match the below IP Phone\'s
 option 060:
 
 match if substring(option vendor-class-identifier, 19, 1) =
-\"`<font color="red">`{=html}**0**`</font>`{=html}\";
+\"<font color="red">**0**</font>\";
 
 \"Cisco VOIP phone
-00`<font color="red">`{=html}**0**`</font>`{=html}562\"
+00<font color="red">**0**</font>562\"
 
 It would also match this string:
 
-\"PXEClient:Arch:0000`<font color="red">`{=html}**0**`</font>`{=html}\"
+\"PXEClient:Arch:0000<font color="red">**0**</font>\"
 
 Because the 20th character is a zero, this IP phone using the above
 configuration would be matched and given the defined options instead of

--- a/docs/kb/reference/archive/Acer-Iconia-Tab-w500.md
+++ b/docs/kb/reference/archive/Acer-Iconia-Tab-w500.md
@@ -11,7 +11,7 @@ tags:
 
 # Acer Iconia Tab w500
 
-`<font color="red">`{=html}Note:`</font>`{=html} This article is older
+<font color="red">Note:</font> This article is older
 (year 2012), and has only had it\'s terminology updated to reflect
 current FOG terminology.
 

--- a/docs/kb/reference/fog-client-installation-options.md
+++ b/docs/kb/reference/fog-client-installation-options.md
@@ -42,16 +42,16 @@ download the client from the FOG Web UI:
 > -   Click on the link 'MSI \-- Network Installer' to run the MSI
 >     package (can also be used with gpo software deployment and other
 >     silent installs).
-> -   The url to download this is
->     <http://fogserver/fog/client/download.php?newclient>
+> -   The url to download this is (where `fogserver` is the name of your fog server hostname)
+>     `http://fogserver/fog/client/download.php?newclient`
 
 ### Smart Installer
 
 > -   Click on the Smart Installer link to download and run the smart
 >     installer. This is a cross-platform installation that detects your
 >     operating system
-> -   The url to download this is
->     <http://fogserver/fog/client/download.php?smartinstaller>
+> -   The url to download this is (where `fogserver` is the name of your local fog server)
+>     `http://fogserver/fog/client/download.php?smartinstaller`
 
 ### Run The Installer
 
@@ -161,16 +161,12 @@ There are various ways to uninstall the client:
 -   Uninstall via 'Programs and Features' or 'Apps & Features'
 -   Uninstall via MSI. Example:
 
-```{=html}
 <!-- -->
-```
     msiexec /i FOGService.msi /quiet
 
 -   Uninstall using the SmartInstaller. Example:
 
-```{=html}
 <!-- -->
-```
     SmartInstaller.exe uninstall 
 
 ## Linux client
@@ -252,9 +248,7 @@ download the client from the FOG Web UI:
 -   Select the SmartInstaller and download it
 -   Run the installer with mono:
 
-```{=html}
 <!-- -->
-```
     sudo mono SmartInstaller.exe
 
 The client will install to /opt/fog-service.
@@ -311,9 +305,7 @@ download the client from the FOG Web UI:
 -   Select the SmartInstaller.
 -   Install the SmartInstaller with mono:
 
-```{=html}
 <!-- -->
-```
     sudo mono SmartInstaller.exe
 
 -   Reboot the system to complete the installation.

--- a/docs/kb/reference/vi.md
+++ b/docs/kb/reference/vi.md
@@ -64,4 +64,4 @@ External Video Link:
 
 Video:
 
-`<embedvideo service="youtube">`{=html}<https://www.youtube.com/watch?v=1konvzseurI>`</embedvideo>`{=html}
+[Watch on YouTube](https://www.youtube.com/watch?v=1konvzseurI)

--- a/docs/kb/troubleshooting/troubleshoot-ftp.md
+++ b/docs/kb/troubleshooting/troubleshoot-ftp.md
@@ -57,9 +57,7 @@ Linux machine (this example uses Fedora).
 -   Delete the file.
 -   Exit ftp.
 
-```{=html}
 <!-- -->
-```
     [administrator@D620 ~]$ echo 'some text here to send later' > test.txt
     [administrator@D620 ~]$ ftp
     ftp> open 10.0.0.3
@@ -125,9 +123,7 @@ Linux machine (this example uses Fedora).
 -   Close connection
 -   Close FTP.
 
-```{=html}
 <!-- -->
-```
     c:\SomeFolder>echo This is a bit of text to throw into a file > text.txt
 
     c:\SomeFolder>ftp
@@ -166,18 +162,14 @@ Linux machine (this example uses Fedora).
 
 -   Check the status of FTP with
 
-```{=html}
 <!-- -->
-```
     systemctl status vsftpd.service
 
 (Should be on and green, no errors, and enabled)
 
 -   stop, start, disable and enable FTP service.
 
-```{=html}
 <!-- -->
-```
     systemctl stop vsftpd.service
     systemctl start vsftpd.service
     systemctl disable vsftpd.service
@@ -187,9 +179,7 @@ Linux machine (this example uses Fedora).
     top of this article additionally, if you open a web browser and go
     to
 
-```{=html}
 <!-- -->
-```
     ftp://x.x.x.x
 
 -   Use fog / your-fog-account-Password for the credentials
@@ -199,9 +189,7 @@ Linux machine (this example uses Fedora).
 
 -   Restart FTP service.
 
-```{=html}
 <!-- -->
-```
     service vsftpd restart
 
 -   Enable and disable are not available due to this service being in
@@ -210,9 +198,7 @@ Linux machine (this example uses Fedora).
     top of this article additionally, if you open a web browser and go
     to
 
-```{=html}
 <!-- -->
-```
     ftp://x.x.x.x
 
 -   Use fog / your-fog-account-Password for the credentials (Since v.


### PR DESCRIPTION
## Pandoc artifact cleanup (Fixes #23)

The rst→md migration left Pandoc raw-HTML markers that render as literal code blocks / garbage on **six published pages**. #23 reported it on the Troubleshoot FTP page; the same artifact was present on five others, so this clears all of them in one pass:

- **`troubleshoot-ftp.md`** / **`fog-client-installation-options.md`** — ` ```{=html}\n<!-- -->\n``` ` list-separator fences → bare `<!-- -->` comments (kept so the following indented code blocks stay separated from the lists, invisible in output).
- **`bios-and-uefi-co-existence.md`** / **`Acer-Iconia-Tab-w500.md`** — `` `<font color="red">`{=html}…`</font>`{=html} `` → clean inline `<font color="red">…</font>`.
- **`advanced-boot-menu.md`** — dangling trailing `<hr>` fence removed.
- **`vi.md`** — broken MediaWiki `<embedvideo>` tag (a duplicate of the working link right above it) → plain `[Watch on YouTube](…)` link.

## Client URL placeholder (Addresses #26)

On the FOG Client installation options page the download URLs were rendered as **clickable autolinks** (`<http://fogserver/…>`) with no note that `fogserver` is a placeholder — so users clicked them and hit a dead host. Added the same "where `fogserver` is the name of your fog server hostname" wording the install-fog-client page already uses, and demoted the autolinks to non-clickable code.

> Note: if the original confusion came from the live FOG Web UI page rather than the docs, that would be a separate change in the `fogproject` core repo — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)