### PR TITLE
docs(csv): document host site in associations column (#855)

### DIFF
--- a/docs/kb/reference/csv_import_export.md
+++ b/docs/kb/reference/csv_import_export.md
@@ -201,7 +201,7 @@ only **unescaped** delimiters split the cell. Labels (`groups`, `printers`,
 
 | Class | Labels | Resolves against |
 |-------|--------|------------------|
-| Host | `groups`, `snapins`, `printers`, `modules`, `location`¹ | Group, Snapin, Printer, Module, Location — by name |
+| Host | `groups`, `snapins`, `printers`, `modules`, `location`¹, `site`² | Group, Snapin, Printer, Module, Location, Site — by name |
 | Image | `storagegroups` | Storage Group — by name |
 | Snapin | `storagegroups` | Storage Group — by name |
 | Group | `hosts` | Host — by name (the group's members) |
@@ -211,6 +211,9 @@ only **unescaped** delimiters split the cell. Labels (`groups`, `printers`,
 ¹ `location` is provided by the **Location** plugin and only appears when that
 plugin is installed. A host has a single location, so only the first value is
 used.
+
+² `site` is provided by the **Site** plugin and only appears when that plugin
+is installed. A host has a single site, so only the first value is used.
 
 > **Note:** because `;`, `:` and `|` are structural, an object **name** that
 > literally contains one of those characters must be **escaped** with a
@@ -247,7 +250,7 @@ exactly. `associations` is always the optional final column where supported.
 | 14 | `ADPassLegacy` | 30 | `tokenlock` |
 | 15 | `productKey` | 31 | `associations` *(optional)* |
 
-Associations: `groups`, `snapins`, `printers`, `modules`, `location`¹.
+Associations: `groups`, `snapins`, `printers`, `modules`, `location`¹, `site`².
 
 ### Image
 
@@ -352,7 +355,9 @@ import and export, without patching core:
   receives the `parts` array (by reference) for last‑mile tweaks.
 
 The Location plugin (`addlocationimport.hook.php`) is the reference
-implementation, registering a single‑valued `location` type for hosts.
+implementation, registering a single‑valued `location` type for hosts. The
+Site plugin (`addsiteimport.hook.php`) follows the same pattern for a host's
+`site`.
 
 See issue [#828](https://github.com/FOGProject/fogproject/issues/828) for the
 design discussion and history.


### PR DESCRIPTION
Mirrors the in-repo doc change for fogproject **#855** (Site plugin CSV consumer).

The Site plugin now carries a host's site in the trailing `associations` column, mirroring the Location plugin. This updates the CSV reference page to match:

- Host labels table gains `site`² (resolves against Site by name).
- New footnote ²: `site` is provided by the **Site** plugin and only appears when installed; a host has a single site, so only the first value is used.
- Per-class Host associations line gains `site`².
- Plugin-extensibility section references `addsiteimport.hook.php` alongside the Location reference implementation.

Companion to the escaping docs merged in #46. Code shipped on `working-1.6` (commit `3cd19a84c`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)