### PR TITLE
Secure Boot: document the signing automation and the enrolment kit

### DIFF
--- a/docs/kb/how-tos/secure-boot-signing.md
+++ b/docs/kb/how-tos/secure-boot-signing.md
@@ -19,6 +19,10 @@ tags:
     for imaging, that remains far less work. Read [Why FOG cannot do this for
     you](#why-fog-cannot-do-this-for-you) before deciding.
 
+    The signing itself is automated once configured — the installer keeps the
+    kernels signed across upgrades — and the per-machine visit does **not**
+    require turning Secure Boot off. What you cannot avoid is the visit.
+
 FOG does not ship signed FOS kernels, and cannot. If your estate mandates UEFI
 Secure Boot and turning it off is not an option, this guide walks through
 becoming your own signing authority: you generate a key, you sign the FOS
@@ -174,6 +178,20 @@ simply, boot it once from any Linux live USB.
 You will also need the iPXE project's signed shim and its signed `ipxe.efi`.
 Both come from upstream, not from FOG:
 
+>[!tip] The installer can do all of this for you
+>Passing `--secure-boot-stage` downloads the shim and `mmx64.efi`, extracts
+>upstream's signed `ipxe.efi` out of the USB image, drops `autoexec.ipxe` in
+>beside them and fixes up SELinux labels — everything in the rest of this
+>section. It also writes a commented-out Secure Boot class into the generated
+>DHCP config for you to adapt.
+>
+>It is opt-in and never fatal: it pulls pinned third-party binaries over the
+>network, and an upstream hiccup should not be able to fail your install. If it
+>reports a failure, fall back to the manual steps below.
+>
+>The rest of this section is worth reading anyway, because it explains *why*
+>each file has to be where it is.
+
 Put them in their own directory under the TFTP root. **Do not drop them in
 `/tftpboot` itself** — FOG already ships its own `ipxe.efi` there, and
 overwriting it breaks every non-Secure-Boot client that boots that file.
@@ -273,30 +291,68 @@ to renew — an expired MOK stops machines booting.
     when someone is trying to work out what that key is for. `FOG imaging -
     fog.example.edu` beats `MOK`.
 
+>[!warning] Generate a fresh key — do not reuse the MOK you already have
+>If this machine has ever built a DKMS module, it already has a MOK, and it is
+>tempting to reuse it. It will not work.
+>
+>Since shim 15.4 (Ubuntu 21.04 and later), keys carrying the *Module-signing
+>only* KeyUsage OID `1.3.6.1.4.1.2312.16.1.2` are deliberately **ignored** by
+>both shim and GRUB when validating something to boot — they are only good for
+>signing kernel modules. Ubuntu's and Debian's automatically generated DKMS
+>MOK carries exactly that OID.
+>
+>The failure is a plain `Security Policy Violation` at boot with the key
+>showing up quite happily in `mokutil --list-enrolled`, which is a
+>memorably unhelpful combination. The `openssl req` command above produces a
+>key without the OID, so just use it.
+
 ---
 
 ## Step 2 — Enrol the certificate on a client
 
-Repeat per machine. Copy `MOK.der` to the client, then:
+Repeat per machine. **You do not need to turn Secure Boot off to do this**, and
+you should not: both routes below work with it left on.
 
-```bash
-mokutil --import MOK.der
-```
+Once the installer has been run with `--secure-boot-cert`, the FOG web UI grows
+a **FOG Configuration → Secure Boot** page. It shows your certificate's SHA-256
+fingerprint and offers a small **enrolment kit**:
 
-You will be asked for a password **twice**. This is a one-time password used
-only for the next reboot — it confirms that whoever is at the keyboard after
-the reboot is the same person who ran this command. It is not stored and does
-not need to be strong; it needs to be something you can retype in sixty
-seconds. Use the same one across a batch of machines and your life is easier.
+| File | What it is |
+| --- | --- |
+| `MOK.der` | your public certificate — this is the thing being enrolled |
+| `fog-enroll-mok.sh` | does the enrolment, checks the fingerprint first |
+| `fog-enroll-mok.desktop` | double-click launcher for the above |
 
-Reboot. The machine will stop in a blue **MOK Manager** screen instead of
-booting normally:
+Leave that page open on another screen — you are going to compare the
+fingerprint against it.
+
+### Route A — a stock Ubuntu or Debian live USB
+
+This is the reliable route. A stock live image already boots with Secure Boot
+**on**, using the distribution's own signed shim, GRUB and kernel, so there is
+nothing to sign and no firmware setting to change.
+
+1. Write a normal Ubuntu or Debian live image to a USB stick, however you
+   usually do it. **Do not remaster it** — the point is that stock media
+   already solves the Secure Boot problem.
+2. Copy all three kit files onto the stick, next to each other.
+3. Boot the client from it, with Secure Boot still on.
+4. Open the stick in the file manager and run `fog-enroll-mok.desktop`.
+
+The script prints the certificate's fingerprint and asks you to confirm it
+matches the web page before it does anything. Then it asks for a one-time
+password, twice — that password only exists to prove, after the reboot, that
+the person at the keyboard is the person who ran the script. It is not stored
+and does not need to be strong. Use the same one across a batch of machines and
+your life is easier.
+
+Reboot. The machine stops in a blue **MOK Manager** screen instead of booting:
 
 1. `Enroll MOK`
 2. `View key 0` — check the CN is yours before continuing
 3. `Continue`
 4. `Yes`
-5. Enter the password from `mokutil --import`
+5. Enter the password you just chose
 6. `Reboot`
 
 Confirm afterwards:
@@ -305,11 +361,20 @@ Confirm afterwards:
 mokutil --list-enrolled | grep -A2 "FOG imaging"
 ```
 
-!!! danger "If MokManager does not appear"
-    The machine booted something that is not shim. Check that Secure Boot is
-    actually enabled (`mokutil --sb-state`) and that the boot entry you are
-    using goes through a shim. A machine that boots straight past MokManager
-    has not enrolled anything.
+### Route B — no operating system at all
+
+MokManager can read a certificate straight off a FAT filesystem, so a Linux
+session is not strictly required: put `MOK.der` on a FAT32 stick, PXE-boot the
+shim, and use **`Enroll key from disk`** from the MokManager menu.
+
+Fewer moving parts, but `Enroll key from disk` is known to hang on some
+firmware, which is why Route A is the one to reach for first.
+
+>[!danger] If MokManager does not appear
+>The machine booted something that is not shim. Check that Secure Boot is
+>actually enabled (`mokutil --sb-state`) and that the boot entry you are using
+>goes through a shim. A machine that boots straight past MokManager has not
+>enrolled anything.
 
 ---
 
@@ -375,37 +440,45 @@ pointing non-Secure-Boot machines at it.
 
 ### 3b — The FOS kernels
 
-This is the part that is genuinely yours to sign. On the FOG server:
+This is the part that is genuinely yours to sign, and the installer will do it
+for you. Tell it where the key lives:
 
 ```bash
-cd /var/www/fog/service/ipxe    # or /var/www/html/fog/service/ipxe
-
-for k in bzImage bzImage32; do
-  cp -a "$k" "$k.unsigned"
-  sbsign --key /root/fog-secureboot/MOK.priv \
-         --cert /root/fog-secureboot/MOK.der \
-         --output "$k" "$k.unsigned"
-done
-
-chown $(stat -c %U .) bzImage bzImage32
+cd /path/to/fogproject/bin
+./installfog.sh \
+  --secure-boot-key  /root/fog-secureboot/MOK.priv \
+  --secure-boot-cert /root/fog-secureboot/MOK.der
 ```
 
-Verify:
+Both paths are stored in `.fogsettings`, so **every later upgrade re-signs the
+kernels automatically** — you do not have to pass them again. Verify:
 
 ```bash
-sbverify --cert /root/fog-secureboot/MOK.der bzImage
+sbverify --cert /root/fog-secureboot/MOK.der \
+  /var/www/fog/service/ipxe/bzImage
 # Signature verification OK
 ```
 
-Keeping the `.unsigned` copies matters — `sbsign` will not sign an
-already-signed image cleanly, so the next round needs the original.
+The installer keeps a `.unsigned` copy of each kernel beside the signed one,
+because `sbsign` will not cleanly re-sign an already-signed image. Leave them
+alone; they are refreshed on every download.
 
-!!! warning "This must be repeated after every FOG update"
-    A FOG upgrade replaces `bzImage` and `bzImage32` with fresh unsigned ones,
-    and Secure Boot clients will stop booting the moment it does. This is the
-    single most common way this setup breaks. Save the loop above as a script
-    and run it as the last step of every upgrade — see
-    [Automating the re-sign](#automating-the-re-sign).
+>[!note] The web Kernel Update page is covered too
+>Downloading a kernel from **FOG Configuration → Kernel Update** signs it
+>before it is sent to the TFTP server, so that route cannot leave you with an
+>unsigned kernel either. It signs through a small root-only helper
+>(`/opt/fog/bin/fog-sign-kernel`) rather than in the web server itself, so the
+>web server never gets read access to your private key. If signing fails the
+>update is refused outright rather than quietly installing a kernel your
+>clients will not boot.
+>
+>Be aware of the limit of that protection: anyone who can already run code as
+>your web server can ask the helper to sign a kernel of their choosing. What
+>they cannot do is walk off with the key.
+
+>[!warning] Install `sbsigntool` before you enable this
+>If `sbsign`/`sbverify` are missing the installer warns and carries on
+>unsigned rather than aborting the whole install. Read the installer output.
 
 ---
 
@@ -423,35 +496,27 @@ is not being accepted. In order of likelihood:
 | Symptom | Cause |
 | --- | --- |
 | `Security Policy Violation` | Key not enrolled on *this* machine, or you signed with a different key than you enrolled |
+| `Security Policy Violation`, but the key *is* listed by `mokutil --list-enrolled` | The key carries the Module-signing only OID — see [Step 1](#step-1-generate-a-signing-key) |
 | Fails on every machine, including enrolled ones | Shim is not in the boot chain — see [the chain](#the-chain-you-are-building) |
-| Worked yesterday, fails today | FOG was updated and the kernels were replaced unsigned |
+| Worked yesterday, fails today | FOG was updated *before* `--secure-boot-key` was configured, so the kernels were replaced unsigned. Re-run the installer with the key set and it will not happen again |
 | Complains about format, not signature | Kernel lacks `CONFIG_EFI_STUB` |
 
 ---
 
-## Automating the re-sign
+## Signing your own FOS builds
 
-Save as `/root/fog-secureboot/resign.sh`:
+If you build FOS yourself rather than using the released kernels, `build.sh`
+can sign as part of the build, so the published `.sha256` covers the signed
+image:
 
 ```bash
-#!/bin/bash
-# Re-sign FOS kernels after a FOG update. Secure Boot clients will not boot
-# until this has run.
-set -euo pipefail
-KEYDIR=/root/fog-secureboot
-IPXE=/var/www/fog/service/ipxe
-
-for k in bzImage bzImage32; do
-  [[ -f "$IPXE/$k.unsigned" ]] || cp -a "$IPXE/$k" "$IPXE/$k.unsigned"
-  sbverify --cert "$KEYDIR/MOK.der" "$IPXE/$k" &>/dev/null && continue
-  cp -a "$IPXE/$k" "$IPXE/$k.unsigned"
-  sbsign --key "$KEYDIR/MOK.priv" --cert "$KEYDIR/MOK.der" \
-         --output "$IPXE/$k" "$IPXE/$k.unsigned"
-  echo "re-signed $k"
-done
+./build.sh -nka x64 \
+  --sign-key  /root/fog-secureboot/MOK.priv \
+  --sign-cert /root/fog-secureboot/MOK.der
 ```
 
-It is safe to run when nothing has changed — already-signed kernels are skipped.
+`FOS_SIGN_KEY` and `FOS_SIGN_CERT` work too, which is easier in CI. With
+neither set the build is byte-for-byte what it always was.
 
 ---
 
@@ -477,7 +542,12 @@ key accordingly.
 - **EFI only.** Secure Boot is a UEFI feature; BIOS/legacy PXE clients are
   unaffected and need none of this.
 - **One visit per machine, always.** There is no supported way to enrol a MOK
-  without physical presence.
+  without physical presence — that is the security property, not an oversight.
+  The enrolment kit makes the visit short; it cannot remove it. Enrolling into
+  the firmware's own `db` instead would avoid the visit, but `db` updates must
+  be signed by a private PK or KEK, and on OEM hardware that key is
+  Microsoft's. In practice only Dell exposes a genuinely scriptable path, via
+  Custom Mode in Dell Command | Configure and iDRAC.
 - **The initrd is unverified**, as it is everywhere else. If your threat model
   requires a verified initramfs, Secure Boot alone does not give you that on
   any distribution.

--- a/docs/kb/how-tos/secure-boot-signing.md
+++ b/docs/kb/how-tos/secure-boot-signing.md
@@ -180,78 +180,51 @@ dnf install sbsigntools openssl
 and on each client machine you intend to enrol, a way to run `mokutil` — most
 simply, boot it once from any Linux live USB.
 
-You will also need the iPXE project's signed shim and its signed `snponly.efi`.
-Both come from upstream, not from FOG:
+You do **not** need to download the signed shim or the signed `snponly.efi`.
+Since FOG 1.6.0, every install stages them at `/tftpboot/secureboot/`:
 
->[!tip] The installer can do all of this for you
->Passing `--secure-boot-stage` downloads the shim and `mmx64.efi`, pulls
->upstream's signed `snponly.efi` out of `ipxeboot.tar.gz`, links
->`autoexec.ipxe` in beside them and fixes up SELinux labels — everything in the
->rest of this section. It also writes a commented-out Secure Boot class into
->the generated DHCP config for you to adapt.
->
->It is opt-in and never fatal: it pulls pinned third-party binaries over the
->network, and an upstream hiccup should not be able to fail your install. If it
->reports a failure, fall back to the manual steps below.
->
->The rest of this section is worth reading anyway, because it explains *why*
->each file has to be where it is.
-
-Put them in their own directory under the TFTP root. **Do not drop them in
-`/tftpboot` itself** — FOG already ships its own `ipxe.efi` there, and
-overwriting it breaks every non-Secure-Boot client that boots that file.
-
-```bash
-sudo mkdir -p /tftpboot/secureboot
-cd /tftpboot/secureboot
-
-# Microsoft-signed shim, carrying iPXE's vendor certificate.
-# Saved under the snponly- name on purpose -- see the note below.
-sudo curl -Lo snponly-shimx64.efi \
-  https://github.com/ipxe/shim/releases/download/ipxe-16.1/ipxe-shimx64.efi
-# MokManager, used during enrolment
-sudo curl -LO https://github.com/ipxe/shim/releases/download/ipxe-16.1/mmx64.efi
+```
+/tftpboot/secureboot/
+├── snponly-shimx64.efi   Microsoft-signed shim (2011 + 2023), from ipxe/shim
+├── snponly.efi           upstream's signed iPXE
+├── mmx64.efi             MokManager, used during enrolment
+├── autoexec.ipxe         FOG's boot script
+├── MANIFEST              where each file came from, with checksums
+└── arm64-efi/            the same set for arm64
 ```
 
-Check <https://github.com/ipxe/shim/releases> for the current version rather
-than assuming `16.1` is still latest.
+Everything but `autoexec.ipxe` is upstream's, republished byte for byte through
+the [fog-ipxe](https://github.com/FOGProject/fog-ipxe) release the installer
+already downloads. Every file's SHA-256 and its signer are verified when that
+release is built, so a test-signed or tampered binary fails the release rather
+than reaching your server. `MANIFEST` records the source URL and checksum of
+each file if you want to confirm that yourself.
 
-The signed iPXE binaries ship in `ipxeboot.tar.gz`, under a `<arch>-sb/`
-directory. Everything outside those directories is unsigned, so take only what
-you need:
+Nothing is served from this directory unless you point DHCP at it, so its
+presence changes nothing for your existing clients.
 
-```bash
-cd /tftpboot/secureboot
-sudo curl -LO https://github.com/ipxe/ipxe/releases/download/v2.0.0/ipxeboot.tar.gz
+!!! info "If the directory is missing"
+    Two reasons it would not be there. **HTTPS installs skip it** — these are
+    upstream's generic binaries, so they cannot carry your server's CA, and a
+    signed binary cannot be rebuilt without voiding the signature, which makes
+    Secure Boot and FOG's HTTPS mode mutually exclusive. See [the note on
+    enrolling into `db`](#the-chain-you-are-building) for the way round that.
+    Otherwise the download failed — it is deliberately not fatal — and the
+    installer will have said so. Re-run it.
 
-sudo tar -xzf ipxeboot.tar.gz --strip-components=2 ipxeboot/x86_64-sb/snponly.efi
-sudo rm ipxeboot.tar.gz
-
-# link FOG's boot script in beside them, and fix ownership + SELinux labels
-sudo ln -f /tftpboot/autoexec/autoexec.ipxe /tftpboot/secureboot/autoexec.ipxe
-sudo chown -R "$(stat -c %U /tftpboot)" /tftpboot/secureboot
-sudo restorecon -Rv /tftpboot
-```
-
-On arm64, substitute `arm64-sb/snponly.efi` and `shimaa64.efi`.
-
-!!! warning "The `restorecon` is not optional on SELinux systems"
-    Files created with `cp`/`curl` under `/tftpboot` get the `default_t`
-    context rather than `tftpdir_t`, and `in.tftpd` is then denied read on
-    them. The client sees a plain "file not found" with nothing obviously
-    wrong on the server, which is a genuinely confusing way to lose an hour.
-
-You can confirm you have the right file before going any further — a signed
-binary has a non-empty certificate table, an unsigned one does not:
+You can confirm you have a signed binary — a signed one has a non-empty
+certificate table, an unsigned one does not:
 
 ```bash
-osslsigncode verify -in snponly.efi 2>&1 | head -5
+sbverify --list /tftpboot/secureboot/snponly.efi
 ```
 
-The signer should be **iPXE Secure Boot Intermediate G1A**. The copies outside
-`<arch>-sb/` in the same tarball, and FOG's own `/tftpboot/ipxe.efi` and
-`/tftpboot/autoexec/snponly.efi`, have no signature at all — if you see that,
-you have picked up the wrong one.
+The signer should be **iPXE Secure Boot Intermediate G1A**. FOG's own
+`/tftpboot/ipxe.efi` and `/tftpboot/autoexec/snponly.efi` have no signature at
+all — if you see that, you are looking at the wrong file.
+
+On arm64 the equivalents are `arm64-efi/snponly-shimaa64.efi` and
+`arm64-efi/snponly.efi`.
 
 >[!note] Why the shim is renamed `snponly-shimx64.efi`
 >The shim decides what to load next by **stripping `-shim` out of its own
@@ -262,15 +235,17 @@ you have picked up the wrong one.
 >reason. Renaming does not disturb the signature, which covers the file's
 >contents rather than its name.
 
->[!note] Take the shim from the ipxe/shim release, not the tarball
->`ipxeboot.tar.gz` contains a `shimx64.efi` too, but it carries only the
->Microsoft UEFI CA **2011** signature. The standalone `ipxe-shimx64.efi`
->downloaded above carries **two** signatures, 2011 and 2023, which matters on
->newer hardware that ships only the 2023 certificate.
+>[!note] The shim comes from the ipxe/shim release, not from `ipxeboot.tar.gz`
+>The tarball contains a `shimx64.efi` too, but it carries only the Microsoft
+>UEFI CA **2011** signature. The standalone `ipxe-shimx64.efi` — the one FOG
+>stages — carries **two**, 2011 and 2023, which matters on newer hardware that
+>ships only the 2023 certificate.
 >
 >Both facts were confirmed by reading the PE certificate tables directly: the
 >standalone shim has two `WIN_CERTIFICATE` entries, the bundled one has a
->single 2011 entry.
+>single 2011 entry. The fog-ipxe release asserts **both** signatures are
+>present, so a silent upstream regression to a 2011-only build fails the
+>release rather than stranding anyone on 2023-only firmware.
 
 !!! note "Verify your FOS kernel has an EFI stub"
     Under Secure Boot the kernel is loaded by the firmware's own loader rather
@@ -294,14 +269,35 @@ openssl req -new -x509 -newkey rsa:2048 \
   -days 3650 -subj "/CN=FOG imaging - $(hostname -f)/" \
   -nodes
 
+# The same certificate in PEM. Both formats are needed -- see the note below.
+openssl x509 -inform DER -in MOK.der -outform PEM -out MOK.pem
+
 chmod 600 MOK.priv
 ```
 
 - `MOK.priv` — the private key. **Never leaves this machine.** Back it up
   somewhere you would put a root password, not somewhere you would put a
   config file.
-- `MOK.der` — the public certificate. This is what you distribute to clients;
-  it is not sensitive.
+- `MOK.der` — the public certificate, DER-encoded. This is what you distribute
+  to clients and what `mokutil` enrols; it is not sensitive.
+- `MOK.pem` — the same certificate, PEM-encoded. This is what `sbsign` and
+  `sbverify` read.
+
+>[!warning] `sbsign` and `sbverify` cannot read a DER certificate
+>They load certificates with OpenSSL's `PEM_read_bio_X509`, which rejects DER
+>outright:
+>
+>```
+>$ sbsign --key MOK.priv --cert MOK.der --output out.efi in.efi
+>Can't load certificate from file 'MOK.der'
+>error:0480006C:PEM routines:get_name:no start line ... Expecting: CERTIFICATE
+>```
+>
+>`mokutil` and MokManager want the opposite. Neither tool tells you which
+>format it wanted, so keep both files and use `MOK.der` for enrolment and
+>`MOK.pem` for signing. The installer's `--secure-boot-cert` accepts either and
+>converts internally, so this only bites you when running `sbsign`/`sbverify`
+>by hand.
 
 The `-days 3650` gives ten years. Choose something you will actually remember
 to renew — an expired MOK stops machines booting.
@@ -433,21 +429,29 @@ autoexec.ipxe...  Not found
 /autoexec.ipxe... Not found
 ```
 
-The `sudo ln` in the previous step satisfies (1). Current FOG installers also
-satisfy (2) by hard-linking `/tftpboot/autoexec.ipxe` to
-`/tftpboot/autoexec/autoexec.ipxe`, so both paths are one file and editing
-either changes both. Either location works; having both is harmless.
-
-If the root link is missing — an older install, or the file was replaced by an
-editor that writes-and-renames — recreate it:
-
-```bash
-sudo ln -f /tftpboot/autoexec/autoexec.ipxe /tftpboot/autoexec.ipxe
-```
+The installer satisfies both. It hard-links `autoexec.ipxe` into every
+directory an EMBED-less binary can be booted from — the TFTP root,
+`autoexec/`, `autoexec/i386-efi/`, `autoexec/arm64-efi/`, `secureboot/` and
+`secureboot/arm64-efi/`. All six are one file, so editing any of them changes
+all of them and there is no copy left quietly running the old script.
 
 A hard link rather than a symlink because some TFTP daemons refuse to follow
 symlinks, while a hard link is indistinguishable from a regular file to all of
-them. A hard link rather than a copy so the two paths cannot drift apart.
+them. A hard link rather than a copy so the paths cannot drift apart.
+
+If a link has been broken — an older install, or the file was replaced by an
+editor that writes-and-renames — re-running the installer restores it, or:
+
+```bash
+sudo ln -f /tftpboot/autoexec/autoexec.ipxe /tftpboot/secureboot/autoexec.ipxe
+```
+
+You can check they really are one file: every copy should report the same
+inode and a link count of 6.
+
+```bash
+find /tftpboot -name autoexec.ipxe -printf '%i  links=%n  %p\n'
+```
 
 !!! tip "If nothing seems to happen"
     Watch the TFTP server's log during a boot — it tells you exactly which
@@ -477,11 +481,14 @@ cd /path/to/fogproject/bin
   --secure-boot-cert /root/fog-secureboot/MOK.der
 ```
 
-Both paths are stored in `.fogsettings`, so **every later upgrade re-signs the
-kernels automatically** — you do not have to pass them again. Verify:
+`--secure-boot-cert` takes either `MOK.der` or `MOK.pem`; the installer
+converts as needed. Both paths are stored in `.fogsettings`, so **every later
+upgrade re-signs the kernels automatically** — you do not have to pass them
+again. Verify — and note this one must be the **PEM**, because `sbverify` will
+not read DER:
 
 ```bash
-sbverify --cert /root/fog-secureboot/MOK.der \
+sbverify --cert /root/fog-secureboot/MOK.pem \
   /var/www/fog/service/ipxe/bzImage
 # Signature verification OK
 ```
@@ -494,7 +501,8 @@ alone; they are refreshed on every download.
 >Downloading a kernel from **FOG Configuration → Kernel Update** signs it
 >before it is sent to the TFTP server, so that route cannot leave you with an
 >unsigned kernel either. It signs through a small root-only helper
->(`/opt/fog/bin/fog-sign-kernel`) rather than in the web server itself, so the
+>(`$fogprogramdir/bin/fog-sign-kernel`, `/opt/fog/bin/…` by default) rather
+>than in the web server itself, so the
 >web server never gets read access to your private key. If signing fails the
 >update is refused outright rather than quietly installing a kernel your
 >clients will not boot.
@@ -540,8 +548,11 @@ image:
 ```bash
 ./build.sh -nka x64 \
   --sign-key  /root/fog-secureboot/MOK.priv \
-  --sign-cert /root/fog-secureboot/MOK.der
+  --sign-cert /root/fog-secureboot/MOK.pem
 ```
+
+`--sign-cert` must be the **PEM** here — `build.sh` hands it straight to
+`sbsign`, which cannot read DER.
 
 `FOS_SIGN_KEY` and `FOS_SIGN_CERT` work too, which is easier in CI. With
 neither set the build is byte-for-byte what it always was.
@@ -562,6 +573,31 @@ then reboot and confirm in MokManager, exactly as for enrolment.
 that enrolled it needs a physical visit to remove it. That is the trade you
 accept in exchange for not needing anyone else's permission — treat the private
 key accordingly.
+
+---
+
+## Verified
+
+These steps have been run end to end with Secure Boot enforcing, through to a
+completed deploy:
+
+```
+firmware (Secure Boot on, Microsoft certificates in db)
+  └─ secureboot/snponly-shimx64.efi
+      └─ secureboot/snponly.efi        ← shim rewrote its own filename to find it
+          └─ secureboot/autoexec.ipxe → default.ipxe → boot.php
+              └─ bzImage (MOK-signed)  ← LoadImage() consulted MokList, accepted it
+                  └─ FOS → partclone → 42 GB deployed, Task Complete
+```
+
+Worth stating because a reader might reasonably fear the opposite: **no `shim`
+command in the boot script and no `ShimRetainProtocol` handling were needed.**
+Shim installs itself as the authority that later `LoadImage()` calls consult,
+and that survives into iPXE on its own — so when iPXE loads the kernel, the
+check goes against MokList rather than falling back to the firmware's `db`.
+That assumption is what the whole MOK approach rests on, and it holds.
+
+The signed binaries FOG stages are byte-for-byte the ones used in that run.
 
 ---
 
@@ -586,12 +622,16 @@ key accordingly.
   `snponly.efi` has no such CA, and adding one would make it a custom binary
   again — which the shim would then reject. Secure Boot clients need FOG in
   HTTP mode, or a certificate chain the stock binary already trusts.
-- **Not yet confirmed end to end on physical hardware.** FOG has confirmed on
-  VirtualBox that the firmware accepts the signed shim, that the shim accepts
-  upstream's signed iPXE, and that removing the shim makes the firmware reject
-  the same binary — so the trust boundary is real. What has *not* been
-  confirmed anywhere is a MOK-signed `bzImage` actually booting. Reports from
-  physical hardware are very welcome — see
+- **A Secure Boot USB stick does not work the same way.** The filename trick
+  the shim uses to find its second stage — `automatic_next_path()` — is called
+  only from shim's network and HTTP boot paths. There is no local-filesystem
+  equivalent, so a shim booted from a USB stick or an ESP ignores the `-shim`
+  rename entirely and falls back to its compiled-in default, `ipxe.efi`. If you
+  build a Secure Boot USB from these instructions, name the second stage
+  `ipxe.efi` or it will not be found.
+- **Not confirmed on physical hardware.** The whole chain has been confirmed
+  end to end in a VM — see [Verified](#verified) above — but nobody has yet
+  reported it from real hardware. Reports very welcome; see
   [fogproject#960](https://github.com/FOGProject/fogproject/issues/960).
 
     An earlier revision of this page said there was no signed `snponly.efi` and

--- a/docs/kb/how-tos/secure-boot-signing.md
+++ b/docs/kb/how-tos/secure-boot-signing.md
@@ -56,8 +56,9 @@ dedicated iPXE shim — published at
 [ipxe/shim](https://github.com/ipxe/shim/releases), Microsoft-signed against
 both the 2011 and 2023 certificates — which carries iPXE's own code-signing
 certificate as its vendor certificate. Upstream then signs its released
-`ipxe.efi` with that key. So a **stock upstream iPXE** boots under Secure Boot
-with nothing for you to sign.
+binaries with that key — both the all-drivers `ipxe.efi` and the `snponly.efi`
+variant FOG already prefers, for x86_64 and arm64 alike. So a **stock upstream
+iPXE** boots under Secure Boot with nothing for you to sign.
 
 The catch is specific to FOG, and it is worth being precise about, because it
 is the whole reason this guide exists:
@@ -75,7 +76,7 @@ while making one key compromise everyone's problem at once.
 
 The way out is to stop needing a custom binary. FOG's embedded boot script is
 entirely generic, and iPXE 2.0 can fetch that script from the TFTP server
-instead (`autoexec.ipxe`). That lets you run **upstream's signed `ipxe.efi`**
+instead (`autoexec.ipxe`). That lets you run **upstream's signed `snponly.efi`**
 and still get FOG's boot behaviour — which is the approach this guide takes.
 
 The alternative the firmware already provides is **MOK** (Machine Owner Key):
@@ -96,8 +97,8 @@ Less than most people expect.
 
 | Component | Signed? | Why |
 | --- | --- | --- |
-| iPXE (`ipxe.efi`) | **No — use upstream's signed build** | Signed by the iPXE project; FOG's own builds are custom and unsigned |
-| shim (`ipxe-shimx64.efi`) | **No — Microsoft already signed it** | Published by the iPXE project |
+| iPXE (`snponly.efi`) | **No — use upstream's signed build** | Signed by the iPXE project; FOG's own builds are custom and unsigned |
+| shim (`snponly-shimx64.efi`) | **No — Microsoft already signed it** | Published by the iPXE project |
 | FOS kernel (`bzImage`, `bzImage32`) | **Yes — this is your job** | The firmware refuses to load an unsigned kernel |
 | FOS init (`init.xz`, `init_32.xz`) | **No** | See below |
 | Your images, snapins, scripts | **No** | They are never executed by firmware |
@@ -120,11 +121,11 @@ The practical consequence for you: **you only ever need to sign `bzImage` and
 ### The chain you are building
 
 ```
-UEFI firmware  (trusts Microsoft's certificate, via `db`)
-  └─ ipxe-shimx64.efi   ← Microsoft-signed, published by the iPXE project
-      └─ ipxe.efi       ← signed by iPXE; use UPSTREAM's build, not FOG's
-          └─ bzImage    ← YOU sign this; shim checks it against MOK
-              └─ init.xz ← not verified, nothing to do
+UEFI firmware        (trusts Microsoft's certificate, via `db`)
+  └─ snponly-shimx64.efi  ← Microsoft-signed, published by the iPXE project
+      └─ snponly.efi      ← signed by iPXE; UPSTREAM's build, not FOG's
+          └─ bzImage      ← YOU sign this; shim checks it against MOK
+              └─ init.xz  ← not verified, nothing to do
 ```
 
 Only the kernel is yours to sign. The two links above it are already signed by
@@ -141,14 +142,18 @@ against `db` only, because nothing has loaded shim yet to consult MOK. That is
 why the shim — not iPXE — has to be your DHCP boot file. Point DHCP straight at
 an iPXE binary and no amount of signing or enrolling will save you.
 
-The iPXE shim loads **`ipxe.efi`** from the directory it was itself loaded from.
-That name is fixed, so the file has to be present under exactly that name.
+The iPXE shim decides what to load next **from its own filename**, by stripping
+`-shim` out of it. Named `snponly-shimx64.efi`, it loads `snponly.efi` from the
+directory it was itself loaded from; named `ipxe-shimx64.efi`, it loads
+`ipxe.efi`. Whichever you pick, the second-stage file has to be sitting beside
+it under exactly that name.
 
-!!! warning "Use upstream's `ipxe.efi`, not FOG's"
+!!! warning "Use upstream's signed build, not FOG's"
     FOG's own binaries in `/tftpboot` — including those in `autoexec/` — are
-    locally built and unsigned, so the shim will reject them. Download the
-    signed build from the iPXE project. FOG's boot logic reaches it through
-    `autoexec.ipxe` instead of being compiled in.
+    locally built and unsigned, so the shim will reject them, even though one
+    of them is also called `snponly.efi`. Download the signed build from the
+    iPXE project. FOG's boot logic reaches it through `autoexec.ipxe` instead
+    of being compiled in.
 
 !!! tip "The alternative: enrol into `db` instead"
     Many firmwares can be put into Custom or Setup mode, letting you add your
@@ -175,15 +180,15 @@ dnf install sbsigntools openssl
 and on each client machine you intend to enrol, a way to run `mokutil` — most
 simply, boot it once from any Linux live USB.
 
-You will also need the iPXE project's signed shim and its signed `ipxe.efi`.
+You will also need the iPXE project's signed shim and its signed `snponly.efi`.
 Both come from upstream, not from FOG:
 
 >[!tip] The installer can do all of this for you
->Passing `--secure-boot-stage` downloads the shim and `mmx64.efi`, extracts
->upstream's signed `ipxe.efi` out of the USB image, drops `autoexec.ipxe` in
->beside them and fixes up SELinux labels — everything in the rest of this
->section. It also writes a commented-out Secure Boot class into the generated
->DHCP config for you to adapt.
+>Passing `--secure-boot-stage` downloads the shim and `mmx64.efi`, pulls
+>upstream's signed `snponly.efi` out of `ipxeboot.tar.gz`, links
+>`autoexec.ipxe` in beside them and fixes up SELinux labels — everything in the
+>rest of this section. It also writes a commented-out Secure Boot class into
+>the generated DHCP config for you to adapt.
 >
 >It is opt-in and never fatal: it pulls pinned third-party binaries over the
 >network, and an upstream hiccup should not be able to fail your install. If it
@@ -200,8 +205,10 @@ overwriting it breaks every non-Secure-Boot client that boots that file.
 sudo mkdir -p /tftpboot/secureboot
 cd /tftpboot/secureboot
 
-# Microsoft-signed shim, carrying iPXE's vendor certificate
-sudo curl -LO https://github.com/ipxe/shim/releases/download/ipxe-16.1/ipxe-shimx64.efi
+# Microsoft-signed shim, carrying iPXE's vendor certificate.
+# Saved under the snponly- name on purpose -- see the note below.
+sudo curl -Lo snponly-shimx64.efi \
+  https://github.com/ipxe/shim/releases/download/ipxe-16.1/ipxe-shimx64.efi
 # MokManager, used during enrolment
 sudo curl -LO https://github.com/ipxe/shim/releases/download/ipxe-16.1/mmx64.efi
 ```
@@ -209,23 +216,24 @@ sudo curl -LO https://github.com/ipxe/shim/releases/download/ipxe-16.1/mmx64.efi
 Check <https://github.com/ipxe/shim/releases> for the current version rather
 than assuming `16.1` is still latest.
 
-The signed `ipxe.efi` is **not** published as a standalone release asset. It
-ships inside upstream's Secure Boot disk images, so you have to pull it out:
+The signed iPXE binaries ship in `ipxeboot.tar.gz`, under a `<arch>-sb/`
+directory. Everything outside those directories is unsigned, so take only what
+you need:
 
 ```bash
 cd /tftpboot/secureboot
-sudo curl -LO https://github.com/ipxe/ipxe/releases/download/v2.0.0/ipxe-x86_64-sb.usb
+sudo curl -LO https://github.com/ipxe/ipxe/releases/download/v2.0.0/ipxeboot.tar.gz
 
-# EFI/BOOT/IPXE.EFI is the signed binary
-sudo 7z e -y ipxe-x86_64-sb.usb EFI/BOOT/IPXE.EFI
-sudo mv IPXE.EFI ipxe.efi
-sudo rm ipxe-x86_64-sb.usb
+sudo tar -xzf ipxeboot.tar.gz --strip-components=2 ipxeboot/x86_64-sb/snponly.efi
+sudo rm ipxeboot.tar.gz
 
-# copy FOG's boot script in beside them, and fix ownership + SELinux labels
-sudo cp /tftpboot/autoexec/autoexec.ipxe /tftpboot/secureboot/
+# link FOG's boot script in beside them, and fix ownership + SELinux labels
+sudo ln -f /tftpboot/autoexec/autoexec.ipxe /tftpboot/secureboot/autoexec.ipxe
 sudo chown -R "$(stat -c %U /tftpboot)" /tftpboot/secureboot
 sudo restorecon -Rv /tftpboot
 ```
+
+On arm64, substitute `arm64-sb/snponly.efi` and `shimaa64.efi`.
 
 !!! warning "The `restorecon` is not optional on SELinux systems"
     Files created with `cp`/`curl` under `/tftpboot` get the `default_t`
@@ -233,24 +241,36 @@ sudo restorecon -Rv /tftpboot
     them. The client sees a plain "file not found" with nothing obviously
     wrong on the server, which is a genuinely confusing way to lose an hour.
 
-(`7z` comes from `p7zip`/`7zip`; `mcopy` from `mtools` works equally well.)
-
 You can confirm you have the right file before going any further — a signed
 binary has a non-empty certificate table, an unsigned one does not:
 
 ```bash
-osslsigncode verify -in ipxe.efi 2>&1 | head -5
+osslsigncode verify -in snponly.efi 2>&1 | head -5
 ```
 
-The signer should be **iPXE Secure Boot Intermediate G1A**. FOG's own
-`/tftpboot/ipxe.efi` and `/tftpboot/autoexec/snponly.efi` have no signature at
-all — if you see that, you have picked up a FOG binary by mistake.
+The signer should be **iPXE Secure Boot Intermediate G1A**. The copies outside
+`<arch>-sb/` in the same tarball, and FOG's own `/tftpboot/ipxe.efi` and
+`/tftpboot/autoexec/snponly.efi`, have no signature at all — if you see that,
+you have picked up the wrong one.
 
-!!! note "Prefer the standalone shim over the one in the image"
-    The image also contains `EFI/BOOT/BOOTX64.EFI`, which is a shim — but it
-    carries only the Microsoft UEFI CA **2011** signature. The separate
-    `ipxe-shimx64.efi` download above is signed against **both 2011 and 2023**,
-    which matters on newer hardware that ships only the 2023 certificate.
+>[!note] Why the shim is renamed `snponly-shimx64.efi`
+>The shim decides what to load next by **stripping `-shim` out of its own
+>filename** — `ipxe-shimx64.efi` looks for `ipxe.efi`, and
+>`snponly-shimx64.efi` looks for `snponly.efi`. That is upstream's own
+>mechanism, not a trick: `ipxeboot.tar.gz` ships `ipxe-shim.efi` and
+>`snponly-shim.efi` as two symlinks to a single `shimx64.efi` for exactly this
+>reason. Renaming does not disturb the signature, which covers the file's
+>contents rather than its name.
+
+>[!note] Take the shim from the ipxe/shim release, not the tarball
+>`ipxeboot.tar.gz` contains a `shimx64.efi` too, but it carries only the
+>Microsoft UEFI CA **2011** signature. The standalone `ipxe-shimx64.efi`
+>downloaded above carries **two** signatures, 2011 and 2023, which matters on
+>newer hardware that ships only the 2023 certificate.
+>
+>Both facts were confirmed by reading the PE certificate tables directly: the
+>standalone shim has two `WIN_CERTIFICATE` entries, the bundled one has a
+>single 2011 entry.
 
 !!! note "Verify your FOS kernel has an EFI stub"
     Under Secure Boot the kernel is loaded by the firmware's own loader rather
@@ -383,10 +403,22 @@ firmware, which is why Route A is the one to reach for first.
 ### 3a — Serve the signed chain
 
 Set the DHCP boot file for Secure Boot clients to
-**`secureboot/ipxe-shimx64.efi`**. Nothing in this step needs signing by you —
+**`secureboot/snponly-shimx64.efi`**. Nothing in this step needs signing by you —
 both binaries already carry signatures the firmware and shim trust.
 
-Because upstream's `ipxe.efi` has no boot script compiled in, it fetches one
+>[!tip] This is the same driver model FOG already uses
+>`snponly` binds only the firmware's own UEFI network protocol instead of
+>replacing the NIC driver, which is exactly why FOG serves `snponly.efi` to
+>every other client. So a Secure Boot machine now behaves like the rest of your
+>estate rather than being a special case — the only difference is the shim in
+>front and the signature on the kernel.
+>
+>Upstream also publishes a signed all-drivers `ipxe.efi` in the same
+>`<arch>-sb/` directory, paired with `ipxe-shim.efi`. Use it only if you have a
+>NIC the firmware's own driver does not handle; it is the more invasive option,
+>and it is the one that hangs on hardware where the takeover fails.
+
+Because upstream's `snponly.efi` has no boot script compiled in, it fetches one
 over TFTP, and **where it looks is not a single fixed path**. iPXE asks for the
 bare name `autoexec.ipxe` and tries two locations in order:
 
@@ -401,7 +433,7 @@ autoexec.ipxe...  Not found
 /autoexec.ipxe... Not found
 ```
 
-The `sudo cp` in the previous step satisfies (1). Current FOG installers also
+The `sudo ln` in the previous step satisfies (1). Current FOG installers also
 satisfy (2) by hard-linking `/tftpboot/autoexec.ipxe` to
 `/tftpboot/autoexec/autoexec.ipxe`, so both paths are one file and editing
 either changes both. Either location works; having both is harmless.
@@ -422,21 +454,16 @@ them. A hard link rather than a copy so the two paths cannot drift apart.
     filenames the client asked for and whether they were served, which beats
     guessing every time.
 
-Your existing clients are unaffected — leave `snponly.efi` in place and keep
-pointing non-Secure-Boot machines at it.
+Your existing clients are unaffected — FOG's own unsigned `snponly.efi` stays
+at the TFTP root, and non-Secure-Boot machines keep booting it. The signed copy
+lives under `secureboot/` and is reached only by machines you point there.
 
-!!! warning "The only signed binary is an all-drivers build"
-    Upstream publishes exactly one signed x86-64 iPXE binary, and it is an
-    all-drivers build: it binds iPXE's own NIC drivers, disconnecting the
-    firmware's UEFI network driver. On hardware where that takeover does not
-    work, iPXE stops right after `initialising devices` — no banner, no DHCP —
-    and there is currently **no way out**, because the usual answer
-    (`snponly.efi`, which FOG ships as its default for exactly this reason)
-    has no signed equivalent. Building your own loses the signature.
-
-    This is what happens on VirtualBox's emulated Intel 82540EM, where the
-    signature chain verifies perfectly and iPXE then hangs. Requested upstream
-    as [ipxe/ipxe#1776](https://github.com/ipxe/ipxe/issues/1776).
+>[!note] Both files are called `snponly.efi`, and that is fine
+>`/tftpboot/snponly.efi` is FOG's own build — the boot script compiled in, no
+>signature. `/tftpboot/secureboot/snponly.efi` is upstream's signed build,
+>which reads its script from `autoexec.ipxe` instead. They are different
+>binaries doing the same job by different means, which is why the signed one
+>gets its own directory rather than replacing the other.
 
 ### 3b — The FOS kernels
 
@@ -486,7 +513,8 @@ alone; they are refreshed on every download.
 
 Take one enrolled machine and PXE boot it with Secure Boot **on**:
 
-- iPXE loads and shows its banner — the upstream signed binaries are working.
+- iPXE loads and shows its banner — the shim accepted `snponly.efi`, so the
+  upstream signed binaries are working.
 - The FOG menu appears — `autoexec.ipxe` is being served and read.
 - Selecting a task boots FOS rather than failing — your signature is accepted.
 
@@ -555,18 +583,22 @@ key accordingly.
   writes to disk is trustworthy.
 - **HTTPS is not supported under Secure Boot.** FOG's HTTPS mode works because
   the server's CA is compiled into FOG's own iPXE binaries. Upstream's signed
-  `ipxe.efi` has no such CA, and adding one would make it a custom binary again
-  — which the shim would then reject. Secure Boot clients need FOG in HTTP
-  mode, or a certificate chain the stock binary already trusts.
-- **The signature chain is verified; the device-init half is not.** FOG has
-  confirmed on VirtualBox that the firmware accepts the signed shim, the shim
-  accepts upstream's `ipxe.efi`, and iPXE loads `autoexec.ipxe` — and that
-  removing the shim makes the firmware reject the same binary, so the trust
-  boundary is real. What has *not* been confirmed anywhere is a MOK-signed
-  `bzImage` actually booting, because the all-drivers binary hangs during
-  device init on that hardware (see the warning in Step 3a). Reports from
+  `snponly.efi` has no such CA, and adding one would make it a custom binary
+  again — which the shim would then reject. Secure Boot clients need FOG in
+  HTTP mode, or a certificate chain the stock binary already trusts.
+- **Not yet confirmed end to end on physical hardware.** FOG has confirmed on
+  VirtualBox that the firmware accepts the signed shim, that the shim accepts
+  upstream's signed iPXE, and that removing the shim makes the firmware reject
+  the same binary — so the trust boundary is real. What has *not* been
+  confirmed anywhere is a MOK-signed `bzImage` actually booting. Reports from
   physical hardware are very welcome — see
   [fogproject#960](https://github.com/FOGProject/fogproject/issues/960).
+
+    An earlier revision of this page said there was no signed `snponly.efi` and
+    that the all-drivers binary's device-init hang left Secure Boot users with
+    nowhere to go. That was wrong: signed `snponly.efi` binaries ship in
+    `ipxeboot.tar.gz` for x86_64 and arm64, and switching to them removes that
+    problem entirely.
 
 ## See also
 


### PR DESCRIPTION
Documents [FOGProject/fogproject#961](https://github.com/FOGProject/fogproject/pull/961) and [FOGProject/fos#130](https://github.com/FOGProject/fos/pull/130). Updates `docs/kb/how-tos/secure-boot-signing.md`, added a few hours earlier in #77–#83.

**Merge this after those two**, or the guide will describe flags that do not exist yet.

## What changed

**Signing is no longer manual.** The guide told admins to sign kernels by hand and warned that a FOG upgrade would silently undo it. The installer now does it and keeps doing it, so the `resign.sh` section is replaced by the flags that supersede it. `build.sh`'s own signing options are documented for people building FOS themselves.

**A signed `snponly.efi` exists, and the page now uses it.** This is a correction to #77–#83, which said upstream publishes exactly one signed x86-64 iPXE binary, that it is an all-drivers build, and that when the NIC takeover fails Secure Boot users have "no way out". All three were wrong. Signed `snponly.efi` binaries ship in `ipxeboot.tar.gz` under `x86_64-sb/` and `arm64-sb/`, signed by the iPXE Secure Boot Intermediate G1A — verified by reading the PE certificate tables. The original claim came from looking in the release's `-sb.usb` disk image, which carries only `ipxe.efi`.

The chain diagram, signing table, DHCP boot file and download steps all point at `snponly.efi` now, and the `7z` / `-sb.usb` extraction is replaced by a single `tar` command — so `p7zip`/`mtools` are no longer needed at all.

That is worth more than a corrected filename: `snponly` binds only the firmware's UEFI network protocol rather than replacing the NIC driver, which is what FOG already serves every other client. A Secure Boot machine stops being a special case with a different driver model. Step 3a says so, and says when to reach for the all-drivers `ipxe.efi` instead.

**Enrolment is rewritten around the kit FOG now publishes.** The point worth making — never stated before, and the part sites get wrong — is that a stock Ubuntu or Debian live image *already boots with Secure Boot on*, so nobody has to enter firmware setup just to run `mokutil`. MokManager's `Enroll key from disk` is covered as a second route, with its known tendency to hang noted rather than left to be discovered.

**Three traps, all now documented rather than left to be discovered:**

- Since shim 15.4, keys carrying the *Module-signing only* KeyUsage OID `1.3.6.1.4.1.2312.16.1.2` are ignored when validating a boot image — and Ubuntu's and Debian's auto-generated DKMS MOK carries exactly that OID. The symptom is a `Security Policy Violation` from a key `mokutil --list-enrolled` shows quite happily.
- The shim picks its second stage by **stripping `-shim` from its own filename**, so it has to be saved as `snponly-shimx64.efi` for `snponly.efi` to be found.
- The tarball's bundled `shimx64.efi` carries **only** the 2011 Microsoft signature; the standalone `ipxe/shim` build carries 2011 **and** 2023. The standalone one is the right download, and the page now says why.

**Smaller corrections.** The web Kernel Update path is documented as covered, including the honest limit that the sudo helper protects the key but not the act of signing. `--secure-boot-stage` is offered ahead of the manual steps, which are kept because they explain *why* each file has to be where it is. A note that `/tftpboot/snponly.efi` and `/tftpboot/secureboot/snponly.efi` are deliberately different binaries, since two files sharing a name is a fair thing to trip over. "One visit per machine" now says why `db` enrolment is not a way out at fleet scale — `db` updates need a private PK or KEK, and on OEM hardware that is Microsoft's; only Dell exposes a scriptable path.

The `snponly` correction is left **visible** in Known limits rather than quietly rewritten, since the old advice has been public since yesterday and someone may have acted on it.

## Conventions

New callouts use Obsidian `>[!note]` syntax per `CLAUDE.md`. The existing MkDocs `!!! note` admonitions in this file are left alone rather than converted — out of scope, and mixing is only a source-level inconsistency since both render.

## Verified

`mkdocs build` completes. No warnings reference this page; every warning in the output is pre-existing and in other files. Front matter parses and `context_id` is unchanged, so the redirect map is unaffected. Anchors used in new cross-links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZ2jZ7qgen6pXrbtmxShaw