### PR TITLE
Fix Route B's enrolment mechanism; add internal-CA and HTTPS follow-ups

### DIFF
--- a/docs/kb/how-tos/secure-boot-signing.md
+++ b/docs/kb/how-tos/secure-boot-signing.md
@@ -307,6 +307,41 @@ to renew — an expired MOK stops machines booting.
     when someone is trying to work out what that key is for. `FOG imaging -
     fog.example.edu` beats `MOK`.
 
+>[!tip] Using an internal CA instead of a fresh self-signed key
+>Nothing above requires the key to be self-signed. If your organisation
+>already runs an internal CA (AD Certificate Services or similar) and can
+>issue a code-signing certificate, `--secure-boot-key`/`--secure-boot-cert`
+>(or `--sign-key`/`--sign-cert` in `fos/build.sh`) accept that leaf
+>certificate and its key exactly the same way — enrol that same leaf as the
+>MOK and nothing else changes. Standard code-signing templates do not carry
+>the Module-signing-only OID above, so this does not run into that trap.
+>
+>A CA can do more than substitute for the leaf, if you want it to. shim does
+>not just exact-match the enrolled certificate — it validates the embedded
+>PKCS#7 signature's certificate chain against whatever is enrolled
+>(`sbsign --cert <leaf> --addcert <intermediate>` is what embeds that chain).
+>That means enrolling your CA's root or intermediate **once**, then signing
+>with any leaf issued under it afterward: reissue or rotate the leaf and no
+>machine needs to be touched again. FOG's automation does not do this today —
+>`_resignKernels` and `build.sh --sign-cert` assume the certificate you sign
+>with is also the one to publish for MOK enrolment, so handing them a chain
+>would publish the leaf instead of the CA. Doing it today means signing and
+>publishing by hand: follow Step 3b with `--addcert` added to the `sbsign`
+>call, and enrol the CA's certificate rather than a leaf.
+>
+>One thing this does **not** get you: a way to skip enrolment entirely by
+>piggybacking on infrastructure your fleet might already have. There is no
+>generic Intune/GPO mechanism to push an arbitrary org CA into UEFI `db` —
+>what exists there is only Microsoft's own certificate rollover. If your CA
+>is not already enrolled fleet-wide by some other means (vendor BIOS tooling,
+>or manual Setup Mode), the one-time-per-machine visit still applies — it
+>just becomes permanent once done.
+>
+>Nor does any of this extend to HTTPS. Kernel/shim trust and iPXE's TLS root
+>store are two unrelated mechanisms — enrolling a CA here changes nothing
+>about which HTTPS servers a Secure Boot client will fetch from. See
+>Known limits below.
+
 >[!warning] Generate a fresh key — do not reuse the MOK you already have
 >If this machine has ever built a DKMS module, it already has a MOK, and it is
 >tempting to reuse it. It will not work.
@@ -380,17 +415,39 @@ mokutil --list-enrolled | grep -A2 "FOG imaging"
 ### Route B — no operating system at all
 
 MokManager can read a certificate straight off a FAT filesystem, so a Linux
-session is not strictly required: put `MOK.der` on a FAT32 stick, PXE-boot the
-shim, and use **`Enroll key from disk`** from the MokManager menu.
+session is not strictly required — but reaching it needs one more thing than
+an earlier revision of this page said.
 
-Fewer moving parts, but `Enroll key from disk` is known to hang on some
-firmware, which is why Route A is the one to reach for first.
+**A plain PXE boot through the shim never shows MokManager.** Shim only hands
+control to MokManager (`mmx64.efi`) when a *pending* MOK enrolment request
+already exists — normally staged by `mokutil --import`, which is what Route A
+does. With nothing staged, the shim boots straight through to `snponly.efi`
+and the blue MokManager screen never appears, however long you wait.
+
+The FOG PXE menu's **`Enroll Secure Boot Key`** item does this the easy way:
+it chains directly to `secureboot/mmx64.efi`, deliberately bypassing the
+shim's normal gate — which is the only way to reach `Enroll key from disk`
+with nothing pre-staged. Pick it from the menu on any client; no DHCP or
+firmware change is needed, and nothing needs switching back afterward.
+
+If your FOG version predates that menu item, the equivalent by hand is to
+point that one client's DHCP boot file straight at `secureboot/mmx64.efi`
+(`secureboot/arm64-efi/mmx64.efi` on arm64), boot it, enrol, then point DHCP
+back at `secureboot/snponly-shimx64.efi` for normal imaging afterward.
+
+Either way, put `MOK.der` on a FAT32 stick first, then use
+**`Enroll key from disk`** from the MokManager menu.
+
+Fewer moving parts than Route A, but `Enroll key from disk` is known to hang
+on some firmware, which is why Route A is the one to reach for first.
 
 >[!danger] If MokManager does not appear
->The machine booted something that is not shim. Check that Secure Boot is
->actually enabled (`mokutil --sb-state`) and that the boot entry you are using
->goes through a shim. A machine that boots straight past MokManager has not
->enrolled anything.
+>Confirm you actually reached `secureboot/mmx64.efi` — via the
+>`Enroll Secure Boot Key` menu item, or a boot file pointed straight at it —
+>rather than `secureboot/snponly-shimx64.efi`. Booting through the shim
+>normally will not show MokManager; that needs a *pending* MOK request
+>staged first, and this route does not stage one. Also check that Secure
+>Boot is actually enabled (`mokutil --sb-state`).
 
 ---
 
@@ -617,11 +674,41 @@ The signed binaries FOG stages are byte-for-byte the ones used in that run.
   any distribution.
 - Signing covers *booting*. It says nothing about whether the image FOS then
   writes to disk is trustworthy.
