### PR TITLE
Document uninstalling the FOG server

### DIFF
--- a/docs/installation/server/command-line-options.md
+++ b/docs/installation/server/command-line-options.md
@@ -16,13 +16,13 @@ tags:
 
 The FOG installer has quite a few command line options. See the output
 below. You might want force FOG to setup the web interface via HTTPS,
-change the default PXE boot file or web root directory.
+change the web root directory, or install to a non-default location.
 
     ./installfog.sh --help
-    Usage: ./installfog.sh [-h?dEUuHSCKYXTFA] [-f <filename>] [-N <databasename>]
+    Usage: ./installfog.sh [-h?odEUHSCKYyXTFl] [-f <filename>] [-N <databasename>]
             [-D </directory/to/document/root/>] [-c <ssl-path>]
             [-W <webroot/to/fog/after/docroot/>] [-B </backup/path/>]
-            [-s <192.168.1.10>] [-e <192.168.1.254>] [-b <undionly.kpxe>]
+            [-s <192.168.1.10>] [-e <192.168.1.254>]
         -h -? --help            Display this info
         -o    --oldcopy         Copy back old data
         -d    --no-defaults     Don't guess defaults
@@ -31,6 +31,12 @@ change the default PXE boot file or web root directory.
         -S    --force-https     Force HTTPS for all comunication
         -C    --recreate-CA     Recreate the CA Keys
         -K    --recreate-keys   Recreate the SSL Keys
+              --external-ca     Sign FOG's server certificate with an
+                                existing external/intermediate CA instead
+                                of generating a self-signed CA
+              --ca-cert         Path to the intermediate CA certificate (PEM)
+              --ca-key          Path to the intermediate CA private key (PEM)
+              --ca-root         Path to the root CA certificate (PEM)
         -Y -y --autoaccept      Auto accept defaults and install
         -f    --file            Use different update file
         -c    --ssl-path        Specify the ssl path
