### PR TITLE
Add a how-to for running FOG under UEFI Secure Boot

### DIFF
--- a/docs/kb/how-tos/secure-boot-signing.md
+++ b/docs/kb/how-tos/secure-boot-signing.md
@@ -47,6 +47,30 @@ the operational discipline that implies, and get a shim through Microsoft's
 review process. Even then, a signature is only as meaningful as the key behind
 it — a signing key that ships to everyone protects nobody.
 
+There is a harder obstacle than key management, and it is worth understanding
+because it will not go away:
+
+**Neither Microsoft nor the shim maintainers will sign a loader that executes
+unsigned code, and that is precisely what iPXE is for.** Microsoft's UEFI
+signing policy excludes bootloaders that can load arbitrary code, because a
+signed one would be a universal Secure Boot bypass on every PC — boot it, chain
+anything. The shim review process applies the same rule from the other side: to
+get a shim signed, whatever it loads must verify signatures before executing.
+iPXE does not, and FOG depends on it not doing so.
+
+iPXE's own source says this out loud. Its shim-handling code documents
+deliberately working *around* shim — not requiring a second-stage loader,
+stopping the PXE base code protocol so shim does not re-download over TFTP, and
+patching the `SbatLevel` variable — each with a note that there is no point
+trying to get a fix upstreamed. Those workarounds are what makes iPXE useful,
+and they are exactly what would fail a review.
+
+So the missing signature on FOG's iPXE binaries is not an oversight or a
+to-do. Signing them with a FOG-held key would not help either: the signature is
+inert until someone enrols the certificate on each machine, which is the same
+physical visit this guide already asks for — it would only change who holds the
+key, while making a single key compromise everyone's problem at once.
+
 The alternative the firmware already provides is **MOK** (Machine Owner Key):
 a per-machine list of extra certificates that *you*, as the physical owner of
 the machine, choose to trust. That is the route this guide takes.
@@ -65,7 +89,7 @@ Less than most people expect.
 
 | Component | Signed? | Why |
 | --- | --- | --- |
-| iPXE (`ipxe.efi`, `snponly.efi`, …) | **Yes** — but upstream already does it | iPXE publishes Microsoft-signed binaries |
+| iPXE (`ipxe.efi`, `snponly.efi`, …) | **Yes — this is your job too** | FOG builds these itself; nothing signs them (see above) |
 | FOS kernel (`bzImage`, `bzImage32`) | **Yes — this is your job** | The firmware refuses to load an unsigned kernel |
 | FOS init (`init.xz`, `init_32.xz`) | **No** | See below |
 | Your images, snapins, scripts | **No** | They are never executed by firmware |
@@ -88,19 +112,36 @@ The practical consequence for you: **you only ever need to sign `bzImage` and
 ### The chain you are building
 
 ```
-UEFI firmware  (trusts Microsoft's certificate)
-  └─ shim, from the iPXE project      ← Microsoft-signed, published upstream
-      └─ ipxe.efi                     ← signed, published upstream
+UEFI firmware  (trusts Microsoft's certificate, via `db`)
+  └─ shim                             ← Microsoft-signed; take one from a distro
+      └─ ipxe.efi                     ← YOU sign this; shim checks it against MOK
           └─ bzImage                  ← YOU sign this; shim checks it against MOK
               └─ init.xz              ← not verified, nothing to do
 ```
 
-The middle link is the one to understand. **MOK is shim's database, not the
+The first link is the one to understand. **MOK is shim's database, not the
 firmware's** — the firmware has never heard of it. Shim installs itself as the
 authority that later `LoadImage()` calls consult, and *that* is what accepts
-your key. Boot a signed iPXE directly, without shim in front of it, and your
-MOK-signed kernel will be rejected: there is nothing in the chain that knows to
-look at MOK.
+your key.
+
+The consequence is easy to get wrong: **MOK cannot help the first binary in the
+chain.** When the firmware PXE-boots a file directly, it checks that file
+against `db` only, because nothing has loaded shim yet to consult MOK. So
+pointing DHCP straight at a MOK-signed `snponly.efi` fails no matter how
+carefully you signed it. Shim has to be the boot file, and iPXE has to be what
+shim loads.
+
+Shim looks for a fixed second-stage filename next to itself — `grubx64.efi` in
+a stock build — so the signed iPXE has to be published under that name for shim
+to pick it up.
+
+!!! tip "The alternative: enrol into `db` instead"
+    Many firmwares can be put into Custom or Setup mode, letting you add your
+    own certificate to `db` directly. That removes shim from the picture
+    entirely — sign `snponly.efi` with your key and the firmware loads it
+    itself. It is cleaner where the firmware supports it, but the menus vary
+    enormously between vendors and some do not expose `db` editing at all,
+    which is why this guide takes the MOK route.
 
 ---
 
@@ -119,11 +160,10 @@ dnf install sbsigntools openssl
 and on each client machine you intend to enrol, a way to run `mokutil` — most
 simply, boot it once from any Linux live USB.
 
-You also need iPXE binaries that can work under Secure Boot at all. FOG's
-default binaries have their boot script *compiled in*, and an embedded script
-is not permitted in a Secure Boot build. Use the binaries from
-`packages/tftp/autoexec/` instead, which read their script from
-`autoexec.ipxe` on the TFTP server. Point your DHCP `filename` option at those.
+You will also need a Microsoft-signed **shim**, which you take from a
+distribution rather than from FOG — `shimx64.efi` out of Ubuntu's `shim-signed`
+package or Fedora's `shim-x64` is the usual choice. Copy it into `/tftpboot`
+and point your DHCP boot file at it instead of at `snponly.efi`.
 
 !!! note "Verify your FOS kernel has an EFI stub"
     Under Secure Boot the kernel is loaded by the firmware's own loader rather
@@ -204,7 +244,33 @@ mokutil --list-enrolled | grep -A2 "FOG imaging"
 
 ---
 
-## Step 3 — Sign the FOS kernels
+## Step 3 — Sign iPXE and the FOS kernels
+
+### 3a — iPXE
+
+Shim will only hand control to a binary it can verify, so iPXE has to carry your
+signature as well. Sign it into the second-stage filename shim looks for:
+
+```bash
+cd /tftpboot
+
+sbsign --key /root/fog-secureboot/MOK.priv \
+       --cert /root/fog-secureboot/MOK.der \
+       --output grubx64.efi snponly.efi
+
+sbverify --cert /root/fog-secureboot/MOK.der grubx64.efi
+# Signature verification OK
+```
+
+The name is not cosmetic — a stock shim loads `grubx64.efi` from the directory
+it was itself loaded from, whatever that binary actually is. Leave the original
+`snponly.efi` in place for your non-Secure-Boot clients; they keep using it
+unchanged.
+
+Your DHCP boot file for Secure Boot clients should now be `shimx64.efi`, not
+`snponly.efi`.
+
+### 3b — The FOS kernels
 
 On the FOG server:
 
@@ -314,6 +380,13 @@ key accordingly.
   any distribution.
 - Signing covers *booting*. It says nothing about whether the image FOS then
   writes to disk is trustworthy.
+- **This chain has not yet been verified end to end by the FOG Project.** The
+  individual links are each standard practice — a distro shim as the boot file,
+  a MOK-signed second stage, a MOK-signed kernel — but FOG's own Secure Boot
+  testing is still outstanding. Treat the procedure as sound in principle and
+  worth reporting back on, rather than as something already proven on FOG's
+  test hardware. If shim rejects iPXE, check that your key is in MOK
+  (`mokutil --list-enrolled`) before suspecting the signature itself.
 
 ## See also
 

