### PR TITLE
Say where the signed ipxe.efi actually comes from

### DIFF
--- a/docs/kb/how-tos/secure-boot-signing.md
+++ b/docs/kb/how-tos/secure-boot-signing.md
@@ -183,9 +183,40 @@ curl -LO https://github.com/ipxe/shim/releases/download/ipxe-16.1/ipxe-shimx64.e
 curl -LO https://github.com/ipxe/shim/releases/download/ipxe-16.1/mmx64.efi
 ```
 
-and a signed `ipxe.efi` from the matching iPXE release, placed alongside them.
 Check <https://github.com/ipxe/shim/releases> for the current version rather
 than assuming `16.1` is still latest.
+
+The signed `ipxe.efi` is **not** published as a standalone release asset. It
+ships inside upstream's Secure Boot disk images, so you have to pull it out:
+
+```bash
+cd /tftpboot
+curl -LO https://github.com/ipxe/ipxe/releases/download/v2.0.0/ipxe-x86_64-sb.usb
+
+# EFI/BOOT/IPXE.EFI is the signed binary
+7z e -y ipxe-x86_64-sb.usb EFI/BOOT/IPXE.EFI
+mv IPXE.EFI ipxe.efi
+rm ipxe-x86_64-sb.usb
+```
+
+(`7z` comes from `p7zip`/`7zip`; `mcopy` from `mtools` works equally well.)
+
+You can confirm you have the right file before going any further — a signed
+binary has a non-empty certificate table, an unsigned one does not:
+
+```bash
+osslsigncode verify -in ipxe.efi 2>&1 | head -5
+```
+
+The signer should be **iPXE Secure Boot Intermediate G1A**. FOG's own
+`/tftpboot/ipxe.efi` and `/tftpboot/autoexec/snponly.efi` have no signature at
+all — if you see that, you have picked up a FOG binary by mistake.
+
+!!! note "Prefer the standalone shim over the one in the image"
+    The image also contains `EFI/BOOT/BOOTX64.EFI`, which is a shim — but it
+    carries only the Microsoft UEFI CA **2011** signature. The separate
+    `ipxe-shimx64.efi` download above is signed against **both 2011 and 2023**,
+    which matters on newer hardware that ships only the 2023 certificate.
 
 !!! note "Verify your FOS kernel has an EFI stub"
     Under Secure Boot the kernel is loaded by the firmware's own loader rather


### PR DESCRIPTION
The guide told the reader to fetch a signed `ipxe.efi` "from the matching iPXE release". **There is no such asset** — upstream publishes only `.iso` and `.usb` Secure Boot images, and the signed binary lives inside them at `EFI/BOOT/IPXE.EFI`. As written the step could not be followed.

Replaces it with the extraction command, plus a way to confirm the file is the right one. Verified against the real artefacts:

| Binary | Certificate table | Signer |
|---|---|---|
| upstream `EFI/BOOT/IPXE.EFI` | 8552 bytes | iPXE Secure Boot Intermediate G1A |
| `ipxe-shimx64.efi` | 19232 bytes | Microsoft UEFI CA 2011 **and** 2023 |
| image's `EFI/BOOT/BOOTX64.EFI` | 9728 bytes | Microsoft UEFI CA 2011 only |
| FOG's `/tftpboot/ipxe.efi` | **none** | — |
| FOG's `autoexec/snponly.efi` | **none** | — |

Picking up a FOG binary by mistake is the obvious failure mode here, so the guide now shows how to check.

Also notes the bundled shim is 2011-only while the standalone `ipxe-shimx64.efi` is dual-signed — which matters on hardware shipping only the 2023 CA.

Refs FOGProject/fogproject#957

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgmXVdyZCweJvShtUx49AM