### PR TITLE
docs: fix post-download disk variable ($disk → $hd)

### DIFF
--- a/docs/kb/how-tos/post-download-scripts.md
+++ b/docs/kb/how-tos/post-download-scripts.md
@@ -72,7 +72,8 @@ include:
 
 | Variable | Meaning |
 | --- | --- |
-| `$disk` | the disk that was imaged (for example `/dev/sda` or `/dev/nvme0n1`) |
+| `$hd` | the disk that was imaged (for example `/dev/sda` or `/dev/nvme0n1`) |
+| `$disks` | space-separated list of all target disks, for multi-disk images |
 | `$hostname` | the host's name as registered in FOG |
 | `$mac` | the host's primary MAC address |
 | `$img` | the name of the image that was deployed |
@@ -104,7 +105,7 @@ A minimal skeleton that only acts on one image looks like this:
 case "$img" in
     win11-lab)
         # mount the deployed Windows partition and do something
-        mount /dev/${disk#/dev/}2 /mnt 2>/dev/null
+        mount /dev/${hd#/dev/}2 /mnt 2>/dev/null
         # ... your changes here ...
         umount /mnt 2>/dev/null
         ;;


### PR DESCRIPTION
### Summary

Follow-up to #62. While validating that PR against the current FOS source (`bin/fog` → `fog.download` → `completeTasking` → `fog.postdownload`), I found the post-download variable table has a second incorrect entry: `$disk`.

### The problem

`$disk` is **not** a variable your post-download script can rely on:

- It is **not** a kernel-cmdline export (unlike `$img`, `$osid`, `$hostname`, `$mac`, which FOS exports from `/proc/cmdline` in `S40network`).
- `fog.download` resets it to `""` at the top, and the only assignments during a deploy (`for disk in $disks` loops, `getDiskFromPartition`) are all declared `local` inside the restore functions (`performRestore`, `getFSID`, everything in `partition-funcs.sh`). Dynamic scoping keeps those writes contained, so the global `$disk` never gets set.

Result: for a normal single-disk deploy, `$disk` is **empty** at post-download time, so the doc's own example expands to `mount /dev/2 /mnt` and fails.

### The fix

The variable FOS actually populates with the imaged disk is **`$hd`** (primary/single disk), with **`$disks`** holding the space-separated list for multi-disk images. This matches FOS's own debug output (`fog.debug`), which dumps `hd=` and `disks=` but never `disk=`.

- Variable table: `$disk` → `$hd`, plus a new `$disks` row for multi-disk images.
- Worked example: `mount /dev/${disk#/dev/}2` → `mount /dev/${hd#/dev/}2`.

Docs-only change; no functional code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)