### PR TITLE
Document LDAP nested groups and LDAPS certificate verification, and correct the role model

### DIFF
--- a/docs/kb/faqs/fog-user-guide.md
+++ b/docs/kb/faqs/fog-user-guide.md
@@ -456,12 +456,18 @@ Plugins enhance FOG's functionality. See \[Plugins\](Plugins
 
 ### LDAP Plugin
 
--   Allows you to link with a LDAP server to add an user validation
--   You can add mulitple LDAP servers
--   You can config the DN base and the port of the LDAP Server
--   If FOG can not connect with the LDAP Server, FOG tries to do a local
-    validation
--   If the user does not exist, FOG create one with the mobile profile
+-   Lets people sign in to FOG with their directory account instead of a
+    password stored in FOG
+-   You can add multiple LDAP servers, and a user is authenticated
+    against all of them
+-   You configure each server's address, port, search base DN and
+    whether it uses SSL
+-   A local FOG account is never taken over by the plugin, so an
+    existing FOG login keeps working
+-   The first time a directory user signs in successfully, FOG creates
+    their account automatically. What that account can do comes from the
+    roles you map to their directory groups — see
+    [LDAP Authentication](../../management/web/ldap.md)
 
 ### Location Plugin
 

--- a/docs/management/web/ldap.md
+++ b/docs/management/web/ldap.md
@@ -27,6 +27,14 @@ The **LDAP** plugin lets people sign in to FOG with their directory
 account — Active Directory, OpenLDAP, FreeIPA, or any generic LDAP
 server — instead of a password stored in FOG.
 
