### PR TITLE
docs(api): document 1.6 pagination, ?expand, and pluginItems

### DIFF
--- a/docs/kb/integrations/api-expansion-and-pagination.md
+++ b/docs/kb/integrations/api-expansion-and-pagination.md
@@ -1,0 +1,299 @@
+---
+title: API Pagination, Expansion & Plugin Items
+description: How to paginate list results, inline related objects with ?expand, and read the pluginItems envelope in the FOG REST API
+context_id: api-expansion-and-pagination
+aliases:
+    - API Expansion
+    - API Pagination
+    - API Expand
+    - Plugin Items
+tags:
+    - 1_6-changes
+    - kb
+    - integrations
+    - api
+---
+
+# API Pagination, Expansion & Plugin Items
+
+FOG 1.6 adds three **additive, opt-in** capabilities to the REST API described
+in the main [API](api.md) article:
+
+* **Pagination** — page through large list endpoints with `start`/`length`.
+* **Relation expansion** — inline full related objects with `?expand=…`.
+* **The `pluginItems` envelope** — a namespaced place where plugins inject their
+  associations without ever clobbering core fields.
+
+!!! info "Nothing changes unless you ask for it"
+    These features are strictly additive. If you don't send `?expand=…` and
+    don't page, every existing response keeps exactly the same shape it had
+    before. Scalar foreign keys (for example `imageID`) are always preserved —
+    expansion **adds** an object alongside the key, it never replaces the key.
+
+All examples assume the API is enabled and you are sending the
+`fog-api-token` and `fog-user-token` headers (see
+[Authentication](api.md#authentication)).
+
+---
+
+## Pagination
+
+List endpoints (`/fog/host`, `/fog/image`, `/fog/snapin`, `/fog/user`, …) are
+backed by FOG's DataTables server-side processor. They accept the standard
+DataTables parameters and return a DataTables-shaped envelope.
+
+!!! warning "List parameters go in the request BODY, not the query string"
+    Because of the internal web-server rewrite that fronts the API, list
+    endpoints read their parameters (`start`, `length`, `search`, `order`,
+    `draw`) from the **request body**, not from the URL query string. With
+    `curl` you pass them with `--data`. The request is still a `GET`.
+
+### Parameters
+
+| Parameter | Meaning                                                        | Default |
+|-----------|----------------------------------------------------------------|---------|
+| `start`   | Zero-based offset of the first row to return.                  | `0`     |
+| `length`  | Maximum number of rows to return.                              | all     |
+| `search`  | Free-text filter (DataTables global search value).             | none    |
+| `order`   | DataTables ordering array.                                     | by name |
+| `draw`    | Echoed back verbatim; useful for correlating async responses.  | `0`     |
+
+### Response envelope
+
+```json
+{
+  "draw": 0,
+  "recordsTotal": 85,
+  "recordsFiltered": 85,
+  "data": [ { "id": 1, "name": "..." }, ... ],
+  "_lang": "host"
+}
+```
+
+* `recordsTotal` — total rows in the table before filtering.
+* `recordsFiltered` — rows matching the current `search` (equals
+  `recordsTotal` when no search is applied).
+* `data` — the current page of rows.
+
+### Examples
+
+First three hosts:
+
+```bash
+curl -H 'fog-api-token: yourapitoken' \
+     -H 'fog-user-token: yourusertoken' \
+     -X GET --data 'start=0&length=3' \
+     http://fogserver/fog/host
+```
+
+The next page (rows 4–5):
+
+```bash
+curl -H 'fog-api-token: yourapitoken' \
+     -H 'fog-user-token: yourusertoken' \
+     -X GET --data 'start=3&length=2' \
+     http://fogserver/fog/host
+```
+
+---
+
+## Relation expansion (`?expand`)
+
+By default a list row or a single entity contains scalar foreign keys
+(`imageID`, `snapins` as an array of IDs, and so on). Add `?expand=…` to inline
+the **full related objects** instead of having to make a second round of calls.
+
+### Requesting expansion
+
+`expand` is a comma-separated list of relation tokens on the URL query string.
+Tokens are **case-insensitive**.
+
+| Form                              | Effect                                             |
+|-----------------------------------|----------------------------------------------------|
+| `?expand=image`                   | Inline the single `image` relation.                |
+| `?expand=snapins,printers`        | Inline several relations.                          |
+| `?expand=all`                     | Inline every relation the entity supports.         |
+
+Expansion works on **both** a single-entity GET (`/fog/host/48?expand=all`) and
+a list endpoint (`/fog/host?expand=snapins`) — in the list case every row on the
+page is enriched.
+
+### Supported relations
+
+The set of expandable relations depends on the entity (and on which plugins are
+installed). For a **host** the built-in relations are:
+
+| Token      | Kind        | Inlines                                  |
+|------------|-------------|------------------------------------------|
+| `image`    | one         | The assigned image object.               |
+| `snapins`  | many        | The host's snapin objects.               |
+| `printers` | many        | The host's printer objects.              |
+| `groups`   | many        | The groups the host belongs to.          |
+| `modules`  | many        | The host's client modules.               |
+
+The **Location** plugin adds two more tokens, delivered through the
+[`pluginItems`](#the-pluginitems-envelope) envelope: `location` (on a host) and
+`hosts` (on a location).
+
+### One-to-one relations
+
+A one-to-one relation is inlined as an object under its token, **next to** the
+untouched scalar key:
+
+```json
+{
+  "id": 48,
+  "imageID": 5,
+  "image": { "id": 5, "name": "Win11", "path": "/images/win11", ... }
+}
+```
+
+### One-to-many relations
+
+A one-to-many relation becomes an **array** under its token, accompanied by two
+companion keys so you can detect truncation:
+
+```json
+{
+  "modules": [ { "id": 1, "name": "..." }, ... ],
+  "modules_total": 13,
+  "modules_truncated": false
+}
+```
+
+* `<token>_total` — the true number of related items (before any cap).
+* `<token>_truncated` — `true` when the array was capped and therefore does
+  **not** contain every item.
+
+!!! note "Expansion is capped at 2500 items per relation"
+    To bound memory, each one-to-many relation inlines at most **2500** items.
+    When more exist, the array holds the first 2500, `<token>_total` reports the
+    real count, and `<token>_truncated` is `true`. Fetch the remainder from that
+    relation's own list endpoint.
+
+### Depth is one level
+
+Expansion goes **exactly one level deep**. Inlined related objects are *not*
+themselves expanded and do not carry a `pluginItems` envelope, so responses can
+never recurse or contain back-references to their parent.
+
+### Pagination + expansion together
+
+Because expansion materializes a full object for every row, an expanded **list**
+request bounds its own page size:
+
+* If you send an explicit `length` of **2500 or fewer**, it is honored.
+* If `length` is omitted, `0`, or greater than **2500**, it is clamped to
+  2500 (and `start` defaults to `0`).
+
+So to page through an expanded list, always send an explicit
+`length` ≤ 2500:
+
+```bash
+curl -H 'fog-api-token: yourapitoken' \
+     -H 'fog-user-token: yourusertoken' \
+     -X GET --data 'start=0&length=100' \
+     'http://fogserver/fog/host?expand=snapins'
+```
+
+### Sensitive fields are never exposed by expansion
+
+Decrypted secrets (Active Directory password, product key, client security
+tokens, and the like) are returned **only** on a direct single-entity GET of the
+owning object (for example `GET /fog/host/48`). They are always stripped from:
+
+* every row of a **list** response, including expanded list rows, and
+* any object inlined as a **related** object or through `pluginItems`.
+
+In other words, `GET /fog/host/48` may return the host's decrypted `ADPass`, but
+that host appearing inside `GET /fog/location/1?expand=hosts`, or as a row of
+`GET /fog/host?expand=all`, will not.
+
+---
+
+## The `pluginItems` envelope
+
+Plugins can contribute their associations to another entity's API output. To
+guarantee a plugin can never overwrite (or be confused with) a core field, all
+plugin-contributed data lives under a single namespaced key: `pluginItems`.
+
+```json
+{
+  "id": 48,
+  "name": "lab-pc-01",
+  "imageID": 5,
+  "pluginItems": {
+    "location": { "id": 1, "name": "Main Office", "link": "..." }
+  }
+}
+```
+
+Like the core expansion, `pluginItems` is only ever attached at the **top
+level** — on a single-entity GET or on each row of a list — never on a nested
+related object. That is what keeps plugin data free of back-references.
+
+### Example: the Location plugin
+
+The Location plugin is bidirectional and demonstrates the pattern.
+
+**On a host** — `pluginItems.location` is a lightweight link by default:
+
+```json
+"pluginItems": {
+  "location": {
+    "id": 1,
+    "name": "Main Office",
+    "link": "../management/index.php?node=location&sub=edit&id=1"
+  }
+}
+```
+
+Add `?expand=location` to inline the **full** location object instead:
+
+```bash
+curl -H 'fog-api-token: yourapitoken' \
+     -H 'fog-user-token: yourusertoken' \
+     -X GET 'http://fogserver/fog/host/48?expand=location'
+```
+
+```json
+"pluginItems": {
+  "location": { "id": 1, "name": "Main Office", "storagegroup": {...}, ... }
+}
+```
+
+**On a location** — `pluginItems.hostCount` is always present; add
+`?expand=hosts` to also inline the member hosts:
+
+```bash
+curl -H 'fog-api-token: yourapitoken' \
+     -H 'fog-user-token: yourusertoken' \
+     -X GET 'http://fogserver/fog/location/1?expand=hosts'
+```
+
+```json
+"pluginItems": {
+  "hostCount": 42,
+  "hosts": [ { "id": 9, "name": "..." }, ... ],
+  "hosts_truncated": false
+}
+```
+
+The inlined `hosts` array follows the same rules as any expanded one-to-many
+relation: capped at 2500, `hosts_truncated` signals a cap, and each host has its
+sensitive fields stripped.
+
+---
+
+## Quick reference
+
+| Goal                                   | How                                                            |
+|----------------------------------------|---------------------------------------------------------------|
+| Page a list                            | Send `start` / `length` in the request **body**.              |
+| Inline one relation                    | `?expand=<token>`                                             |
+| Inline several relations               | `?expand=a,b,c`                                               |
+| Inline everything                      | `?expand=all`                                                |
+| Detect a capped one-to-many relation   | Check `<token>_truncated` / `<token>_total`.                 |
+| Page an expanded list                  | Send an explicit `length` ≤ 2500.                            |
+| Read plugin associations               | Look under `pluginItems`.                                    |
+| Get decrypted secrets                  | Direct single-entity GET only (never lists/expansions).      |

--- a/docs/kb/integrations/api.md
+++ b/docs/kb/integrations/api.md
@@ -14,110 +14,160 @@ tags:
 
 # API
 
-In here you'll find some practical api examples. But first lets explain
-how to get autheticated
+In here you'll find some practical API examples. But first, let's explain how
+to authenticate.
 
 ## Basics
 
-To be able to use the API via external calls it needs to be enabled in
-the FOG web UI (FOG Configuration :octicons-arrow-right-24: FOG Settings :octicons-arrow-right-24: API System)
-first.
+To be able to use the API via external calls it needs to be enabled in the FOG
+web UI (FOG Configuration :octicons-arrow-right-24: FOG Settings
+:octicons-arrow-right-24: API System) first.
 
-### Authentication
+## Authentication
 
-#### Tokens
+### Tokens
 
-API global token is a header required with the name `fog-api-token`
-You can find yours via FOG-Configuration:octicons-arrow-right-24:FOG Settings:octicons-arrow-right-24:API System #.
-API user token is a header that can be used (*highly recommended*) being
-passed as a header in the form `fog-user-token` You can find yours via
-Users:octicons-arrow-right-24:List All Users:octicons-arrow-right-24:Your Username:octicons-arrow-right-24:API Settings
+**API global token** &mdash; a header named `fog-api-token`. You can find yours
+via FOG Configuration :octicons-arrow-right-24: FOG Settings
+:octicons-arrow-right-24: API System.
 
-#### HTTP Basic Auth
+**API user token** (*highly recommended*) &mdash; a header named
+`fog-user-token`. You can find yours via Users :octicons-arrow-right-24: List
+All Users :octicons-arrow-right-24: *your username* :octicons-arrow-right-24:
+API. The user's **User API Enable** checkbox on that tab must be ticked, or the
+token is rejected even when sent.
 
-You can use HTTP Basic Authorization (with `curl -u <user>:<password>`
-or header with name
-`Authorization: Basic <base64encoded username:password>`. Although I
-have allowed the ability for this type of authentication, and it will
-work, I would still recommend using user token system as it cannot be
-received and decoded to a valid username/password pair to manage your
-fog server.
+!!! note "Copy the token value as shown"
+    The web UI already displays both tokens **base64-encoded**, which is exactly
+    the form the server expects in the header. Copy the displayed value verbatim
+    &mdash; the server base64-decodes the header before comparing it. A raw,
+    un-encoded token will fail with `403 Forbidden`.
+
+### HTTP Basic Auth
+
+You can use HTTP Basic Authorization (with `curl -u <user>:<password>` or a
+header of the form `Authorization: Basic <base64encoded username:password>`).
+Although this type of authentication is allowed and will work, the user-token
+system is still recommended, as a token cannot be decoded back into a valid
+username/password pair capable of managing your FOG server.
 
 ### Example
 
-While many different tools can be used to make API calls `curl` is just
-one of the very basic ones if you are on Linux and want to give it a
-try:
+While many different tools can be used to make API calls, `curl` is one of the
+most basic ones if you are on Linux and want to give it a try:
 
-    curl -H 'fog-api-token: yourapitoken' -H 'fog-user-token: yourusertoken' -X GET http://fogserver/fog/system/info
+```bash
+curl -H 'fog-api-token: yourapitoken' \
+     -H 'fog-user-token: yourusertoken' \
+     -X GET http://fogserver/fog/system/info
+```
 
 ## Routes and Methods
 
-To keep the iformation in the documentation as universial as possible,
-we will only show the url for the api calls GET \-\--Here are some core
-GET calls: #. `/fog/system/info` Simple check to see if the API is
-enabled and working. Returns 200 if accessible. #. `/fog/task/active`
-Returns a list of pending and active tasks #.
-`/fog/multicastsession/current` Returns a list of active multicast
-sessions #. `/fog/host` Returns a list of all the registerd hosts #.
-`fog/host/search/*` Returns images or hosts that match the search term
-(replace wildcard with search term)
+To keep the information in the documentation as universal as possible, we only
+show the URL for each API call.
+
+### GET
+
+Here are some core GET calls:
+
+| Route | Description |
+| --- | --- |
+| `/fog/system/info` | Health check &mdash; confirms the API is enabled and reachable. Requires no token and returns a small JSON payload containing the server version. |
+| `/fog/task/active` | Returns a list of pending and active tasks. |
+| `/fog/multicastsession/current` | Returns a list of active multicast sessions. |
+| `/fog/host` | Returns a list of all the registered hosts. |
+| `/fog/<class>/search/<term>` | Returns the records of `<class>` that match the search term, e.g. `/fog/host/search/<term>` for hosts or `/fog/image/search/<term>` for images. |
 
 ### POST
 
-#### Creating a image:
+#### Creating an image
 
-You can use the following api call for creating a image:
-`/fog/image/create` You need to pass the following parameters: #. name -
-The name of the image #. path - The path to the image #. imageTypeID -
-The way image is stored
+Use the following API call to create an image: `/fog/image/create`. You need to
+pass the following parameters:
 
-##### List of all the image types:
+| Parameter | Description |
+| --- | --- |
+| `name` | The name of the image. |
+| `path` | The path to the image. |
+| `imageTypeID` | How the image is stored (see the table below). |
+| `osID` | The operating system ID for the image. |
 
-1.  Single Disk - Resizable
-2.  Multipul Partition Image - Single Disk (Not Resizable)
-3.  Multipul Partition Image - All Disks (Not Resizable)
-4.  Raw Image (Sector By Sector, DD Slow)
+Any other Image field (for example `description`, `imagePartitionTypeID`,
+`format`, or `compress`) may also be included in the body.
 
-###### Creating a Capture task:
+**Image types** &mdash; the value to pass as `imageTypeID`:
 
-Put the ID of the host in the url of the api call `/fog/host/id/task`
+| `imageTypeID` | Type |
+| --- | --- |
+| 1 | Single Disk - Resizable |
+| 2 | Multiple Partition Image - Single Disk (Not Resizable) |
+| 3 | Multiple Partition Image - All Disks (Not Resizable) |
+| 4 | Raw Image (Sector By Sector, DD, Slow) |
 
-##### Task types:
+A successful create returns the full JSON of the saved image object.
 
-1.  Deploy
-2.  Capture
-3.  Debug
-4.  Memtest
-5.  Test Disk
-6.  Disk Surface Test
-7.  Recover
-8.  Hardware inventory
-9.  Password Reset
-10. All Snapins
-11. Single Snapins
-12. Wake-up
-13. Deploy - Debug
-14. Capture - Debug
-15. Deploy - No Snapin
-16. Fast Wipe
-17. Normal Wipe
-18. Full Wipe
-19. Virus Scan
-20. Virus Scan - Quarantine
+#### Creating a task (deploy, capture, etc.)
 
-Example body for deploying a image:
+Put the ID of the host in the URL of the API call: `/fog/host/<id>/task` (this
+also works for other tasking objects, such as groups). The body selects the
+task with a `taskTypeID` key, for example:
 
-:   `{"taskType": "1"}`
+```json
+{"taskTypeID": "1"}
+```
 
-NOTE: You need to assign the image to the host before you can deploy it.
-You can assing the host with a PUT request
+`taskTypeID` `1` deploys and `2` captures. The full list of task types follows.
 
-If the api call is correct you'll get the following response: `""`\`
+!!! warning "The body key is `taskTypeID`, not `taskType`"
+    The endpoint reads the JSON property `taskTypeID`. A body of
+    `{"taskType": "1"}` leaves `taskTypeID` unset and results in a `404`.
+
+**Task types** &mdash; the value to pass as `taskTypeID`:
+
+| `taskTypeID` | Task |
+| --- | --- |
+| 1 | Deploy |
+| 2 | Capture |
+| 3 | Debug |
+| 4 | Memtest86+ |
+| 5 | Test Disk |
+| 6 | Disk Surface Test |
+| 7 | Recover |
+| 8 | Multi-Cast |
+| 10 | Hardware Inventory |
+| 11 | Password Reset |
+| 12 | All Snapins |
+| 13 | Single Snapin |
+| 14 | Wake-Up |
+| 15 | Deploy - Debug |
+| 16 | Capture - Debug |
+| 17 | Deploy - No Snapins |
+| 18 | Fast Wipe |
+| 19 | Normal Wipe |
+| 20 | Full Wipe |
+| 21 | Virus Scan |
+| 22 | Virus Scan - Quarantine |
+
+!!! note "The IDs are not contiguous"
+    There is intentionally no task type `9`, and `8` is Multi-Cast &mdash; pass
+    the ID from the table, not the row position.
+
+!!! note "Assign an image first"
+    You must assign an image to the host (and the image must be enabled) before
+    you can deploy it. Assign it with a PUT request (see below).
+
+A successful task call returns an empty string (`""`).
 
 ### PUT
 
-Edit a host: `/fog/host/id/edit` Example body: `{"imageID": "1"}`
+Edit a host: `/fog/host/<id>/edit`. Example body:
+
+```json
+{"imageID": "1"}
+```
+
+A successful edit returns the full JSON of the updated host object.
 
 ## Pagination, expansion & plugin items
 

--- a/docs/kb/integrations/api.md
+++ b/docs/kb/integrations/api.md
@@ -118,3 +118,10 @@ If the api call is correct you'll get the following response: `""`\`
 ### PUT
 
 Edit a host: `/fog/host/id/edit` Example body: `{"imageID": "1"}`
+
+## Pagination, expansion & plugin items
+
+FOG 1.6 adds opt-in query features for working with the API: paging large list
+results, inlining related objects with `?expand=…`, and reading plugin-injected
+associations from the `pluginItems` envelope. See
+[API Pagination, Expansion & Plugin Items](api-expansion-and-pagination.md).


### PR DESCRIPTION
## What

Documents the additive, opt-in REST API features introduced in FOG 1.6, addressing the request to document "all the new features, how to paginate, how to expand, all that."

Adds a dedicated Integrations page — **API Pagination, Expansion & Plugin Items** — and cross-links it from the existing `api.md`.

## Covered

- **Pagination** — `start`/`length` sent in the request **body** (per the API's internal-rewrite quirk), and the DataTables response envelope (`draw`/`recordsTotal`/`recordsFiltered`/`data`).
- **Relation expansion** (`?expand=<tokens>` / `?expand=all`) — supported host relations (`image`, `snapins`, `printers`, `groups`, `modules`), one-to-one vs one-to-many response shapes, the `<token>_total`/`<token>_truncated` markers, the 2500-item cap, one-level depth (no recursion/back-references), and the pagination interaction (explicit `length` ≤ 2500 honored, otherwise clamped to 2500).
- **The `pluginItems` envelope** — how plugins inject associations without clobbering core fields, with the Location plugin as the worked bidirectional example (`host → pluginItems.location` link/full; `location → pluginItems.hostCount`/`hosts`).
- **Security note** — decrypted secrets (AD password, product key, client tokens) are only returned on a direct single-entity GET, never in list rows or expanded/related objects.

## Notes

Every request/response shape in the page was verified against a running FOG 1.6 server. Local `mkdocs build` was not run (mkdocs isn't installed on the authoring box), but the new page's YAML frontmatter parses and all internal links resolve; the page lands in `docs/kb/integrations/` where `include_dir_to_nav` picks it up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)