### PR TITLE
docs(csv): document export association batching

### DIFF
--- a/docs/kb/reference/csv_import_export.md
+++ b/docs/kb/reference/csv_import_export.md
@@ -383,12 +383,35 @@ import and export, without patching core:
   ```
 
 - **`EXPORT_ASSOCIATIONS`** — fired while a row's associations cell is built;
-  receives the `parts` array (by reference) for last‑mile tweaks.
+  receives the `parts` array (by reference) for last‑mile tweaks. To keep large
+  exports fast this event only fires when a listener is actually registered, so
+  a row with no `EXPORT_ASSOCIATIONS` listeners never hydrates its object.
+
+- **`EXPORT_ASSOCIATIONS_PRIME`** — fired **once per export** (not per row),
+  before any cell is built, with `childClass` and the full list of row `ids`.
+  Plugins can use it to bulk‑resolve their label for the whole result set in a
+  couple of queries and hand the result back via
+  `FOGPage::primeAssociationLabel($childClass, $label, $byParentId)`, where
+  `$byParentId` maps each parent id to an array of names. Any label that is not
+  primed simply falls back to the per‑row `get` path, so listening is purely an
+  optimization.
 
 The Location plugin (`addlocationimport.hook.php`) is the reference
-implementation, registering a single‑valued `location` type for hosts. The
-Site plugin (`addsiteimport.hook.php`) follows the same pattern for a host's
-`site`.
+implementation, registering a single‑valued `location` type for hosts and
+listening for `EXPORT_ASSOCIATIONS_PRIME` to batch that label. The Site plugin
+(`addsiteimport.hook.php`) follows the same pattern for a host's `site`.
 
-See issue [#828](https://github.com/FOGProject/fogproject/issues/828) for the
-design discussion and history.
+### Export performance
+
+Building the associations column naively costs roughly five queries per row (a
+fresh object plus one lazy lookup per label). To avoid that N+1, the exporter
+bulk‑primes every row's association names **once** before formatting begins:
+core host labels (`groups`, `snapins`, `printers`, `modules`) are loaded with a
+single `IN()` query per association class, cached per parent id, and each row's
+cell is then built from that cache with no per‑row object or query. Plugins opt
+into the same batching via `EXPORT_ASSOCIATIONS_PRIME` (above). The output is
+identical to the per‑row path — this only changes how the names are fetched.
+
+See issues [#828](https://github.com/FOGProject/fogproject/issues/828) (design
+and history) and [#857](https://github.com/FOGProject/fogproject/issues/857)
+(export batching) for details.


### PR DESCRIPTION
Documents the CSV **export** association batching shipped in fogproject working-1.6 (commit `beb14bf33`, tracking issue [fogproject#857](https://github.com/FOGProject/fogproject/issues/857)).

- Notes that `EXPORT_ASSOCIATIONS` now fires only when a listener is registered (no per-row object hydration otherwise).
- Documents the new **`EXPORT_ASSOCIATIONS_PRIME`** hook and the `FOGPage::primeAssociationLabel($childClass, $label, $byParentId)` plugin contract for batching a label across the whole export.
- Adds an **Export performance** subsection explaining the once-per-export bulk prime (one `IN()` query per association class) that replaces the per-row N+1, with identical output.

Edits are additive and confined to the *Plugin extensibility* section, so they should not conflict with the open Site (#47) / FK (#48) doc PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)