### PR TITLE
Document multicast sessions and the 1.6 port pool change

### DIFF
--- a/docs/management/web/config.md
+++ b/docs/management/web/config.md
@@ -17,6 +17,20 @@ tags:
 
 much more content is needed here
 
+## Multicast Settings
+
+The settings under **FOG Settings :octicons-arrow-right-24: Multicast Settings**
+control how many multicast sessions may run at the same time, which ports and
+addresses they use, and how long a session waits for its clients before it starts
+transmitting.
+
+`FOG_MULTICAST_PORT_OVERRIDE` in particular changed in FOG 1.6: it is now a comma
+separated pool of base ports, and **each port in the list is one session that can
+run concurrently**. A single port still works and behaves as a pool of one.
+
+These are documented in full, with their upgrade implications, on the
+[Multicast Sessions](multicast.md) page.
+
 ## Other Settings
 
 ## Table display mode (infinite scroll vs. paging)

--- a/docs/management/web/multicast.md
+++ b/docs/management/web/multicast.md
@@ -1,0 +1,175 @@
+---
+title: Multicast Sessions
+aliases:
+    - Multicast
+    - Multicast Sessions
+    - Multicast Deploy
+description: How FOG multicast sessions work, how clients join them, and how to configure concurrent sessions
+context_id: multicast
+tags:
+    - 1_6-changes
+    - management
+    - web-management
+    - web-ui
+    - tasks
+    - multicast
+---
+
+# Multicast Sessions
+
+## Overview
+
+A multicast session deploys one image to many machines at the same time. Instead
+of sending a separate copy to each client, the server runs a single `udp-sender`
+process that transmits the image once, and every client receiving it writes the
+same stream to disk.
+
+That single transmission is the whole point, and it is also the constraint: a
+machine that arrives after the transmission has started cannot be given the part
+it missed. Everything below follows from that.
+
+## Creating a session
+
+There are three ways to start one.
+
+**From Image Management** — creates a *named* session that other machines can
+join by name. You give it a name, the number of clients to expect, and how long
+to wait for them. This is the usual choice when you are imaging a room and want
+machines to join as they boot.
+
+**From a host or a group** — creates a session for exactly those machines. Group
+tasking is the common case: every host in the group is added up front, so there
+is nobody left to wait for.
+
+**From a booting machine** — a machine at the boot menu can join a session by
+name, and if no session has that name it can create one. FOG asks two questions
+before it does:
+
+- *Clients expected to join, including this one* — the number of machines that
+  will receive the image.
+- *Minutes to wait for them before starting* — how long the session stays open.
+
+Both answers are required. A session with no expected size cannot be joined by
+name by anyone else, so creating one without them would produce a session that
+only ever images the machine that made it.
+
+!!! note
+    Creating a session from a booting machine requires a login that holds the
+    `task.task` permission, the same permission needed to create tasking anywhere
+    else. See [Roles & Permissions](roles.md).
+
+## Joining a session
+
+A machine joins by selecting the multicast join option at the boot menu, logging
+in, and entering the session name.
+
+The session stays open to new machines until the transmission actually begins,
+which happens when **either**:
+
+- every expected client has joined, **or**
+- the wait period expires.
+
+After that the session is closed and a machine trying to join is told the session
+has already started. This is deliberate. Previously a late machine was allowed to
+join, received only the tail of the image, and was still reported as a successful
+deployment.
+
+If you typo the session name, FOG offers to create a session with that name
+rather than dropping you out of the menu. Answer `0` to the expected-clients
+prompt to go back and re-enter the name instead.
+
+## Watching a session
+
+Active sessions appear under **Task Management :octicons-arrow-right-24: Active
+Multicast Tasks**, and under **Image Management :octicons-arrow-right-24:
+Multicast** for named sessions.
+
+The client column reads **joined / expected** — for example `7 / 30` means seven
+machines have checked in of the thirty the session is waiting for. A dash in
+place of the expected number means the session was created without one, which is
+normal for host and group sessions.
+
+More detail is available on the client itself with [ctl]+[alt]+f2, and the
+server keeps a per-session log under `/opt/fog/log`.
+
+## Settings
+
+All of these live under **FOG Configuration :octicons-arrow-right-24: FOG
+Settings :octicons-arrow-right-24: Multicast Settings**.
+
+### FOG_MULTICAST_PORT_OVERRIDE
+
+The base ports FOG may use for multicast, as a comma separated list:
+
+```
+63100,63200,63300
+```
+
+**Each port in the list is one session that can run at the same time.** The
+example above allows three concurrent sessions. A session uses the port you list
+plus the one immediately above it, so ports must be even and between 1024 and
+65534; anything else in the list is ignored.
+
+Leave it at `0` (the default) to let FOG pick a port for each session
+automatically.
+
+!!! warning
+    Before FOG 1.6 this setting was a single port, and every session was forced onto
+    it — so setting it meant only one multicast session could ever really run, and a
+    second would silently collide with the first. If you have a single port set
+    today it keeps working: it is simply a pool of one. Add more ports to allow more
+    concurrent sessions.
+
+### FOG_MULTICAST_MAX_SESSIONS
+
+The maximum number of multicast sessions allowed to run at once. Attempting to
+create one beyond the limit fails with a message rather than starting a session
+that cannot run.
+
+!!! note
+    In earlier versions this limit was only checked when creating a session from
+    Image Management — sessions created from a host, a group, or a booting machine
+    ignored it. It now applies to every path, so a server that was quietly running
+    more sessions than this number may start refusing them. Raise the value if that
+    is not what you want.
+
+### FOG_UDPCAST_MAXWAIT
+
+The default number of **minutes** a session waits for its expected clients before
+transmitting anyway. Sessions created from a booting machine ask for this value
+directly instead of using the default.
+
+### FOG_MULTICAST_ADDRESS
+
+An alternate multicast data address. Each concurrent session needs its own
+address; when a port pool is configured FOG derives one per pool entry, which is
+what keeps two sessions from colliding.
+
+### FOG_UDPCAST_STARTINGPORT
+
+The port FOG starts from when no port pool is configured. FOG moves this along
+by itself as sessions are created; you do not normally need to touch it.
+
+## Troubleshooting
+
+**A session sits waiting and never starts.** It is waiting for clients that have
+not arrived. It will transmit when the wait period expires. Check the expected
+client count is right — if it is higher than the number of machines you are
+actually imaging, every session waits the full period.
+
+**A machine is told the session has already started.** The transmission is
+already under way and it cannot be added. Start a new session for it.
+
+**A machine cannot join a session by name.** Only sessions created with an
+expected client count can be joined by name. Sessions created directly from a
+host or group have no name to join.
+
+**Sessions fail to start when several run at once.** Check
+`FOG_MULTICAST_PORT_OVERRIDE`. If it holds a single port, only one session can
+run; add more ports to the list.
+
+## See also
+
+- [Task Management](tasks.md)
+- [Image Management](images.md)
+- [Roles & Permissions](roles.md)

