### PR TITLE
docs: fix $imagename → $img in UEFI boot-entries how-to

### DIFF
--- a/docs/kb/how-tos/uefi-boot-entries.md
+++ b/docs/kb/how-tos/uefi-boot-entries.md
@@ -106,7 +106,7 @@ command(s), then enable it by adding this line to `fog.postdownload`:
 
 Inside the script the deployed disks are available as the usual block devices
 (for example `/dev/nvme0n1`), so the same `efibootmgr -c …` command shown above
-works there. FOS exports variables such as `$hostname` and `$imagename`, so you
+works there. FOS exports variables such as `$hostname` and `$img`, so you
 can branch on the host or image if a fix-up should only apply to certain
 machines.
 


### PR DESCRIPTION
### Summary

Follow-up to #62 and #63. Scanning the remaining how-to docs for the same class of variable error surfaced one more occurrence: the UEFI boot-entries how-to's post-download section tells users FOS exports `$imagename`.

FOS does not expose `$imagename` — the deployed image name is available as `$img` (validated against the FOS source and already corrected in #62/#63 for `post-download-scripts.md`).

### Change

- `uefi-boot-entries.md`: `$imagename` → `$img` in the post-download variables note.

I checked every other `$var` reference across all how-to docs; this was the only remaining error. The rest (`$img`, `$hd`, `$disks`, `$hostname`, `$osid`, `$mac`, `${postdownpath}`, `${postinitpath}`) all match what FOS actually provides.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)