### PR TITLE
A user with no role now has no access, not full access

### DIFF
--- a/docs/management/web/ldap.md
+++ b/docs/management/web/ldap.md
@@ -1,0 +1,120 @@
+---
+title: LDAP Authentication
+aliases:
+    - LDAP
+    - LDAP Plugin
+    - Active Directory Login
+    - Directory Authentication
+description: How the LDAP plugin authenticates users against a directory and which role each one receives
+context_id: ldap
+tags:
+    - 1_6-changes
+    - management
+    - users
+    - roles
+    - permissions
+    - plugins
+    - ldap
+    - web-ui
+    - web-management
+---
+
+# LDAP Authentication
+
+## Overview
+
+The **LDAP** plugin lets people sign in to FOG with their directory
+account — Active Directory, OpenLDAP, FreeIPA, or any generic LDAP
+server — instead of a password stored in FOG.
+
+You do not create these users by hand. The first time someone signs in
+successfully, FOG creates a matching user account for them
+automatically, and refreshes it on every later login.
+
+## What FOG stores for a directory user
+
+- **The directory password is never stored.** The account is marked as
+  authenticated by the directory itself; the password field is filled
+  with a random value that no typed password can ever match.
+- The account is stamped with its **source** so FOG knows it came from a
+  directory rather than being created locally. That stamp is what keeps
+  the upgrade, the CSV export and the local login path from treating
+  directory accounts as ordinary FOG users.
+
+!!! note "Upgrading from an earlier build"
+
+    Older versions of this plugin stored a hash of the user's real
+    directory password in FOG. Those rows are cleaned up automatically
+    on each user's first login after upgrading.
+
+## Which role a directory user gets
+
+Directory users are subject to [roles](roles.md) exactly like anyone
+else, and — like anyone else — **a directory user with no role has no
+access**. The plugin decides which role each login earns.
+
+Go to **LDAP → Global Options**. Three settings map a login outcome to
+a role:
+
+| Setting | Applies to |
+|---|---|
+| **Role for LDAP admin group** | The user is a member of the server's configured admin group |
+| **Role for LDAP user group** | The user is a member of the server's configured user group |
+| **Role when group matching is off** | The server has group matching disabled |
+
+Leaving one of these unset means a login of that kind earns no role,
+and therefore no access.
+
+!!! warning "Group matching off means *everyone*"
+
+    On a server with group matching disabled, FOG can authenticate the
+    account but has no way to tell an administrator from anybody else.
+    The "group matching is off" role is therefore granted to **every
+    account in the directory that can bind** — not a subset. Choose it
+    accordingly, or leave it blank.
+
+### Roles are re-evaluated on every login
+
+The three roles above are recomputed from the directory each time the
+user signs in. Remove someone from the admin group in your directory
+and their next FOG login downgrades them automatically.
+
+Any **other** role an administrator attached to that user by hand is
+left alone. That carve-out is deliberate: without it the sync would
+silently revoke grants you made on purpose, and you would have no way
+to give a directory user anything extra.
+
+## Multiple LDAP servers
+
+If more than one LDAP server is configured, FOG tries them all and
+keeps the **most privileged** result:
+
+```
+admin group  >  user group  >  group matching off  >  no match
+```
+
+A server where the account does not exist never downgrades a match
+found on another server. A server with group matching disabled ranks
+*below* a verified user-group match, because "this account can bind and
+we cannot check what it is" is a weaker answer than one the directory
+actually gave.
+
+## API access
+
+Each LDAP server has its own **allow API** setting, which controls
+whether accounts authenticated through that server may use the
+[REST API](../../kb/integrations/api.md). A directory user's API token
+still carries only their role's permissions — see
+[API tokens follow roles](roles.md#api-tokens-follow-roles).
+
+## Upgrade notes
+
+- **Existing directory accounts are not given a role by the upgrade.**
+  The plugin assigns their role at login, so there is nothing useful for
+  a one-time migration to say about them, and copying their old account
+  type across would hand every directory account administrator access.
+  Configure the three role settings above **before** telling users to
+  sign in again.
+- Before roles existed, every account this plugin created was in effect
+  a full administrator. If that is not what you want, the role mapping
+  is where you fix it.

--- a/docs/management/web/roles.md
+++ b/docs/management/web/roles.md
@@ -25,7 +25,7 @@ Starting with FOG 1.6, role-based access control is built into FOG
 itself. A **role** is a named set of permissions that you assign to one
 or more user accounts. Once a user holds a role, they can only see and
 do what that role's permissions allow — both in the web UI and through
-the [REST API](../../kb/reference/api.md).
+the [REST API](../../kb/integrations/api.md).
 
 This replaces the old **Access Control plugin**, which could define
 roles but never actually enforced anything. See
@@ -76,14 +76,30 @@ You can assign roles from either direction:
 
 ## Users without a role
 
-A user with **no role at all has full administrator access**. This is
-deliberate: it means upgrading to 1.6 changes nobody's access until you
-actually start assigning roles.
+A user with **no role at all has no access**. Access in FOG is granted,
+never assumed: an account can only do what some role it holds says it
+can do, and an account holding nothing can do nothing.
 
-Once at least one user on the system holds a role, any role-less user
-sees a warning banner after logging in ("this account has no role and
-therefore has full administrator access") as a reminder to either
-assign them a role or leave them as an intentional administrator.
+Such a user can still log in, and sees a warning banner explaining that
+the account has no role and therefore no access to any management page,
+along with a suggestion to ask an administrator to assign one. They keep
+the handful of pages that belong to any signed-in user regardless —
+their dashboard, the client-facing pages, and log out.
+
+!!! warning "This changed during the 1.6 beta"
+
+    Early 1.6 builds did the opposite: a role-less account was treated
+    as a full administrator, so that adopting roles could not lock an
+    existing server out before anyone had been assigned one.
+
+    That was a trap. It made removing a user's last role a **promotion**
+    rather than a restriction, and it meant any account created by an
+    authentication plugin arrived with unlimited access simply by virtue
+    of arriving without a role.
+
+    The upgrade converts every account that was relying on the old
+    behaviour into an explicit role, so nobody's access changes silently
+    — see [What the upgrade does to existing users](#what-the-upgrade-does-to-existing-users).
 
 ## What restricted users see
 
@@ -105,7 +121,7 @@ If you need to restrict a user to only the hosts, users and groups of
 their own location or team, install the **Site** plugin. It layers an
 object boundary on top of the role: a site-scoped user keeps their
 role's actions but only ever sees the objects in their site(s), in both
-the web UI and the API. Role-less users and full-access roles are never
+the web UI and the API. Users holding a full-access role are never
 scoped.
 
 See [Site Scoping](site-scoping.md) for the full workflow.
@@ -114,8 +130,9 @@ See [Site Scoping](site-scoping.md) for the full workflow.
 
 A user API token inherits that user's role permissions: API requests
 made with the token can only do what the user could do in the web UI.
-Scripts and integrations that need unrestricted access should
-authenticate with a user that is an administrator (or has no role).
+Scripts and integrations that need unrestricted access must authenticate
+as a user holding a full-access role — a token belonging to a role-less
+account can do nothing at all.
 
 ## Lockout protection
 
@@ -123,6 +140,39 @@ FOG will refuse any change that would leave the system with **no
 effective administrator** — deleting the last admin role, removing its
 last member, unticking its full access, or deleting the last admin
 user account. You cannot accidentally lock everyone out.
+
+## What the upgrade does to existing users
+
+Because a role-less account now has no access, upgrading has to give
+every existing account a role that says what it could already do.
+The database upgrade does this for you, in one pass, for **local
+accounts that hold no role at all**:
+
+| Existing account | Role it receives |
+|---|---|
+| A normal FOG administrator | **Administrator** — full access, exactly as before |
+| A "mobile" account (the restricted tier whose separate UI was removed back in 2017) | **Legacy Restricted** — a new role created by the upgrade |
+
+**Legacy Restricted** grants what that old tier could actually do:
+view hosts and images, start imaging tasks, watch tasks, and read
+reports. It grants nothing that edits or deletes. It is deliberately
+*not* the seeded **Technician** role, which is broader.
+
+Accounts that **already hold a role** are left alone. Those were scoped
+on purpose, and quietly widening them would undo your work.
+
+**Accounts that came from an external directory are also left alone** —
+see [LDAP Authentication](ldap.md). Their role is decided by the LDAP
+plugin every time they log in, so the upgrade has nothing useful to say
+about them, and copying their old account type across would hand every
+directory account the administrator role.
+
+!!! tip "After upgrading"
+
+    Review **Roles → Administrator → Users**. Any account that was an
+    administrator only because nobody had ever restricted it is now an
+    administrator explicitly, and this is a good moment to move it to
+    something narrower.
 
 ## Upgrading from the Access Control plugin
 

--- a/docs/management/web/site-scoping.md
+++ b/docs/management/web/site-scoping.md
@@ -34,7 +34,7 @@ hosts, users, groups and user groups into **sites**, and restrict a
 user so they only see and touch the objects in their own site(s). A
 site-scoped help-desk admin at the "Chicago" site sees only Chicago's
 hosts, both in the web UI and through the [REST
-API](../../kb/reference/api.md).
+API](../../kb/integrations/api.md).
 
 Site scoping is layered **on top of** roles, not instead of them. A
 user's role still decides what they can do; their site membership
@@ -77,10 +77,10 @@ You can assign objects from either direction:
 
 Two things make a user site-scoped:
 
-1. **They hold a role.** A user with *no* role has full administrator
-   access and is never scoped (see
-   [Users without a role](roles.md#users-without-a-role)). The same is
-   true of any role that grants **Administrator (full access)**.
+1. **They hold a role that is not full access.** A role granting
+   **Administrator (full access)** bypasses site scoping entirely. A
+   user with *no* role has no access at all and so is never scoped
+   either — see [Users without a role](roles.md#users-without-a-role).
 2. **They are assigned to one or more sites**, via their **Site
    Association** tab.
 
@@ -98,15 +98,17 @@ directly returns them to the dashboard with a permission error.
     deliberate — scoping fails closed, so a user is never shown objects
     you did not explicitly grant.
 
-    If a role-holding user should see everything, either give their role
-    **Administrator (full access)** or leave them role-less. Otherwise,
-    make sure every scoped user is assigned to at least one site.
+    If a user should see everything, give them a role with
+    **Administrator (full access)** ticked. Otherwise, make sure every
+    scoped user is assigned to at least one site.
 
 ## Who is never scoped
 
-- **Role-less users** — full administrators, unaffected by sites.
 - **Full-access roles** — any role with **Administrator (full access)**
   ticked bypasses site scoping entirely.
+
+Users with no role are not "unscoped" — they have no access to scope in
+the first place.
 
 Site scoping only ever *narrows* a user who already holds a restricting
 role. It cannot grant access a role does not already allow.
@@ -118,14 +120,12 @@ same way it applies to the web UI. A site-scoped user's token returns
 only in-scope hosts, users, groups and user groups from list and search
 endpoints, and is denied out-of-scope objects on single-object
 requests. Scripts and integrations that need to see everything should
-authenticate with an administrator (a role-less user or a full-access
-role).
+authenticate as a user holding a full-access role.
 
 ## Removing scoping
 
 - **Unassign the user** from their site(s) to change what they see, or
-  give them a full-access role / remove their role to make them an
-  administrator again.
+  give them a full-access role to make them an administrator again.
 - **Uninstalling the Site plugin** removes the object boundary
   entirely; every user's role permissions
   ([Roles & Permissions](roles.md)) are unchanged, and all users can

--- a/docs/management/web/users.md
+++ b/docs/management/web/users.md
@@ -60,5 +60,5 @@ FOG accounts can be modified from within the users section.
 
 Starting with FOG 1.6, each user account has a **Roles** tab where you
 can assign one or more roles to limit what the account can see and do.
-A user with no role has full administrator access. See
-[Roles & Permissions](roles.md) for details.
+A user with no role has no access at all, so every account needs at
+least one. See [Roles & Permissions](roles.md) for details.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,6 +114,7 @@ nav:
       - User Management: management/web/users.md
       - Roles & Permissions: management/web/roles.md
       - Site Scoping: management/web/site-scoping.md
+      - LDAP Authentication: management/web/ldap.md
       - Host Management: management/web/hosts.md
       - Group Management: management/web/groups.md
       - Image Management: management/web/images.md


### PR DESCRIPTION
Early 1.6 builds treated a role-less account as a **full administrator**, so that adopting roles could not lock an existing server out before anyone had been assigned one. That inverted badly: removing a user's last role was a *promotion*, and any account an authentication plugin created arrived with unlimited access simply by arriving without a role. 1.6 now denies by default — and the docs still said the opposite in four places.

## What changed

**`roles.md`**
- Rewrote **Users without a role** for deny-by-default, with a note on what the beta used to do and why it changed.
- Corrected **API tokens follow roles** — "authenticate with a user that is an administrator (or has no role)" was actively harmful advice.
- New section: **What the upgrade does to existing users**. Nobody's access should change silently, so this spells out the mapping the database upgrade applies — local administrators → **Administrator**, the old "mobile" tier → a new **Legacy Restricted** role, accounts that already hold a role left untouched, directory accounts left to the LDAP plugin.

**`site-scoping.md`** — three passages told readers to leave a user role-less in order to give them everything.

**`users.md`** — same one-line claim.

**`ldap.md` (new page)** — the LDAP plugin had no documentation at all, and it is now what decides a directory user's role on every login. Covers the tier → role mapping, re-evaluation on each login (and the carve-out for hand-assigned roles), how multiple servers are ranked, and the case worth calling out loudly: on a server with **group matching disabled** the mapped role reaches *every account in the directory that can bind*, which an administrator should not have to infer.

## Drive-by

`kb/reference/api.md` has never existed — the page is `kb/integrations/api.md`. Two existing pages linked to the wrong path; fixed in both plus the new page.

## Related

- FOGProject/fogproject#872 — the deny-by-default flip
- FOGProject/fogproject#871 — LDAP tier → role mapping
- FOGProject/fogproject#880 — schema updater now keys on roles (documented in #66)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNfnxiUR6CGbGQnG7U8S4s