### PR TITLE
Document the autoexec/ UEFI boot files and their BIOS limitation

### DIFF
--- a/docs/installation/network-setup/dhcp-server-settings.md
+++ b/docs/installation/network-setup/dhcp-server-settings.md
@@ -59,6 +59,44 @@ For older legacy models, these are the boot files to set
 
 You can find other pxe boot files in you `/tftpboot` directory on your fogserver.
 
+### The `autoexec/` boot files (UEFI only)
+
+Alongside the files above, FOG ships a second set of UEFI binaries in
+`/tftpboot/autoexec/`. They are built from identical source, with one
+difference: the iPXE boot script is **not** compiled into the binary. Instead
+they download a plain text script — `autoexec.ipxe` — over TFTP from the same
+folder they were loaded from, and run that.
+
+The practical benefit is that the boot logic becomes a file you can edit on the
+server. Changing something like the menu timeout means editing
+`/tftpboot/autoexec/autoexec.ipxe`, not rebuilding binaries.
+
+To use them, prefix the file name in option 67 with `autoexec/`:
+
+* `autoexec/snponly.efi`
+* `autoexec/ipxe.efi`
+* `autoexec/i386-efi/snponly.efi`
+* `autoexec/arm64-efi/snponly.efi`
+
+Option 66 does not change.
+
+> [!warning]
+> **This works for UEFI clients only.** Legacy BIOS boot files
+> (`undionly.kpxe`, `undionly.kkpxe`, `ipxe.kpxe`, `ipxe.kkpxe`) cannot use it.
+> The mechanism that fetches `autoexec.ipxe` exists only in iPXE's EFI startup
+> path; there is no BIOS equivalent, so a BIOS binary would simply ignore the
+> file. This is why no BIOS boot files are shipped in `autoexec/` — a copy there
+> would boot, but only because it still has the script compiled in, which makes
+> it look like the mechanism works for BIOS when it does not.
+>
+> In a mixed environment, keep BIOS clients pointed at the root
+> (`undionly.kpxe`) and use `autoexec/` only for the UEFI classes.
+
+Both sets are installed and kept in step with each other. The files in the root
+of `/tftpboot` remain the default and are what every existing FOG install uses;
+`autoexec/` is opt-in and behaves identically otherwise. If you are not sure
+which you want, use the root files.
+
 ## Examples of DHCP server configurations
 
 The below are some examples with screen shots on how to configure these settings in some servers.


### PR DESCRIPTION
FOG ships a second set of UEFI binaries in `/tftpboot/autoexec/`, built without the iPXE boot script compiled in — they fetch `autoexec.ipxe` over TFTP from the folder they were loaded from. That turns the boot logic into an editable text file instead of something baked into every binary, but it was undocumented.

Adds a subsection under Option 67 covering:

- how to use it — prefix the option 67 file name with `autoexec/` (option 66 unchanged)
- that it is **UEFI only** — iPXE's autoexec loader exists only in the EFI startup path, so legacy BIOS binaries cannot use it
- why no BIOS binaries are shipped in `autoexec/`: a copy there would boot from its embedded script and wrongly imply the mechanism works for legacy PXE
- that the root `/tftpboot` files remain the default; `autoexec/` is opt-in

Verified on a UEFI VM against the lab server: with option 67 set to `autoexec/snponly.efi`, the client loads the EMBED-less binary, fetches `autoexec.ipxe`, and re-DHCPs as iPXE.

Refs FOGProject/fogproject#957

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgmXVdyZCweJvShtUx49AM