### PR TITLE
docs(csv): document delimiter escaping in associations column

### DIFF
--- a/docs/kb/reference/csv_import_export.md
+++ b/docs/kb/reference/csv_import_export.md
@@ -159,6 +159,33 @@ Example (a host):
 groups:Lab A|Lab B;snapins:7zip|Chrome;printers:FrontDesk
 ```
 
+#### Escaping delimiters in names
+
+If an object's **name** legitimately contains one of the structural
+characters (`;`, `:`, `|`) — or a backslash — prefix it with a backslash
+(`\`) so it is treated as a literal part of the name rather than a separator.
+Export does this automatically; you only need to write escapes by hand when
+authoring an import file.
+
+| Character in a name | Write it as |
+|---------------------|-------------|
+| `\` (backslash)     | `\\`        |
+| `;`                 | `\;`        |
+| `:`                 | `\:`        |
+| `\|`                | `\\|`       |
+
+Example — a group literally named `Lab A|Lab B` and a printer named
+`Room 3: Floor 2`:
+
+```
+groups:Lab A\|Lab B;printers:Room 3\: Floor 2
+```
+
+This parses as the **single** group name `Lab A|Lab B` and the **single**
+printer name `Room 3: Floor 2`. A `\\` is read as one literal backslash, and
+only **unescaped** delimiters split the cell. Labels (`groups`, `printers`,
+…) are fixed keys and are never escaped.
+
 ### Resolution rules
 
 - **Id or name.** Each value is resolved by **numeric id first, then by
@@ -185,9 +212,10 @@ groups:Lab A|Lab B;snapins:7zip|Chrome;printers:FrontDesk
 plugin is installed. A host has a single location, so only the first value is
 used.
 
-> **Caveat:** because `;`, `:` and `|` are structural, an object **name** that
-> literally contains one of those characters can't currently be expressed in
-> the associations cell. Such values are best referenced by **id**.
+> **Note:** because `;`, `:` and `|` are structural, an object **name** that
+> literally contains one of those characters must be **escaped** with a
+> backslash (see *Escaping delimiters in names* above). Export escapes them for
+> you; referencing such an object by **id** also avoids the issue entirely.
 
 ---
 


### PR DESCRIPTION
Mirrors the in-repo `docs/CSV_IMPORT_EXPORT.md` update for fogproject **#854** (follow-up to **#828**).

The CSV `associations` column uses `;` `:` `|` as structural delimiters, so an object **name** that literally contains one of them previously corrupted the cell. The fogproject change adds backslash escaping so such names round-trip; this PR documents it:

- Adds an **"Escaping delimiters in names"** subsection with the escape table (`\` → `\\`, `;` → `\;`, `:` → `\:`, `|` → `\|`) and a worked example.
- Revises the former *"best referenced by id"* caveat — escaping now resolves the collision (id reference still works as an alternative).

Code change: FOGProject/fogproject@ad9ef13f4 on `working-1.6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)