### PR TITLE
Drop the 1.6-only framing from the multicast port pool and session cap

### DIFF
--- a/docs/management/web/multicast.md
+++ b/docs/management/web/multicast.md
@@ -114,10 +114,10 @@ Leave it at `0` (the default) to let FOG pick a port for each session
 automatically.
 
 !!! warning
-    Before FOG 1.6 this setting was a single port, and every session was forced onto
-    it — so setting it meant only one multicast session could ever really run, and a
-    second would silently collide with the first. If you have a single port set
-    today it keeps working: it is simply a pool of one. Add more ports to allow more
+    This setting used to be a single port, and every session was forced onto it — so
+    setting it meant only one multicast session could ever really run, and a second
+    would silently collide with the first. If you have a single port set today it
+    keeps working: it is simply a pool of one. Add more ports to allow more
     concurrent sessions.
 
 ### FOG_MULTICAST_MAX_SESSIONS
@@ -127,8 +127,8 @@ create one beyond the limit fails with a message rather than starting a session
 that cannot run.
 
 !!! note
-    In earlier versions this limit was only checked when creating a session from
-    Image Management — sessions created from a host, a group, or a booting machine
+    This limit used to be checked only when creating a session from Image
+    Management — sessions created from a host, a group, or a booting machine
     ignored it. It now applies to every path, so a server that was quietly running
     more sessions than this number may start refusing them. Raise the value if that
     is not what you want.


### PR DESCRIPTION
The multicast port pool and the every-path `FOG_MULTICAST_MAX_SESSIONS` check have been backported to `dev-branch` (1.5.x), so the two notes on this page that anchored the old behaviour to "before FOG 1.6" are no longer accurate — 1.6 is not the boundary any more.

Both notes now describe what the behaviour *used to be*, without naming a release:

- **FOG_MULTICAST_PORT_OVERRIDE** — "Before FOG 1.6 this setting was a single port…" → "This setting used to be a single port…"
- **FOG_MULTICAST_MAX_SESSIONS** — "In earlier versions this limit was only checked…" → "This limit used to be checked only…"

No behavioural claims changed; only the version framing.

Deliberately does **not** name the 1.5.x release carrying the backport: it has not shipped yet, and the page has no version selector to hang that on. Worth a follow-up once the version is settled.

Note that three things this page describes remain 1.6-only, as they were not backported — the boot-menu prompts for expected clients/wait, the joined/expected client column, and the `task.task` permission gate on boot-menu session creation. The page does not claim otherwise, so nothing there is inaccurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)