### PR TITLE
docs(how-tos): flesh out post download scripts page

### DIFF
--- a/docs/kb/how-tos/post-download-scripts.md
+++ b/docs/kb/how-tos/post-download-scripts.md
@@ -2,12 +2,10 @@
 title: Post Download Scripts
 aliases:
     - Post Download Scripts
-description: How to use post download scripts
+    - Post Install Scripts
+description: How to use FOG post download scripts to run custom automation on a host after an image is deployed
 context_id: post-download-scripts
 tags:
-    - in-progress
-    - updating-content
-    - help-wanted
     - driver-injection
     - post-download
     - how-to
@@ -16,16 +14,120 @@ tags:
 
 # Post Download Scripts
 
-Fog has the ability to run bash scripts to add various automations after an image finished downloading to a host. This page will eventually outline these in detail but it is a place holder for now.
+FOG can run your own bash scripts on a host **after an image finishes deploying
+but before the host reboots**, from inside the FOS imaging environment. This is
+the hook you use for anything FOG itself doesn't do — injecting drivers,
+recreating UEFI boot entries, renaming partitions, writing host-specific config,
+and so on.
 
-There is lots of information on this topic in the forums that will be organized and moved into this page and maybe some sub-pages
+> [!note]
+> These run **after a deploy (download)**. If you need to run something *before*
+> imaging (for example, custom partitioning), use a post-init script instead —
+> see [Post-init scripts](#post-init-scripts-before-imaging) below.
 
-For a worked example, see [[uefi-boot-entries|Managing UEFI Boot Entries (efibootmgr)]], which uses a post-download script to recreate UEFI boot entries after a deploy.
+## How it works
 
-See these posts for some more examples
+The installer creates a scripts directory and a master script on your FOG server:
 
-* *[The magical, mystical FOG post download script | FOG Project](https://forums.fogproject.org/topic/7740/the-magical-mystical-fog-post-download-script)
-* [FOG Post install script for Win Driver injection | FOG Project](https://forums.fogproject.org/topic/8889/fog-post-install-script-for-win-driver-injection?_=1682187993801)
+```
+/images/postdownloadscripts/fog.postdownload
+```
 
+`fog.postdownload` is the entry point that FOS runs. It is **sourced** (with the
+`.` / `source` builtin), so any script you call from it runs in the same shell
+and inherits all of the imaging environment's variables. The file ships with the
+calling syntax in its comments:
 
+```bash
+#!/bin/bash
+## This file serves as a starting point to call your custom postimaging scripts.
+## <SCRIPTNAME> should be changed to the script you're planning to use.
+## Syntax of post download scripts are
+#. ${postdownpath}<SCRIPTNAME>
+```
 
+To add your own script:
+
+1.  Drop it in `/images/postdownloadscripts/`, e.g.
+    `/images/postdownloadscripts/myscript.sh`.
+2.  Add a line to `fog.postdownload` that sources it (note the leading `.` and
+    that `${postdownpath}` already points at the scripts directory):
+
+    ```bash
+    . ${postdownpath}myscript.sh
+    ```
+
+3.  That's it — the script runs on every deploy. Use the variables described
+    below to limit it to specific hosts or images.
+
+> [!tip]
+> Because `fog.postdownload` is sourced, you generally don't need to `chmod +x`
+> your script — but keeping it executable does no harm. Make sure the files are
+> readable by the FOG/apache user so FOS can pull them over NFS.
+
+## Variables available to your script
+
+FOS exports a number of variables you can branch on. The commonly used ones
+include:
+
+| Variable | Meaning |
+| --- | --- |
+| `$disk` | the disk that was imaged (for example `/dev/sda` or `/dev/nvme0n1`) |
+| `$hostname` | the host's name as registered in FOG |
+| `$mac` | the host's primary MAC address |
+| `$imagename` | the name of the image that was deployed |
+| `$osid` | the numeric OS ID set on the image |
+| `${postdownpath}` | path to the post-download scripts directory |
+
+The deployed partitions are present as the usual block devices, but FOS does not
+necessarily leave them mounted — if your script needs to read or write files on
+the deployed OS, mount the partition yourself (for example
+`mount /dev/sda2 /mnt`) and unmount it when you're done.
+
+> [!tip]
+> The exact set of variables can differ between FOS versions. To see everything
+> that is available in your environment, temporarily add `printenv | sort` to
+> your script and watch the host's screen (or its imaging log) during a deploy.
+
+## Worked examples
+
+-   **Recreate UEFI boot entries** after a multi-disk or dual-boot deploy —
+    [[uefi-boot-entries|Managing UEFI Boot Entries (efibootmgr)]] and
+    [[deploy-dual-boot-multi-disk-image|Deploying a Dual-Boot Multi-Disk Image]].
+-   **Windows driver injection** — see the forum write-up linked below.
+
+A minimal skeleton that only acts on one image looks like this:
+
+```bash
+#!/bin/bash
+# /images/postdownloadscripts/example.sh
+case "$imagename" in
+    win11-lab)
+        # mount the deployed Windows partition and do something
+        mount /dev/${disk#/dev/}2 /mnt 2>/dev/null
+        # ... your changes here ...
+        umount /mnt 2>/dev/null
+        ;;
+esac
+```
+
+## Post-init scripts (before imaging)
+
+There is a matching hook that runs **before** imaging begins (right after FOS
+loads), useful for custom partitioning or disk prep. It mirrors the
+post-download layout:
+
+```
+/images/dev/postinitscripts/fog.postinit
+```
+
+Call your scripts from `fog.postinit` with:
+
+```bash
+. ${postinitpath}<SCRIPTNAME>
+```
+
+## More examples and discussion
+
+-   [The magical, mystical FOG post download script (FOG forums)](https://forums.fogproject.org/topic/7740/the-magical-mystical-fog-post-download-script)
+-   [FOG post install script for Windows driver injection (FOG forums)](https://forums.fogproject.org/topic/8889/fog-post-install-script-for-win-driver-injection)


### PR DESCRIPTION
Fills the `post-download-scripts.md` placeholder (the first of the "missing data" pages).

### What's covered
- **Mechanism** — `/images/postdownloadscripts/fog.postdownload` as the entry point, sourced with `.` so your scripts inherit the imaging environment; the `. ${postdownpath}<script>` calling syntax. All verified against the installer's `configureStorage()` in `lib/common/functions.sh`.
- **How to add a script** (drop in the dir, source it from `fog.postdownload`).
- **Variables** available to scripts, with worked examples and a minimal skeleton.
- **Post-init scripts** — the matching pre-imaging hook at `/images/dev/postinitscripts/fog.postinit`.
- Cross-links to the efibootmgr and dual-boot pages; keeps the two original forum links.
- Drops the stale `in-progress`/`updating-content`/`help-wanted` tags.

### ⚠️ One thing for you to verify before/after merge
The **variables table** (`$disk`, `$hostname`, `$mac`, `$imagename`, `$osid`, `${postdownpath}`) is drawn from FOG domain knowledge + the forum write-ups, **not** verified against the FOS source (that lives in the buildroot repo, not `fogproject`). I hedged it with a `printenv | sort` "discover what's available in your version" tip, but you'd know the exact, current names. Correct any and I'll amend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)