+!!! note "This page describes FOG 1.6"
+
+    Two things work differently on 1.5, and both are covered where they
+    come up below: what a directory login is granted
+    ([roles and user groups](#what-a-directory-user-gets), where 1.5 has
+    a single admin group and a single user group), and
+    [nested groups](#nested-groups).
+
 You do not create these users by hand. The first time someone signs in
 successfully, FOG creates a matching user account for them
 automatically, and refreshes it on every later login.
@@ -168,6 +176,15 @@ Group mappings are **additive**. A user in three mapped groups receives
 everything all three grant; there is no ranking and no "highest wins".
 Directory groups you have not mapped grant nothing.
 
+!!! note "On FOG 1.5 this is two groups and two tiers"
+
+    1.5 has one **admin group** and one **user group** per server, and a
+    login lands in whichever it matches — administrator, or the
+    restricted "mobile" tier. There are no per-group mappings, no roles,
+    and no user group grants. Upgrading converts those two lists into
+    mappings; see the note below about what the two surviving role
+    settings are for.
+
 One setting in **LDAP → Global Options** covers the case where there are
 no groups to look at:
 
@@ -293,6 +310,27 @@ If you see it, raise the depth.
 Cycles are handled automatically. A group that contains a group that
 contains the first one resolves correctly and does not consume the depth
 limit.
+
+!!! warning "Nesting on FOG 1.5 is not this feature"
+
+    1.5 has a single **nested group** checkbox instead of the three
+    strategies above, and it is `LDAP_MATCHING_RULE_IN_CHAIN` only. On
+    OpenLDAP, FreeIPA or anything else that rule matches nobody, and 1.5
+    does not check whether the directory supports it — so the box ticks,
+    saves, and silently grants nothing.
+
+    It is also unreachable on most installs. The setting needs a column
+    that was added to the plugin's table in February 2026, and 1.5 has
+    no mechanism to add a column to a *plugin* table on an install that
+    already exists — the core schema updater only ever touches core
+    tables. If your LDAP plugin was installed before that date, the
+    column is simply not there and the setting has nowhere to go.
+
+    Reinstalling the plugin would create the column, and would also drop
+    every LDAP server you have configured along with the FOG accounts
+    the plugin created, so it is not a workaround. Upgrading to 1.6 is
+    the fix — see
+    [issue #892](https://github.com/FOGProject/fogproject/issues/892).
 
 !!! note "posixGroup / memberUid groups cannot nest"
 

--- a/docs/management/web/ldap.md
+++ b/docs/management/web/ldap.md
@@ -47,18 +47,125 @@ automatically, and refreshes it on every later login.
     directory password in FOG. Those rows are cleaned up automatically
     on each user's first login after upgrading.
 
-## Which role a directory user gets
+## Connecting over LDAPS
+
+Tick **Use LDAP SSL** on the server and FOG connects with `ldaps://`
+instead of `ldap://`, on whichever port you have set — normally 636.
+Two fields on the server's **General** tab then decide how hard FOG
+checks the certificate the directory presents.
+
+| **Certificate Verification** | What FOG does |
+|---|---|
+| **Inherit - use the system ldap.conf setting** | Whatever `TLS_REQCERT` says on the FOG server itself. The default. |
+| **Hard - require a valid certificate** | The certificate must be trusted *and* must match the address FOG connects to, or the sign-in fails. |
+| **Never - do not verify (insecure)** | The connection is encrypted, but the certificate is not checked at all. |
+
+**CA Certificate Path** is the absolute path to a PEM file holding the
+CA that signed your directory's certificate. Leave it blank when that CA
+is already in the server's system trust store — which is the case for
+any publicly issued certificate, and for a private CA you have installed
+system-wide.
+
+Both fields are ignored on a server with **Use LDAP SSL** off, because
+there is no certificate to check. There is no StartTLS option — a
+connection is either LDAPS or plain LDAP.
+
+### "Inherit" means the operating system, not FOG
+
+**Inherit** does not inherit anything from FOG. It means *make no demand
+of my own*, which leaves the decision to the OpenLDAP client library on
+the FOG server. That library resolves it from configuration, in this
+order:
+
+1. the `LDAPTLS_REQCERT` environment variable, if it is set;
+2. `TLS_REQCERT` in `$LDAPCONF`, `/etc/openldap/ldap.conf` or
+   `/etc/ldap/ldap.conf`, whichever exists;
+3. `demand` — verify, and refuse the connection if verification fails —
+   when none of those say anything.
+
+So on an untouched server, **Inherit** verifies. If someone has
+previously relaxed `TLS_REQCERT` there to get an internal CA working,
+**Inherit** keeps that arrangement running — which is exactly why it is
+the default. The plugin asserted no TLS setting of its own before these
+fields existed, so `ldap.conf` governed, and defaulting to **Hard** on
+upgrade would have broken every install that depended on it.
+
+### Both fields are per server, deliberately
+
+One FOG install can have an Active Directory and an OpenLDAP configured
+at the same time, and whether verification can succeed is a property of
+the *directory*, not of FOG. Putting a server on **Hard** with its own
+CA leaves every other server's setting alone.
+
+!!! warning "Never is a diagnostic, not a fix"
+
+    **Never** encrypts the traffic but accepts any certificate at all,
+    including one presented by a machine that is not your directory
+    server. Use it to confirm that a connection problem really is
+    certificate-related, then fix the certificate and move back off it.
+
+### Getting Hard to work with a private CA
+
+Two things have to be true, and only the first one is obvious:
+
+- **FOG has to trust the CA.** Point **CA Certificate Path** at the CA's
+  PEM file, or install that CA into the server's system trust store.
+- **The certificate has to name the address FOG connects to.** A
+  certificate issued as `CN=dc1.example.local` with no subjectAltName
+  will not verify when the server's address in FOG is an IP address, no
+  matter how correctly the CA is trusted. The failure reads *hostname
+  does not match name in peer certificate*. Fix it by entering the name
+  the certificate carries in **LDAP Server Address**, or by reissuing
+  the certificate with the address you actually use as a
+  subjectAltName.
+
+!!! note "The path must be absolute, and readable by PHP"
+
+    A relative path is resolved against the PHP process's working
+    directory, which is not where you would expect — always give a full
+    path beginning with `/`.
+
+    The file is opened by the **PHP-FPM pool user**, which is not
+    necessarily the account that owns your web root (on RedHat with
+    nginx, PHP runs as `apache` while nginx runs as `nginx`). If FOG
+    cannot read the file, it writes a line to the web server's error log
+    and carries on **without** it — so a private CA quietly stops being
+    trusted and **Hard** starts failing until the permissions are fixed.
+
+    FOG deliberately does not reject an unreadable path when you save
+    it. Administrators routinely configure a server before its
+    certificate is in place, and refusing the save would make that
+    impossible.
+
+!!! note "Settable outside the web UI too"
+
+    Both fields are part of the LDAP server CSV export and import, and
+    both are readable and writable on `/fog/ldap/<id>` through the
+    [REST API](../../kb/integrations/api.md). An illegal verification
+    level, or a CA path that is relative or too long, is refused there
+    with a **406** naming the value it rejected — the same rule the form
+    applies.
+
+## What a directory user gets
 
 Directory users are subject to [roles](roles.md) exactly like anyone
 else, and — like anyone else — **a directory user with no role has no
-access**. The plugin decides which role each login earns.
+access**. The plugin decides what each login earns.
 
-You map **each directory group to whatever roles it should grant**. Open
-the server, go to its **LDAP Groups** tab, add the directory group by
-name, then attach roles to it.
+You map **each directory group to whatever it should grant**. On the
+server's **General** tab, click **Create New LDAP Group**, enter the
+directory group's name, and pick the server it belongs to. Then open
+that group and use its **Role Association** and **User Group
+Association** tabs to say which [roles](roles.md) and which FOG user
+groups it hands out.
+
+The server's own **Grants** tab is a read-only summary of that: one
+table listing every directory group on the server and the roles it
+grants, another listing the user groups. The grants themselves are
+always edited on the group, not here.
 
 Group mappings are **additive**. A user in three mapped groups receives
-the roles from all three; there is no ranking and no "highest wins".
+everything all three grant; there is no ranking and no "highest wins".
 Directory groups you have not mapped grant nothing.
 
 One setting in **LDAP → Global Options** covers the case where there are
@@ -89,16 +196,16 @@ access.
     targets — which is all those two settings are still for. Nobody's
     access changes as a result of the conversion.
 
-### Roles are re-evaluated on every login
+### Grants are re-evaluated on every login
 
-The roles above are recomputed from the directory each time the user
-signs in. Remove someone from a mapped group in your directory and their
-next FOG login drops the roles that group granted.
+The roles and user groups above are recomputed from the directory each
+time the user signs in. Remove someone from a mapped group in your
+directory and their next FOG login drops whatever that group granted.
 
-Any **other** role an administrator attached to that user by hand is
-left alone. That carve-out is deliberate: without it the sync would
-silently revoke grants you made on purpose, and you would have no way
-to give a directory user anything extra.
+Anything an administrator attached to that user **by hand** is left
+alone. That carve-out is deliberate: without it the sync would silently
+revoke grants you made on purpose, and you would have no way to give a
+directory user anything extra.
 
 ## Nested groups
 
@@ -217,15 +324,15 @@ cost nothing here, and revoking a token is immediate.
 ## Multiple LDAP servers
 
 If more than one LDAP server is configured, FOG tries them **all** and
-combines the result. Every role earned on every server is granted, the
-same way multiple group mappings on one server combine.
+combines the result. Every role and user group earned on every server is
+granted, the same way multiple group mappings on one server combine.
 
 A server where the account does not exist contributes nothing and never
 takes away a match found on another server.
 
 Group mappings belong to the server they were created on, so the same
 directory group name on two different servers is two separate mappings
-and can grant different roles.
+and can grant different things.
 
 The display name and the **allow API** setting are taken from the first
 server that accepted the credential, rather than combined — otherwise a
@@ -250,3 +357,7 @@ still carries only their role's permissions — see
 - Before roles existed, every account this plugin created was in effect
   a full administrator. If that is not what you want, the role mapping
   is where you fix it.
+- **Certificate verification does not change on upgrade.** Existing
+  servers come through set to **Inherit**, which is the behaviour they
+  already had — whatever `TLS_REQCERT` on the FOG server says. Nothing
+  starts failing because the setting arrived.

--- a/docs/management/web/ldap.md
+++ b/docs/management/web/ldap.md
@@ -53,17 +53,23 @@ Directory users are subject to [roles](roles.md) exactly like anyone
 else, and — like anyone else — **a directory user with no role has no
 access**. The plugin decides which role each login earns.
 
-Go to **LDAP → Global Options**. Three settings map a login outcome to
-a role:
+You map **each directory group to whatever roles it should grant**. Open
+the server, go to its **LDAP Groups** tab, add the directory group by
+name, then attach roles to it.
+
+Group mappings are **additive**. A user in three mapped groups receives
+the roles from all three; there is no ranking and no "highest wins".
+Directory groups you have not mapped grant nothing.
+
+One setting in **LDAP → Global Options** covers the case where there are
+no groups to look at:
 
 | Setting | Applies to |
 |---|---|
-| **Role for LDAP admin group** | The user is a member of the server's configured admin group |
-| **Role for LDAP user group** | The user is a member of the server's configured user group |
 | **Role when group matching is off** | The server has group matching disabled |
 
-Leaving one of these unset means a login of that kind earns no role,
-and therefore no access.
+Leaving it unset means such a login earns no role, and therefore no
+access.
 
 !!! warning "Group matching off means *everyone*"
 
@@ -73,31 +79,157 @@ and therefore no access.
     account in the directory that can bind** — not a subset. Choose it
     accordingly, or leave it blank.
 
+!!! note "Where the old admin/user group settings went"
+
+    Earlier builds had a single **admin group** and **user group** per
+    server, each mapped to one role. Those became per-group mappings so
+    that different groups can grant different roles. Your existing group
+    lists are converted automatically on upgrade, using the **Role for
+    LDAP admin group** and **Role for LDAP user group** settings as the
+    targets — which is all those two settings are still for. Nobody's
+    access changes as a result of the conversion.
+
 ### Roles are re-evaluated on every login
 
-The three roles above are recomputed from the directory each time the
-user signs in. Remove someone from the admin group in your directory
-and their next FOG login downgrades them automatically.
+The roles above are recomputed from the directory each time the user
+signs in. Remove someone from a mapped group in your directory and their
+next FOG login drops the roles that group granted.
 
 Any **other** role an administrator attached to that user by hand is
 left alone. That carve-out is deliberate: without it the sync would
 silently revoke grants you made on purpose, and you would have no way
 to give a directory user anything extra.
 
+## Nested groups
+
+By default a user must be a **direct** member of a mapped group. If your
+directory nests groups — a mapped group whose members include *other*
+groups — those users match nothing until you turn nesting on.
+
+For example, with only `all-techs` mapped:
+
+```
+all-staff ──▶ all-techs ──▶ chicago-techs ──▶ alice
+```
+
+`alice` is a member of `chicago-techs`, which is a member of
+`all-techs`. With nesting off she matches nothing, because she is not a
+direct member of anything mapped. Note that `chicago-techs` does **not**
+need to be mapped — nesting is about reaching mapped groups through
+unmapped ones.
+
+Set this **per server**, on the server's own page, because whether
+nesting works and what it costs depends on the directory:
+
+| **Nested Groups** | What it does |
+|---|---|
+| **Off - direct membership only** | Today's behaviour. Direct members only. |
+| **Expand - walk the chain (any directory)** | FOG walks up the group tree itself, one query per level. Works on **every** directory. |
+| **Chain - LDAP_MATCHING_RULE_IN_CHAIN (AD only)** | The directory resolves the whole chain server-side, in a single query. |
+
+**If you are unsure, choose Expand.** It works everywhere and the cost
+is small. Choose **Chain** on Active Directory when you want the lowest
+possible query count.
+
+!!! warning "Nesting widens access, including for users who already matched"
+
+    A parent group's roles reach **everyone beneath it**. That includes
+    people who were already matching directly.
+
+    In the example above, if `all-staff` is also mapped, then turning
+    nesting on gives `alice` the roles from both `all-techs` and
+    `all-staff` — and it does the same for a user who was already a
+    direct member of `all-techs`, because that group is still beneath
+    `all-staff`.
+
+    Before enabling it, look at what your **top-level** groups are
+    mapped to. A role attached to a broad parent group like "all staff"
+    reaches every nested member of it.
+
+    Turning nesting on can only ever **add** access, never remove it, so
+    it is safe to enable in the sense that nobody loses anything.
+
+### Chain is refused on directories that cannot do it
+
+`LDAP_MATCHING_RULE_IN_CHAIN` is an Active Directory feature. OpenLDAP,
+FreeIPA and other directories do not implement it, and a filter that
+uses it there simply matches **nothing** — every nested login would
+fail silently.
+
+So FOG asks the directory before saving. Choose **Chain** against a
+server that does not advertise support and the save is **rejected**,
+with a message telling you to use **Expand** instead. This applies
+however the setting is written, including through the REST API.
+
+If FOG cannot reach the directory at all when you save, it cannot prove
+support is missing, so the setting is stored and a note is written to
+the web server's error log. Configuring a server before it is reachable
+therefore still works.
+
+### Depth limit (Expand only)
+
+Walking the tree costs one directory query per level, so **Expand** has
+a depth limit. **Chain** has none — the directory does the work — and
+ignores this setting entirely.
+
+- **LDAP → Global Options → Default nested group depth** sets the
+  default. It ships as **10**.
+- **Nested Depth** on an individual server overrides it. Leave it blank
+  to inherit the global.
+
+Ten levels is far deeper than most directories nest. If a walk does hit
+the limit, FOG writes a line to the web server's error log naming the
+server, the user and the depth — so a truncated result tells you it was
+truncated rather than looking like a user who simply matched nothing.
+If you see it, raise the depth.
+
+Cycles are handled automatically. A group that contains a group that
+contains the first one resolves correctly and does not consume the depth
+limit.
+
+!!! note "posixGroup / memberUid groups cannot nest"
+
+    If your groups record membership with `memberUid` rather than
+    `member`, nesting cannot work — and that is a property of the schema,
+    not a limitation of FOG. `memberUid` holds bare **usernames**, so
+    there is no way to express "this group contains that group". Direct
+    membership works exactly as before.
+
+### Cost per login
+
+Nesting adds directory queries to each sign-in:
+
+| Strategy | Queries per login |
+|---|---|
+| Off | 1 |
+| Chain | 1 |
+| Expand | one per level, up to the depth limit |
+
+There is deliberately **no caching** of group membership, so removing
+someone from a directory group takes effect on their very next login
+rather than whenever a cache expires.
+
+If the extra queries matter for automation, note that a
+[REST API token](../../kb/integrations/api.md) does not touch the
+directory at all — only interactive sign-in does. Scripts using a token
+cost nothing here, and revoking a token is immediate.
+
 ## Multiple LDAP servers
 
-If more than one LDAP server is configured, FOG tries them all and
-keeps the **most privileged** result:
+If more than one LDAP server is configured, FOG tries them **all** and
+combines the result. Every role earned on every server is granted, the
+same way multiple group mappings on one server combine.
 
-```
-admin group  >  user group  >  group matching off  >  no match
-```
+A server where the account does not exist contributes nothing and never
+takes away a match found on another server.
 
-A server where the account does not exist never downgrades a match
-found on another server. A server with group matching disabled ranks
-*below* a verified user-group match, because "this account can bind and
-we cannot check what it is" is a weaker answer than one the directory
-actually gave.
+Group mappings belong to the server they were created on, so the same
+directory group name on two different servers is two separate mappings
+and can grant different roles.
+
+The display name and the **allow API** setting are taken from the first
+server that accepted the credential, rather than combined — otherwise a
+server that grants nothing else could still hand out API access.
 
 ## API access
 


### PR DESCRIPTION
Story 4 of FOGProject/fogproject#884 — the docs for the nested-group work that
landed on `working-1.6` (stories 1–3, all live-verified against both an OpenLDAP
and a Samba AD fixture).

## What's documented

- **What nesting is**, with a worked example, including the non-obvious part:
  the *bridging* group does not need to be mapped. That is exactly the case the
  feature exists for.
- **Choosing a strategy** — Expand (any directory, one query per level) vs Chain
  (AD only, single query), with a plain "if unsure, choose Expand".
- **Chain is refused** on directories that don't advertise support, through any
  writer including the REST API — plus the "FOG couldn't reach the directory"
  case, which stores the setting and logs, so configuring a server before it's
  reachable isn't mistaken for a bug.
- **Depth limit** (Expand only; Chain ignores it), the global default of 10, the
  per-server override, and the fact that hitting the cap writes a log line
  naming server/user/depth — so a truncated result announces itself rather than
  looking like a user who matched nothing.
- **Cycles** are handled and don't consume depth.
- **posixGroup/memberUid can't nest**, by schema rather than by FOG's choice.
- **Cost per login**, including that there is deliberately no caching (so
  directory removals take effect on the next login) and that API tokens don't
  touch the directory at all.

## ⚠️ Also corrects two stale sections

Flagging this because it's beyond "add nesting docs" and it changes what the page
says about **access control**:

1. **"Which role a directory user gets"** described one admin group and one user
   group per server, each mapped to a single role. That model is gone. Roles now
   come from per-group mappings, reached from the server's **General** tab, and are
   **additive** — a user in three mapped groups gets all three groups' roles.
   `FOG_PLUGIN_LDAP_ADMIN_ROLE` / `_USER_ROLE` survive only as the targets the
   upgrade converts the old lists into, which the page now says explicitly
   instead of presenting them as the live model.
2. **"Multiple LDAP servers"** described keeping the *most privileged* result
   from a tier ladder (`admin > user > matching-off > no match`). There is no
   ladder — the plugin iterates every configured server and merges the roles.
   Display name and allow-API are the documented exceptions, taken from the
   first server that accepted the credential.

Both were verified against the code on `working-1.6`, not assumed.

The corrections aren't optional polish: the new **"nesting widens access"**
warning explains that a parent group's roles reach everyone beneath it, which
cannot be written truthfully on a page asserting that only the single most
privileged result is kept. Documenting nesting on top of the old description
would have produced a page that contradicted itself about who gets access.

## Not verified

`mkdocs` isn't installed on this machine, so I couldn't run `mkdocs build
--strict`. Structure, heading nesting, admonition syntax and the two internal
link targets (`roles.md#api-tokens-follow-roles`, `../../kb/integrations/api.md`)
were each checked by hand.


---

## Second commit — LDAPS certificate verification (fogproject#893)

Extends this PR rather than stacking a second one, since it lands on the same
page.

- **Certificate Verification** (`inherit` / `hard` / `never`) and **CA
  Certificate Path**, the two per-server fields added by
  FOGProject/fogproject#893.
- **The load-bearing detail:** `inherit` resolves from the *FOG server's*
  `ldap.conf` — `LDAPTLS_REQCERT`, then `TLS_REQCERT`, then `demand` — not from
  anything in FOG. Someone reading the word will otherwise assume FOG is the
  thing being inherited from. The page also says why it's the default (the
  plugin asserted no TLS option before #893, so defaulting to `hard` on upgrade
  would break installs that had relaxed `TLS_REQCERT` to reach an internal CA).
- **Why the pair is per server:** one install can have an AD and an OpenLDAP at
  once, and whether verification can succeed is a property of the directory.
- **Getting `hard` to work with a private CA needs two things**, and only the
  first is obvious: trust the CA *and* have a certificate that names the address
  FOG connects to. A `CN=dc1.example.local` cert with no SAN fails against an IP
  no matter how well the CA is trusted. This one bites in practice.
- **CA path must be absolute and readable by the PHP-FPM pool user** — which is
  not necessarily the web root's owner (RedHat + nginx: `apache` vs `nginx`). An
  unreadable path is logged and skipped, so a private CA silently stops being
  trusted. Also states why FOG doesn't refuse the save.
- CSV export/import and REST API coverage, including the **406** on an illegal
  value.
- Upgrade note: existing servers arrive on `inherit`, so nothing starts failing.

## ⚠️ Also corrects the grants workflow

The page described adding directory groups on an **LDAP Groups** tab of the
server. That tab doesn't exist. As shipped: groups are created from the
**General** tab's footer button, their grants are edited on the group's own
**Role Association** and **User Group Association** tabs, and the server's
**Grants** tab is a read-only summary of both.

**User group grants were undocumented entirely.** The plugin syncs LDAP-granted
*user groups* on exactly the same terms as roles — recomputed each login, with
the same carve-out for anything an admin attached by hand — so the role-only
wording is generalised wherever that's what the code does.

The user guide's LDAP plugin blurb is refreshed too; it still described creating
accounts "with the mobile profile", a tier removed in 2017.

Field labels, tab names and the sync behaviour were read out of
`packages/web/lib/plugins/ldap/` on `working-1.6`, not assumed. `mkdocs` still
isn't installed here, so the new link (`../../management/web/ldap.md` from the
user guide) was checked by hand like the others.
