### PR TITLE
docs(imaging): document per-LV LVM capture and deploy

### DIFF
--- a/docs/kb/reference/lvm-imaging.md
+++ b/docs/kb/reference/lvm-imaging.md
@@ -1,0 +1,163 @@
+---
+title: LVM and Imaging
+aliases:
+    - LVM and Imaging
+    - LVM
+    - Logical Volume Manager
+    - Imaging LVM Volumes
+description: How FOG captures and deploys Linux LVM volumes per logical volume, which layouts are supported, and how to fall back to the old raw-blob behavior
+context_id: lvm-imaging
+tags:
+    - imaging
+    - linux
+    - lvm
+    - reference
+---
+
+# LVM and Imaging
+
+Most modern Linux installers (Ubuntu, RHEL/Rocky/Alma, Fedora, openSUSE)
+default to **LVM**: instead of putting filesystems directly on partitions,
+they create one partition as an LVM **physical volume** (PV), group it into a
+**volume group** (VG), and carve the actual filesystems out of that as
+**logical volumes** (LVs) — typically a root LV and a swap LV.
+
+FOG images these installs **per logical volume**. This is part of the FOS
+imaging engine, so it applies to any FOG server version running a FOS build
+that includes it.
+
+> [!note]
+> **Older FOS behavior.** FOS builds without per-LV support capture the whole
+> PV partition byte-for-byte with `partclone.imager`, which has no used-block
+> map for LVM — a 500 GB PV with 20 GB of data produced a ~500 GB read at
+> capture. That path still exists and is what unsupported layouts fall back
+> to (see below).
+
+## What capture does
+
+When capture finds a partition holding an LVM physical volume (detected by
+content, so it works regardless of the partition's type ID), it:
+
+1. Activates the volume group and checks the layout is supported (see
+   below). Capture never writes to the source machine.
+2. Records the PV/VG/LV layout — names, UUIDs, sizes — in two small metadata
+   files stored with the image (`dNpM.lvm` and `dNpM.lvm.vgcfg`).
+3. Captures **each logical volume individually** with the partclone type
+   matching its filesystem, used blocks only — the same way a plain
+   partition is captured. Each LV becomes its own file in the image
+   (`dNpM.<lvname>.img`).
+4. Swap LVs are not imaged at all; only their UUID is recorded, exactly like
+   swap partitions.
+
+Image size and capture time become proportional to the **data in the logical
+volumes**, not the size of the PV partition.
+
+## What deploy does
+
+Deploy recreates the partition at its original size, rebuilds the PV and VG
+from the recorded metadata, restores each logical volume's filesystem, and
+regenerates swap LVs. **Every UUID is preserved** — physical volume, volume
+group, logical volumes, filesystems, and swap — so `/etc/fstab`, GRUB
+configs, and initramfs references in the deployed OS keep working without
+modification.
+
+Deploy failures are treated as fatal: the task stops with a message rather
+than leaving a half-restored volume group that might appear to boot.
+
+## Supported layouts
+
+Per-LV imaging handles the layout desktop and server installers create by
+default:
+
+- **one volume group** on the PV,
+- the VG lives **entirely on that one PV**, and
+- all logical volumes are **linear** (plain LVs — the default).
+
+Anything else falls back to the old raw capture of the whole PV partition —
+the pre-existing behavior, not a failure. The capture log tells you when
+this happens and why:
+
+```
+ * LVM layout is not supported for per-LV capture: volume group vg0 spans 2 physical volumes
+ * Falling back to raw capture of the whole physical volume
+```
+
+Layouts that fall back:
+
+- **Multi-PV volume groups** — a VG spanning two or more disks/partitions.
+- **Thin pools, RAID/mirror LVs, cache LVs, snapshots** — any non-linear LV
+  in the VG.
+- **A PV with no volume group** on it.
+
+A raw-captured PV deploys the same way it did before: byte-for-byte, only
+onto a partition of identical size (in practice this means the
+*Multiple Partition Image - All Disks* image type).
+
+Two more cases worth knowing:
+
+- **LUKS inside an LV** (e.g. Ubuntu's "encrypt with LVM" option) is fine —
+  the encrypted LV is captured raw, but only at the LV's size, and restores
+  working.
+- **Whole-disk PVs** (a PV created directly on `/dev/sdb` with no partition
+  table) are not detected and not captured. This is unchanged from before.
+
+## Sizing: the PV partition is fixed-size
+
+Phase 1 of LVM support restores the volume group **at its original size**.
+The PV partition is automatically treated as a fixed-size partition by the
+resize engine, so:
+
+- Deploy to a disk **the same size or larger** than the source. On a larger
+  disk, the extra space is left unallocated after the PV partition — you can
+  expand into it manually (`growpart`/`pvresize`/`lvextend`) after deploy.
+- With the *Single Disk - Resizable* image type, the disk still needs **at
+  least one resizable non-LVM partition** (standard installs satisfy this
+  with the ext4 `/boot` partition). A disk that is only EFI + PV should use
+  one of the *Multiple Partition* image types.
+
+Shrinking and expanding the logical volumes themselves to fit the target
+disk is planned as a follow-up; the metadata this phase records is the
+foundation for it.
+
+## Multicast is not supported yet
+
+The multicast sender does not yet know about per-LV image files, so a
+multicast deploy of an LVM image stops with:
+
+```
+Multicast deploy of LVM images is not supported yet, deploy unicast
+```
+
+Deploy LVM images with **unicast** tasks (or group deploys, which are
+unicast per host).
+
+## Reverting to the old behavior: `skiplvm=1`
+
+If per-LV capture misbehaves on some machine, add `skiplvm=1` to the host's
+**Kernel Arguments** (Host Management → the host → *Host Kernel Arguments*)
+and capture again. FOS then treats the PV partition exactly as older
+versions did: one raw image of the whole partition. Remove the argument to
+get per-LV behavior back.
+
+## Image compatibility
+
+- **Old images deploy unchanged.** An image captured before per-LV support
+  has a raw PV image file and no LVM metadata files, so deploy takes the
+  raw path it always has.
+- **New images need a current FOS.** An LVM image captured with per-LV
+  support cannot be deployed by an older FOS client — keep client (kernel +
+  init) and images moving forward together, as with any FOS feature. A
+  deploy will also refuse, rather than guess, if it meets metadata written
+  by a **newer** FOS than the one deploying:
+
+```
+Image was captured with a newer LVM format (LVMFORMAT 2), update FOS
+```
+
+## See also
+
+- [[images|Image Management]] — image types and their constraints
+- [[capture-an-image|Capture an Image]]
+- [[deploy-an-image|Deploy an Image]]
+- [[sector-size-imaging|Sector Sizes and Imaging]] — the other geometry
+  constraint on deploys

--- a/docs/management/web/images.md
+++ b/docs/management/web/images.md
@@ -106,7 +106,9 @@ tags:
     It is possible to capture Linux systems with this type of image given the following criteria
 
     :   -   There is a Grub boot loader present.
-        -   LVM is not used.
+        -   LVM setups are supported on FOS builds that include
+            [[lvm-imaging|per-LV LVM imaging]]; on older FOS builds LVM
+            must not be used.
         -   The partitions include **ext2**, **ext3**, **ext4**,
             **reiserfs**, and/or **swap**.
         -   The swap partition should be moved out of the extended


### PR DESCRIPTION
Companion documentation for FOGProject/fos#120 (per-LV LVM capture and deploy).

## New page

**`docs/kb/reference/lvm-imaging.md`** — reference page covering:

- What capture does: content-based PV detection, per-LV partclone imaging (used blocks only), the two metadata sidecar files, swap-LV UUID recording.
- What deploy does: PV/VG/LV recreation with every UUID preserved (so `fstab`/GRUB/initramfs survive), swap regeneration, fail-loud semantics.
- Supported layouts (single-PV VG, linear LVs — the installer default) and the loud raw-blob fallback for multi-PV VGs, thin/RAID/cache/snapshot LVs, and VG-less PVs, with the actual log messages quoted.
- Sizing: the PV partition deploys fixed-size (same-or-larger disks; grow manually into extra space), and the Single Disk - Resizable requirement of one resizable non-LVM partition.
- Unicast-only for now (multicast refusal message quoted).
- The `skiplvm=1` kernel-argument escape hatch back to raw-blob capture.
- Image compatibility: old images deploy unchanged; newer-format metadata refuses with a clear message.

Framed version-neutrally as FOS imaging-engine behavior, same approach as the sector-size pages (#52). Auto-appears in the nav via include_dir_to_nav.

## Touched page

**`docs/management/web/images.md`** — the Linux capture criteria for *Multiple Partition Image - Single Disk* said "LVM is not used."; now links to the new page and notes the constraint only applies to older FOS builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)