### PR TITLE
docs(how-tos): replace the OS X DHCP stub with accurate guidance

### DIFF
--- a/docs/kb/how-tos/bios-and-uefi-co-existence.md
+++ b/docs/kb/how-tos/bios-and-uefi-co-existence.md
@@ -376,11 +376,19 @@ or server options.
 
 # Using OS X DHCP
 
-osx dhcp tbd
+> [!note]
+> macOS Server's DHCP service (bootpd) has been deprecated by Apple and is not
+> available on current macOS. This section is kept for reference.
 
-### Steps Here
+macOS Server's DHCP can hand out a next-server (option 66) and a single boot file
+name (option 67), but it does **not** support the architecture-based conditional
+logic FOG needs to serve different boot files to BIOS and UEFI clients (the way
+ISC dhcpd, dnsmasq, and Windows DHCP do).
 
-Please list OS X steps here.\'
+If you must use macOS for DHCP in a mixed BIOS/UEFI environment, run a proxyDHCP
+helper such as dnsmasq alongside it to supply the boot file — see
+[[proxy-dhcp|Proxy DHCP with dnsmasq]]. Otherwise, use one of the other DHCP
+servers covered on this page.
 
 ## Building custom DHCP Classes for co-existence with FOG
 


### PR DESCRIPTION
Last small missing-data stub: the `osx dhcp tbd` / "Please list OS X steps here" placeholder in the BIOS/UEFI co-existence page.

Rather than fabricate steps for a deprecated product, I replaced it with the accurate situation: macOS Server's DHCP (bootpd) is deprecated by Apple and lacks the architecture-based conditional bootfile logic FOG needs, so for mixed BIOS/UEFI you'd pair it with a proxyDHCP helper (dnsmasq) — with a link to the proxy-dhcp page.

Tweak the macOS framing if you'd prefer to just drop the section entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)