@@ -41,13 +47,37 @@ change the default PXE boot file or web root directory.
                                 (E.G. http://127.0.0.1/fog,
                                       http://127.0.0.1/)
                                 Defaults to /fog/
+              --fogprogramdir   Specify the FOG base directory
+                                defaults to /opt/fog
+                                remembered in /etc/fog/fog.conf, so it
+                                only needs giving on a first install
+        -N    --mysqldbname     Specify the FOG database name
+                                defaults to fog
         -B    --backuppath      Specify the backup path
-              --uninstall       Uninstall FOG
+              --uninstall       Uninstall FOG. Removes FOG's own files,
+                                services and config, and restores the
+                                files FOG replaced. Your database,
+                                images, snapins, SSL CA and the fog
+                                account are KEPT unless purged below.
+                                Packages are never removed.
+              --dry-run         With --uninstall, list what would be
+                                removed and exit without changing anything
+              --force           With --uninstall, skip the typed
+                                confirmation (-Y does NOT skip it)
+              --purge-db        Also drop the FOG database
+              --purge-images    Also delete the image storage
+              --purge-snapins   Also delete the snapins
+              --purge-ssl       Also delete the SSL CA. This permanently
+                                breaks every deployed fog-client
+              --purge-user      Also delete the fog Linux account
+              --purge-all       All of the --purge-* options above
         -s    --startrange      DHCP Start range
         -e    --endrange        DHCP End range
-        -b    --bootfile        DHCP Boot file
         -E    --no-exportbuild  Skip building nfs file
         -X    --exitFail        Do not exit if item fails
         -T    --no-tftpbuild    Do not rebuild the tftpd config file
         -F    --no-vhost        Do not overwrite vhost file
         -l    --list-packages   List of the basic packages FOG needs for install or is currently installed for FOG
+
+The `--uninstall`, `--dry-run`, `--force` and `--purge-*` options are
+covered in detail in [Uninstalling the Fog server](uninstall-fog-server.md).

--- a/docs/installation/server/uninstall-fog-server.md
+++ b/docs/installation/server/uninstall-fog-server.md
@@ -1,0 +1,172 @@
+---
+title: Uninstalling the Fog server
+aliases:
+    - Uninstalling the Fog server
+    - Uninstall Fog
+description: How to remove FOG from a server, and what it does and does not delete
+context_id: uninstall-fog-server
+tags:
+    - installation
+    - fog-server
+---
+
+# Uninstalling the Fog server
+
+The FOG installer can remove itself:
+
+    cd fogproject/bin
+    ./installfog.sh --uninstall
+
+The guiding rule is **remove what FOG installed, keep what FOG stored**.
+Everything FOG put on the server — its own files, its services, its
+configuration — is removed. Your data is not, unless you explicitly ask for
+it.
+
+That means an uninstall is normally recoverable: reinstall over what is left
+and FOG picks your hosts, images and snapins back up. It also makes this a
+reasonable way to rebuild a server that has got into a bad state without
+losing anything.
+
+!!! warning "Uninstall is not reversible in every case"
+    The `--purge-*` options below *are* destructive and there is no undo.
+    Read [What the purge options remove](#what-the-purge-options-remove)
+    before using them, particularly `--purge-ssl`.
+
+## See what it would do first
+
+`--dry-run` prints the complete plan and exits without changing anything:
+
+    ./installfog.sh --uninstall --dry-run
+
+Run this first. The output lists every path that would be removed, every
+configuration file that would be restored, and the fate of each piece of your
+data.
+
+## What is always removed
+
+| | |
+|---|---|
+| Services | The eight FOG daemons — stopped, disabled, and their unit files deleted |
+| Program files | `/opt/fog/service`, `/opt/fog/log`, `/opt/fog/cache`, `/opt/fog/reporting`, `/opt/fog/php.loc`, `/opt/fog/.fogsettings` |
+| Web files | The FOG web directory under your document root, and the `fog` symlink beside it |
+| System entries | `/etc/fog`, the `/var/log/fog` symlink, `/etc/cron.d/fog_reporting`, `/etc/nfs.conf.d/fog-nfs.conf` |
+| Web server | FOG's own virtual host (`fog.conf` or `001-fog.conf`) |
+| TFTP | The contents of the TFTP root — PXE binaries and boot menus |
+
+If your FOG lives somewhere other than `/opt/fog`, the uninstaller finds it
+the same way the installer does, via `/etc/fog/fog.conf`. You can also point
+it explicitly with `--fogprogramdir`.
+
+## What is always kept
+
+**Packages are never removed.** The web server, database server, NFS server
+and PHP are routinely shared with other things on the same machine, and the
+installer does not record which of them it installed versus found already
+present. Removing them is left to you.
+
+Your data is kept by default:
+
+- the FOG database
+- your images
+- your snapins
+- the SSL CA
+- the `fogproject` Linux account
+
+## Configuration files FOG replaced
+
+FOG does not add lines to `/etc/exports`, `vsftpd.conf`, `dhcpd.conf` or (on
+some distributions) the web server config. It moves the existing file aside as
+`<file>.<timestamp>` and writes its own version.
+
+On uninstall these are restored from the **oldest** such backup, which is the
+genuine pre-FOG original — newer ones are just FOG's own earlier versions. The
+version FOG was using is kept as `<file>.fog-uninstall.<timestamp>` rather than
+deleted, so nothing is lost.
+
+!!! note "Check these afterwards"
+    If you edited any of those files yourself after installing FOG, those edits
+    are in the `.fog-uninstall.` copy, not in the restored file. Review them
+    before restarting the affected service.
+
+## What the purge options remove
+
+These are opt-in, and permanent.
+
+| Option | Removes |
+|---|---|
+| `--purge-db` | Drops the FOG database — hosts, images, snapins, users, task history |
+| `--purge-images` | Deletes your image storage, normally `/images` |
+| `--purge-snapins` | Deletes your snapins |
+| `--purge-ssl` | Deletes the SSL CA — **see below** |
+| `--purge-user` | Deletes the `fogproject` Linux account and its home directory |
+| `--purge-all` | All of the above |
+
+!!! danger "`--purge-ssl` permanently breaks every fog-client"
+    The CA private key signs the certificate every fog-client validates, and
+    the iPXE binaries are built trusting it. Delete it and every client you
+    have deployed stops talking to the server, and every PXE binary must be
+    rebuilt. There is no recovery — each client has to be reinstalled by hand.
+
+    Do not use this unless you are decommissioning the server for good.
+
+The CA lives under the snapins directory (`/opt/fog/snapins/ssl` by default),
+which is why the uninstaller removes FOG's directories individually rather than
+deleting `/opt/fog` wholesale.
+
+The database is dumped to your backup path before anything happens, whatever
+options you pass, since it is the only part that cannot be rebuilt from the FOG
+sources.
+
+## Confirmation
+
+The uninstaller shows you the full plan and asks you to type the server's
+hostname to continue. Anything else aborts without changing a thing.
+
+`-Y`/`--autoaccept` does **not** satisfy this prompt. That flag is already
+present in a lot of people's install scripts, and it must never be enough to
+wipe a server by accident. For automation that genuinely means it, use
+`--force`:
+
+    ./installfog.sh --uninstall --force
+
+## Examples
+
+Remove FOG, keep everything you care about:
+
+    ./installfog.sh --uninstall
+
+Preview a full decommission without touching anything:
+
+    ./installfog.sh --uninstall --purge-all --dry-run
+
+Rebuild a broken server — uninstall, then reinstall over the surviving data:
+
+    ./installfog.sh --uninstall
+    ./installfog.sh
+
+Decommission the machine completely, unattended:
+
+    ./installfog.sh --uninstall --purge-all --force
+
+## Troubleshooting
+
+**"No FOG installation found"**
+
+The uninstaller reads `.fogsettings` to learn what your install created — which
+document root, which storage location, which database. Without it there is
+nothing it can safely remove, so it stops rather than guessing at paths that
+might belong to something else.
+
+If FOG is installed somewhere other than `/opt/fog`, tell it where:
+
+    ./installfog.sh --uninstall --fogprogramdir /srv/fog
+
+**Services still listed after uninstalling**
+
+The unit files are removed and systemd is reloaded, but a shell that was open
+beforehand may still show cached completions. Open a new one.
+
+**The web server still serves something at /fog**
+
+FOG's virtual host is removed but the web server is not restarted, in case the
+machine serves other sites. Reload it yourself when you are ready.


### PR DESCRIPTION
`installfog.sh --uninstall` is implemented as of fogproject `e445e97f1`. It had been advertised in the help text for years while its handler did nothing but `exit 0`, so there was nothing to document before now.

## New page — `installation/server/uninstall-fog-server.md`

Covers what the uninstaller removes, what it deliberately keeps, and the `--purge-*` options.

The emphasis is on data surviving by default: an uninstall is normally recoverable by reinstalling over what is left, which also makes it a reasonable way to rebuild a server that has got into a bad state without losing hosts or images.

`--purge-ssl` gets a danger callout of its own. Deleting the CA permanently breaks every deployed fog-client and every PXE binary signed against it, with no recovery short of reinstalling each client by hand — and that is not obvious from the option name, which otherwise reads like a sibling of `--purge-snapins`.

Also documents the confirmation behaviour, including that `-Y`/`--autoaccept` deliberately does **not** satisfy the prompt (that flag is already in a lot of people's install scripts and must never be enough to wipe a server by accident), and `--force` for automation that means it.

## Refreshed — `installation/server/command-line-options.md`

The `--help` transcript had drifted a fair way from reality:

- synopsis advertised `-u` and `-A`, both long since removed
- listed `-b`/`--bootfile`, retired in fogproject `dffd0aba6` and dead well before that
- missing `--external-ca`, `--ca-cert`, `--ca-key`, `--ca-root`, `--fogprogramdir`, `-N`/`--mysqldbname`
- the intro sentence offered "change the default PXE boot file" as an example of what you might use it for

Regenerated from the current `usage()` output, keeping the existing column layout.

## Notes

- No `mkdocs.yml` change needed — `include_dir_to_nav` picks the new page up from the directory automatically.
- `mkdocs` isn't installed on my machine, so I have not been able to run a local build; the page uses only admonitions, tables and a relative link, all of which are already used elsewhere in this repo.