--- a/docs/kb/how-tos/secure-boot-signing.md
+++ b/docs/kb/how-tos/secure-boot-signing.md
@@ -1,0 +1,321 @@
+---
+title: Secure Boot - signing FOS with your own key
+aliases:
+    - Secure Boot - signing FOS with your own key
+description: How to run FOG on machines with UEFI Secure Boot enabled by signing the FOS kernel with a key you control and enrolling it as a MOK
+context_id: secure-boot-signing
+tags:
+    - how-to
+    - secure-boot
+    - uefi
+    - advanced
+---
+
+# Secure Boot: signing FOS with your own key
+
+!!! warning "This is an advanced, hands-on procedure"
+    It requires generating and looking after a signing key, and **physically
+    visiting each machine once**. If your site can leave Secure Boot disabled
+    for imaging, that remains far less work. Read [Why FOG cannot do this for
+    you](#why-fog-cannot-do-this-for-you) before deciding.
+
+FOG does not ship signed FOS kernels, and cannot. If your estate mandates UEFI
+Secure Boot and turning it off is not an option, this guide walks through
+becoming your own signing authority: you generate a key, you sign the FOS
+kernel with it, and you tell each machine's firmware to trust that key.
+
+The result is entirely under your control — which is also the point. Nobody
+else, FOG Project included, can produce something your machines will boot.
+
+---
+
+## Why FOG cannot do this for you
+
+Secure Boot is a chain of signatures, and each link only trusts what it was
+built to trust.
+
+Your firmware ships with Microsoft's certificates in its allowed-signature
+database (`db`). Practically everything bootable is signed either directly by
+Microsoft or by a **shim** — a small loader that Microsoft signs once, and
+which then carries the *distribution's own* certificate inside it. That is how
+Ubuntu and Fedora work: Canonical and Red Hat each got one shim signed, and
+from then on they sign their own kernels with their own keys, checked against
+the certificate baked into their shim.
+
+For FOG to do the same, the FOG Project would have to own a signing key with
+the operational discipline that implies, and get a shim through Microsoft's
+review process. Even then, a signature is only as meaningful as the key behind
+it — a signing key that ships to everyone protects nobody.
+
+The alternative the firmware already provides is **MOK** (Machine Owner Key):
+a per-machine list of extra certificates that *you*, as the physical owner of
+the machine, choose to trust. That is the route this guide takes.
+
+!!! info "Why enrolment cannot be automated"
+    MOK enrolment requires a human at the physical console pressing keys. That
+    is not an oversight — it is the security property. If a remote process
+    could enrol a signing key, Secure Boot would be decorative. Budget for one
+    visit per machine, the same way you would for a firmware password.
+
+---
+
+## What actually needs signing
+
+Less than most people expect.
+
+| Component | Signed? | Why |
+| --- | --- | --- |
+| iPXE (`ipxe.efi`, `snponly.efi`, …) | **Yes** — but upstream already does it | iPXE publishes Microsoft-signed binaries |
+| FOS kernel (`bzImage`, `bzImage32`) | **Yes — this is your job** | The firmware refuses to load an unsigned kernel |
+| FOS init (`init.xz`, `init_32.xz`) | **No** | See below |
+| Your images, snapins, scripts | **No** | They are never executed by firmware |
+
+### The initrd is not verified — by anyone
+
+This surprises people, so it is worth stating plainly: **the initramfs is not
+covered by Secure Boot**, on any distribution. Ubuntu and Fedora do not sign
+theirs either. They cannot — `dracut` and `initramfs-tools` build the initramfs
+locally on each machine at install time and on every kernel update, so the
+distribution never sees those bytes.
+
+It is a well-known gap in the model, and the modern answer to it is the
+Unified Kernel Image (kernel, initrd and command line stapled into a single
+signed binary). FOG does not use UKIs today.
+
+The practical consequence for you: **you only ever need to sign `bzImage` and
+`bzImage32`.** Leave `init.xz` and `init_32.xz` alone.
+
+### The chain you are building
+
+```
+UEFI firmware  (trusts Microsoft's certificate)
+  └─ shim, from the iPXE project      ← Microsoft-signed, published upstream
+      └─ ipxe.efi                     ← signed, published upstream
+          └─ bzImage                  ← YOU sign this; shim checks it against MOK
+              └─ init.xz              ← not verified, nothing to do
+```
+
+The middle link is the one to understand. **MOK is shim's database, not the
+firmware's** — the firmware has never heard of it. Shim installs itself as the
+authority that later `LoadImage()` calls consult, and *that* is what accepts
+your key. Boot a signed iPXE directly, without shim in front of it, and your
+MOK-signed kernel will be rejected: there is nothing in the chain that knows to
+look at MOK.
+
+---
+
+## Before you start
+
+You will need, on the FOG server:
+
+```bash
+# Debian / Ubuntu
+apt install sbsigntool openssl
+
+# RHEL / Rocky / Alma / Fedora
+dnf install sbsigntools openssl
+```
+
+and on each client machine you intend to enrol, a way to run `mokutil` — most
+simply, boot it once from any Linux live USB.
+
+You also need iPXE binaries that can work under Secure Boot at all. FOG's
+default binaries have their boot script *compiled in*, and an embedded script
+is not permitted in a Secure Boot build. Use the binaries from
+`packages/tftp/autoexec/` instead, which read their script from
+`autoexec.ipxe` on the TFTP server. Point your DHCP `filename` option at those.
+
+!!! note "Verify your FOS kernel has an EFI stub"
+    Under Secure Boot the kernel is loaded by the firmware's own loader rather
+    than by iPXE's Linux loader, which requires `CONFIG_EFI_STUB=y`. Stock FOS
+    kernels are expected to have it; if boot fails immediately after signing
+    with a format complaint rather than a signature complaint, this is the
+    first thing to check.
+
+---
+
+## Step 1 — Generate a signing key
+
+Do this **once**, on the FOG server, and keep the result safe. Anyone with
+`MOK.priv` can produce something your machines will boot.
+
+```bash
+mkdir -p /root/fog-secureboot && cd /root/fog-secureboot
+
+openssl req -new -x509 -newkey rsa:2048 \
+  -keyout MOK.priv -outform DER -out MOK.der \
+  -days 3650 -subj "/CN=FOG imaging - $(hostname -f)/" \
+  -nodes
+
+chmod 600 MOK.priv
+```
+
+- `MOK.priv` — the private key. **Never leaves this machine.** Back it up
+  somewhere you would put a root password, not somewhere you would put a
+  config file.
+- `MOK.der` — the public certificate. This is what you distribute to clients;
+  it is not sensitive.
+
+The `-days 3650` gives ten years. Choose something you will actually remember
+to renew — an expired MOK stops machines booting.
+
+!!! tip "Use a descriptive CN"
+    It is shown in MokManager when someone enrols it, and again years later
+    when someone is trying to work out what that key is for. `FOG imaging -
+    fog.example.edu` beats `MOK`.
+
+---
+
+## Step 2 — Enrol the certificate on a client
+
+Repeat per machine. Copy `MOK.der` to the client, then:
+
+```bash
+mokutil --import MOK.der
+```
+
+You will be asked for a password **twice**. This is a one-time password used
+only for the next reboot — it confirms that whoever is at the keyboard after
+the reboot is the same person who ran this command. It is not stored and does
+not need to be strong; it needs to be something you can retype in sixty
+seconds. Use the same one across a batch of machines and your life is easier.
+
+Reboot. The machine will stop in a blue **MOK Manager** screen instead of
+booting normally:
+
+1. `Enroll MOK`
+2. `View key 0` — check the CN is yours before continuing
+3. `Continue`
+4. `Yes`
+5. Enter the password from `mokutil --import`
+6. `Reboot`
+
+Confirm afterwards:
+
+```bash
+mokutil --list-enrolled | grep -A2 "FOG imaging"
+```
+
+!!! danger "If MokManager does not appear"
+    The machine booted something that is not shim. Check that Secure Boot is
+    actually enabled (`mokutil --sb-state`) and that the boot entry you are
+    using goes through a shim. A machine that boots straight past MokManager
+    has not enrolled anything.
+
+---
+
+## Step 3 — Sign the FOS kernels
+
+On the FOG server:
+
+```bash
+cd /var/www/fog/service/ipxe    # or /var/www/html/fog/service/ipxe
+
+for k in bzImage bzImage32; do
+  cp -a "$k" "$k.unsigned"
+  sbsign --key /root/fog-secureboot/MOK.priv \
+         --cert /root/fog-secureboot/MOK.der \
+         --output "$k" "$k.unsigned"
+done
+
+chown $(stat -c %U .) bzImage bzImage32
+```
+
+Verify:
+
+```bash
+sbverify --cert /root/fog-secureboot/MOK.der bzImage
+# Signature verification OK
+```
+
+Keeping the `.unsigned` copies matters — `sbsign` will not sign an
+already-signed image cleanly, so the next round needs the original.
+
+!!! warning "This must be repeated after every FOG update"
+    A FOG upgrade replaces `bzImage` and `bzImage32` with fresh unsigned ones,
+    and Secure Boot clients will stop booting the moment it does. This is the
+    single most common way this setup breaks. Save the loop above as a script
+    and run it as the last step of every upgrade — see
+    [Automating the re-sign](#automating-the-re-sign).
+
+---
+
+## Step 4 — Verify end to end
+
+Take one enrolled machine and PXE boot it with Secure Boot **on**:
+
+- iPXE loads and shows its banner — the upstream signed binaries are working.
+- The FOG menu appears — `autoexec.ipxe` is being served and read.
+- Selecting a task boots FOS rather than failing — your signature is accepted.
+
+If it stops at the third step with a security violation, the kernel signature
+is not being accepted. In order of likelihood:
+
+| Symptom | Cause |
+| --- | --- |
+| `Security Policy Violation` | Key not enrolled on *this* machine, or you signed with a different key than you enrolled |
+| Fails on every machine, including enrolled ones | Shim is not in the boot chain — see [the chain](#the-chain-you-are-building) |
+| Worked yesterday, fails today | FOG was updated and the kernels were replaced unsigned |
+| Complains about format, not signature | Kernel lacks `CONFIG_EFI_STUB` |
+
+---
+
+## Automating the re-sign
+
+Save as `/root/fog-secureboot/resign.sh`:
+
+```bash
+#!/bin/bash
+# Re-sign FOS kernels after a FOG update. Secure Boot clients will not boot
+# until this has run.
+set -euo pipefail
+KEYDIR=/root/fog-secureboot
+IPXE=/var/www/fog/service/ipxe
+
+for k in bzImage bzImage32; do
+  [[ -f "$IPXE/$k.unsigned" ]] || cp -a "$IPXE/$k" "$IPXE/$k.unsigned"
+  sbverify --cert "$KEYDIR/MOK.der" "$IPXE/$k" &>/dev/null && continue
+  cp -a "$IPXE/$k" "$IPXE/$k.unsigned"
+  sbsign --key "$KEYDIR/MOK.priv" --cert "$KEYDIR/MOK.der" \
+         --output "$IPXE/$k" "$IPXE/$k.unsigned"
+  echo "re-signed $k"
+done
+```
+
+It is safe to run when nothing has changed — already-signed kernels are skipped.
+
+---
+
+## Rotating or removing a key
+
+To withdraw a key from a machine:
+
+```bash
+mokutil --delete MOK.der
+```
+
+then reboot and confirm in MokManager, exactly as for enrolment.
+
+**There is no remote revocation.** If `MOK.priv` is compromised, every machine
+that enrolled it needs a physical visit to remove it. That is the trade you
+accept in exchange for not needing anyone else's permission — treat the private
+key accordingly.
+
+---
+
+## Known limits
+
+- **EFI only.** Secure Boot is a UEFI feature; BIOS/legacy PXE clients are
+  unaffected and need none of this.
+- **One visit per machine, always.** There is no supported way to enrol a MOK
+  without physical presence.
+- **The initrd is unverified**, as it is everywhere else. If your threat model
+  requires a verified initramfs, Secure Boot alone does not give you that on
+  any distribution.
+- Signing covers *booting*. It says nothing about whether the image FOS then
+  writes to disk is trustworthy.
+
+## See also
+
+- [BIOS and UEFI co-existence](bios-and-uefi-co-existence.md)
+- [UEFI boot entries](uefi-boot-entries.md)


### PR DESCRIPTION
Adds `docs/kb/how-tos/secure-boot-signing.md`.

Sites with a Secure Boot mandate currently have no documented path other than turning it off. FOG cannot close that itself — shipping a signed FOS kernel would mean shipping the signing key, which protects nobody — so this documents the route that does not require the FOG Project to own a key at all: the admin generates their own, signs FOS with it, and enrols it as a MOK.

It is deliberately written around the things that actually trip people up rather than being a command list:

- **The initrd needs no signature** — not by FOG, not by anyone. Ubuntu and Fedora do not sign theirs either, because dracut builds it locally per machine. So only `bzImage` and `bzImage32` are ever signed, and the guide says so early to stop people chasing `init.xz`.
- **MOK is shim's database, not the firmware's.** Enrol a key and boot something that is not shim, and it is silently ignored. This is the failure mode most likely to waste an afternoon.
- **FOG's default iPXE binaries embed their boot script**, which a Secure Boot build does not permit — the `packages/tftp/autoexec/` binaries added in FOGProject/fogproject#957 are required here.
- **A FOG update replaces the kernels unsigned** and every enrolled client stops booting. Called out as a warning with a re-sign script that is safe to run when nothing changed.
- **Enrolment requires physical presence at each machine, by design.** Stated in the first warning block, so nobody discovers it at machine forty.

Also notes there is no remote revocation, which is the real cost of owning the key.

Related: FOGProject/fogproject#957