-- **HTTPS is not supported under Secure Boot.** FOG's HTTPS mode works because
-  the server's CA is compiled into FOG's own iPXE binaries. Upstream's signed
-  `snponly.efi` has no such CA, and adding one would make it a custom binary
-  again — which the shim would then reject. Secure Boot clients need FOG in
-  HTTP mode, or a certificate chain the stock binary already trusts.
+- **HTTPS still does not work for FOG's typical setup, but there is an
+  unverified exception worth testing.** FOG's usual HTTPS mode compiles the
+  server's own CA into its iPXE binaries — normally a self-signed one, since
+  most FOG deployments never expose imaging infrastructure with a
+  publicly-trusted certificate. Upstream's signed `snponly.efi` has no such CA
+  baked in, and adding one would make it a custom binary again, which the shim
+  would reject. That part is unchanged.
+
+    What is worth knowing: the signed binary is not trust-empty. It ships with
+    a single pinned "iPXE root CA" fingerprint (`src/crypto/rootcert.c`) that
+    is used to **cross-sign the standard public CA list at connect time** —
+    when it meets a server certificate chained to a public root it does not
+    have locally (e.g. Let's Encrypt's ISRG Root X1), it fetches a
+    cross-signature for that root from `http://ca.ipxe.org/auto/<hash>.der`
+    and validates through it. This is documented behaviour, not speculation —
+    see [ipxe/ipxe#606](https://github.com/ipxe/ipxe/issues/606) for a log
+    excerpt of it happening against a real Let's Encrypt certificate.
+
+    So a FOG server with a **publicly-trusted** certificate — not FOG's usual
+    self-signed one — might validate over HTTPS with the stock signed binary,
+    provided: the imaging network has outbound HTTP reachability to
+    `ca.ipxe.org` at boot time (many isolated PXE VLANs deliberately do not),
+    and the certificate uses an algorithm the pinned release supports (RSA is
+    fine; ECDSA support timing relative to this specific v2.0.0 release is
+    unverified). **This has not been tested end to end** against FOG's actual
+    signed binaries or on real hardware — treat it as something to try, not a
+    supported configuration, and report results on
+    [fogproject#960](https://github.com/FOGProject/fogproject/issues/960)
+    alongside the rest of the physical-hardware verification that issue
+    already tracks.
+
+    Either way, enrolling your MOK for kernel signing does nothing for this:
+    Secure Boot/MOK trust (which binaries may execute) and iPXE's TLS root
+    store (which HTTPS servers are trusted) are two entirely separate
+    mechanisms.
 - **A Secure Boot USB stick does not work the same way.** The filename trick
   the shim uses to find its second stage — `automatic_next_path()` — is called
   only from shim's network and HTTP boot paths. There is no local-filesystem


### PR DESCRIPTION
## Summary

Follow-up to the Secure Boot signing guide merged in #84. One real bug fix
and two additions surfaced during review, none of which made it into that
PR.

### Route B was wrong, not just imprecise

The guide said to "PXE-boot the shim, and use `Enroll key from disk` from
the MokManager menu." That doesn't work: shim only hands control to
MokManager when a *pending* MOK enrolment request already exists (normally
staged by `mokutil --import`, which is what Route A does). A plain PXE
boot through the shim boots straight through to `snponly.efi` — MokManager
never appears, however long you wait. Verified against shim's own source
(`mok.c`'s `check_mok_request()`, `MokManager.c`'s unconditional menu).

Corrected to point at `secureboot/mmx64.efi` directly — either via the new
**"Enroll Secure Boot Key"** PXE menu item
([fogproject#976](https://github.com/FOGProject/fogproject/pull/976)), or
for FOG versions that predate it, by temporarily repointing DHCP at that
file by hand. The adjacent `!!! danger "If MokManager does not appear"`
callout was telling readers to check they were going *through* a shim,
which is backwards for this route — fixed to match.

### Two additions from review

- **Using an internal CA instead of a fresh self-signed key.** shim
  validates the enrolled certificate's chain, not an exact match, so
  enrolling a CA once and signing with any leaf under it means a leaf can
  be reissued or rotated without another physical visit. FOG's automation
  doesn't do this directly today (`_resignKernels`/`build.sh --sign-cert`
  assume the signing cert is also the one to publish for enrolment), so
  it's documented as a manual `--addcert` variant of Step 3b.
- **HTTPS isn't simply "not supported."** The signed `snponly.efi` ships
  with a pinned iPXE root CA that cross-signs the standard public CA list
  at connect time
  ([ipxe/ipxe#606](https://github.com/ipxe/ipxe/issues/606)), so a FOG
  server with a genuinely publicly-trusted certificate (not FOG's usual
  self-signed one) might validate over HTTPS with the stock signed binary.
  Documented as an explicitly **unverified** possibility to test and
  report on
  [fogproject#960](https://github.com/FOGProject/fogproject/issues/960),
  not a supported configuration — most FOG deployments use a self-signed
  cert on an isolated imaging VLAN, neither of which this helps.

## Verified

- `mkdocs build` produces the same 8 pre-existing `RoamLinksPlugin`
  warnings (false positives on bash `[[ ]]` syntax elsewhere in the docs,
  unrelated to this page) before and after this change — no new warnings,
  no broken anchors.
- Obsidian callout syntax (`>[!tip]`, `>[!danger]`) matches the existing
  callouts on this page.

Refs #84, fogproject#960, fogproject#976


---
_Generated by [Claude Code](https://claude.ai/code/session_01HZ2jZ7qgen6pXrbtmxShaw)_