--- a/docs/management/web/tasks.md
+++ b/docs/management/web/tasks.md
@@ -57,7 +57,9 @@ For a video demonstration of an image capture, please see: [http://www.youtube.
 
 To perform a simple image send, click on the downward facing arrow next to the host. An image send can be done on a host or a group. When sending an image to multiple computers FOG works in queue mode, which means that it will only send to 10 (by default) computers at one time. This is done to keep the server from being overworked. As soon as the a machine finishes, another from the queue joins.
 
-To perform a multicast image send you must search for a group of hosts on the "Task Management" page. Multicast tasks can only be performed on a group of hosts. Multicast tasks will send to all the computers in the group at once, and the task will not start sending until all members of the group have connected with the server. After starting a multicast task, status can be view by clicking on [ctl]+[alt]+f2. A log is also kept for multicast transfers which is stored at /opt/fog/log.
+A multicast image send transmits one image to many machines at once. It can be started from a group of hosts on the "Task Management" page, from Image Management as a named session that machines join by name, or from a machine sitting at the boot menu. Multicast sends to all the participating computers at the same time, and does not begin transmitting until either every expected client has joined or the configured wait period expires — whichever happens first. Once it starts, the session is closed and no further machines can join it. After starting a multicast task, status can be viewed by clicking on [ctl]+[alt]+f2. A log is also kept for multicast transfers which is stored at /opt/fog/log.
+
+See [Multicast Sessions](multicast.md) for how sessions are created and joined, and for the settings that control how many can run at once.
 
 ## Advanced Tasks
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -122,6 +122,7 @@ nav:
       - Printer Management: management/web/printers.md
       - Service Management: management/web/service.md
       - Task Management: management/web/tasks.md
+      - Multicast Sessions: management/web/multicast.md
       - Report Management: management/web/reports.md
       - Fog Configuration: management/web/config.md
       - AD Config: management/web/ad-integration.md


### PR DESCRIPTION
Multicast had no page of its own and none of its settings were documented. The one substantial description of it, in `tasks.md`, was also inaccurate.

## What this adds

**`docs/management/web/multicast.md`** (new, in nav after Task Management):

- The three ways a session gets created — Image Management, host/group, and from a booting machine
- How machines join, and **when the join window closes and why** (transmission begins once every expected client has joined *or* the wait expires — a machine joining after that would receive only the tail of the image)
- The `joined / expected` client display
- All five Multicast Settings
- Troubleshooting for the common "session never starts" / "can't join by name" cases

**`tasks.md`** — corrects two inaccuracies. It stated *"Multicast tasks can only be performed on a group of hosts"*, which has not been true for some time, and described the session as starting once every member connects without mentioning the wait period that also starts it.

**`config.md`** — a Multicast Settings section pointing at the new page rather than duplicating it.

## Upgrade notes called out for admins

Both are flagged in admonitions on the page:

- **`FOG_MULTICAST_PORT_OVERRIDE` is now a comma separated pool**, where each port is one concurrent session. A single port keeps working as a pool of one — which is what it effectively meant before, since every session was forced onto it and a second silently collided with the first.
- **`FOG_MULTICAST_MAX_SESSIONS` is now enforced on every creation path.** It was previously only checked from Image Management, so a server quietly running more sessions than its configured maximum may start refusing them.

## Conventions

Uses `!!! note` admonitions rather than GitHub style `>[!note]` callouts, since `hook.py` only handles `context_id` redirects and does not convert them. Avoids the `++key++` syntax because `pymdownx.keys` is not among the enabled extensions.

`mkdocs.yml` parses and `context_id: multicast` does not collide with an existing id. The site build itself was not run.