### PR TITLE
Secure Boot: document key generation being on by default

### DIFF
--- a/docs/installation/server/command-line-options.md
+++ b/docs/installation/server/command-line-options.md
@@ -78,6 +78,41 @@ change the web root directory, or install to a non-default location.
         -T    --no-tftpbuild    Do not rebuild the tftpd config file
         -F    --no-vhost        Do not overwrite vhost file
         -l    --list-packages   List of the basic packages FOG needs for install or is currently installed for FOG
+              --secure-boot-key   Private key used to re-sign the FOS
+                                  kernels for UEFI Secure Boot
+              --secure-boot-cert  Certificate matching --secure-boot-key
+                                  (both are required together)
+              --no-secure-boot    Do not generate a Secure Boot signing
+                                  key, and leave the FOS kernels unsigned
 
 The `--uninstall`, `--dry-run`, `--force` and `--purge-*` options are
 covered in detail in [Uninstalling the Fog server](uninstall-fog-server.md).
+
+## Secure Boot options
+
+Since FOG 1.6.0 the installer **generates a Secure Boot signing key by
+default** and signs the FOS kernels with it, so a stock server always has a
+certificate fingerprint to check and an enrolment kit to hand out. The three
+options above only matter if you want to change that:
+
+| Option | Use it when |
+| --- | --- |
+| *(none)* | The default. A key is generated at `/opt/fog/secureboot/` on first install and **reused, never regenerated**, on every later upgrade. |
+| `--secure-boot-key` + `--secure-boot-cert` | You already have a signing key you want FOG to use. Both are required together; the certificate may be PEM or DER. Your key is never overwritten. |
+| `--no-secure-boot` | You do not want a signing key or the root-only signing helper on this server. The FOS kernels are left unsigned. |
+
+`--no-secure-boot` is remembered in `.fogsettings`, so an upgrade will not
+hand back a key and a `sudoers` rule you deliberately declined.
+
+>[!warning] The generated key is never regenerated, and that is deliberate
+>A new signing key silently invalidates enrolment on **every machine that
+>already trusted the old one**, and nothing reports that until a client fails
+>to boot — long after the install that caused it. `--recreate-keys` and
+>`--recreate-CA` deliberately do not touch it. To rotate deliberately, remove
+>`/opt/fog/secureboot/` and re-run the installer, then re-enrol every client.
+
+The private key lives at `/opt/fog/secureboot/MOK.key`, `0600` inside a `0700`
+directory owned by root. It is never copied into the web root and the web
+server cannot read it — see
+[[secure-boot-signing|Secure Boot: signing FOS with your own key]] for the
+full procedure and for what to do on each client.

--- a/docs/kb/how-tos/secure-boot-signing.md
+++ b/docs/kb/how-tos/secure-boot-signing.md
@@ -13,15 +13,22 @@ tags:
 
 # Secure Boot: signing FOS with your own key
 
-!!! warning "This is an advanced, hands-on procedure"
-    It requires generating and looking after a signing key, and **physically
-    visiting each machine once**. If your site can leave Secure Boot disabled
-    for imaging, that remains far less work. Read [Why FOG cannot do this for
-    you](#why-fog-cannot-do-this-for-you) before deciding.
+!!! warning "This is a hands-on procedure"
+    It requires **physically visiting each machine once**. If your site can
+    leave Secure Boot disabled for imaging, that remains far less work. Read
+    [Why FOG cannot do this for you](#why-fog-cannot-do-this-for-you) before
+    deciding.
 
-    The signing itself is automated once configured — the installer keeps the
-    kernels signed across upgrades — and the per-machine visit does **not**
+    The server side is automatic since FOG 1.6.0 — the installer generates a
+    signing key, signs the FOS kernels with it, and keeps them signed across
+    upgrades, with nothing to configure. The per-machine visit does **not**
     require turning Secure Boot off. What you cannot avoid is the visit.
+
+>[!info] What changed in FOG 1.6.0
+>Signing used to be opt-in, enabled by passing `--secure-boot-key` and
+>`--secure-boot-cert`. It is now on by default and the key is generated for
+>you, so [Step 1](#step-1-the-signing-key) is reading rather than doing unless
+>you want to supply your own key. Use `--no-secure-boot` to turn it off.
 
 FOG does not ship signed FOS kernels, and cannot. If your estate mandates UEFI
 Secure Boot and turning it off is not an option, this guide walks through
@@ -167,18 +174,14 @@ it under exactly that name.
 
 ## Before you start
 
-You will need, on the FOG server:
+On the FOG server, nothing. `sbsigntool` (`sbsigntools` on RHEL/Rocky/Alma/
+Fedora and Arch) is part of the installer's baseline package set since FOG
+1.6.0, alongside `openssl`. If your distribution ships neither name the
+installer says so and carries on, leaving the kernels unsigned — read the
+installer output rather than assuming.
 
-```bash
-# Debian / Ubuntu
-apt install sbsigntool openssl
-
-# RHEL / Rocky / Alma / Fedora
-dnf install sbsigntools openssl
-```
-
-and on each client machine you intend to enrol, a way to run `mokutil` — most
-simply, boot it once from any Linux live USB.
+On each client machine you intend to enrol, you need a way to run `mokutil` —
+most simply, boot it once from any Linux live USB.
 
 You do **not** need to download the signed shim or the signed `snponly.efi`.
 Since FOG 1.6.0, every install stages them at `/tftpboot/secureboot/`:
@@ -256,10 +259,41 @@ On arm64 the equivalents are `arm64-efi/snponly-shimaa64.efi` and
 
 ---
 
-## Step 1 — Generate a signing key
+## Step 1 — The signing key
 
-Do this **once**, on the FOG server, and keep the result safe. Anyone with
-`MOK.priv` can produce something your machines will boot.
+**The installer already did this.** On first install it generates a signing
+key and signs the FOS kernels with it, so unless you want to supply your own
+key there is nothing to run here.
+
+```
+/opt/fog/secureboot/          0700, root:root
+├── MOK.key                   0600 — the private key
+├── MOK.pem                   0644 — the certificate, PEM (what sbsign reads)
+└── mok.cnf                   the openssl config used to generate the pair
+```
+
+The directory sits under `$fogprogramdir`, which is never inside the web root,
+so none of it is reachable over HTTP. **The web server cannot read the private
+key**: kernel downloads from the web UI are signed by a small root-only helper
+(`/opt/fog/bin/fog-sign-kernel`) that takes no arguments, rather than in the
+web server itself. Only the public certificate is published, as `MOK.der` in
+the enrolment kit.
+
+Back up `MOK.key` somewhere you would put a root password. Anyone holding it
+can produce something your machines will boot.
+
+>[!warning] The key is never regenerated, on purpose
+>Re-running the installer reuses the existing pair. A fresh key silently
+>invalidates enrolment on **every machine that already trusted the old one**,
+>and nothing surfaces that until a client fails to boot. `--recreate-keys` and
+>`--recreate-CA` deliberately do not reach it. To rotate on purpose, delete
+>`/opt/fog/secureboot/`, re-run the installer, and re-enrol every client — see
+>[Rotating or removing a key](#rotating-or-removing-a-key).
+
+### Bringing your own key
+
+If you already have a signing key — a site CA, or one shared with other
+tooling — pass it instead and the installer will never touch or overwrite it:
 
 ```bash
 mkdir -p /root/fog-secureboot && cd /root/fog-secureboot
@@ -275,6 +309,13 @@ openssl x509 -inform DER -in MOK.der -outform PEM -out MOK.pem
 chmod 600 MOK.priv
 ```
 
+```bash
+cd /path/to/fogproject/bin
+./installfog.sh \
+  --secure-boot-key  /root/fog-secureboot/MOK.priv \
+  --secure-boot-cert /root/fog-secureboot/MOK.der
+```
+
 - `MOK.priv` — the private key. **Never leaves this machine.** Back it up
   somewhere you would put a root password, not somewhere you would put a
   config file.
@@ -282,6 +323,11 @@ chmod 600 MOK.priv
   to clients and what `mokutil` enrols; it is not sensitive.
 - `MOK.pem` — the same certificate, PEM-encoded. This is what `sbsign` and
   `sbverify` read.
+
+Both paths are recorded in `.fogsettings`, so later upgrades keep using them
+without the flags being passed again. The two options are only meaningful
+together — the installer refuses half a pair rather than leaving kernels
+unsigned on a server whose admin believes they are signed.
 
 >[!warning] `sbsign` and `sbverify` cannot read a DER certificate
 >They load certificates with OpenSSL's `PEM_read_bio_X509`, which rejects DER
@@ -300,7 +346,8 @@ chmod 600 MOK.priv
 >by hand.
 
 The `-days 3650` gives ten years. Choose something you will actually remember
-to renew — an expired MOK stops machines booting.
+to renew — an expired MOK stops machines booting. The installer-generated key
+uses the same ten years, with the CN `FOG Project Secure Boot Signing`.
 
 !!! tip "Use a descriptive CN"
     It is shown in MokManager when someone enrols it, and again years later
@@ -321,6 +368,15 @@ to renew — an expired MOK stops machines booting.
 >showing up quite happily in `mokutil --list-enrolled`, which is a
 >memorably unhelpful combination. The `openssl req` command above produces a
 >key without the OID, so just use it.
+>
+>The key the installer generates carries no such OID either, so this only
+>applies if you are supplying your own.
+
+### Turning signing off
+
+`--no-secure-boot` skips key generation entirely and leaves the FOS kernels
+unsigned. It is remembered in `.fogsettings`, so an upgrade will not hand back
+a key and a `sudoers` rule you deliberately declined.
 
 ---
 
@@ -329,9 +385,9 @@ to renew — an expired MOK stops machines booting.
 Repeat per machine. **You do not need to turn Secure Boot off to do this**, and
 you should not: both routes below work with it left on.
 
-Once the installer has been run with `--secure-boot-cert`, the FOG web UI grows
-a **FOG Configuration → Secure Boot** page. It shows your certificate's SHA-256
-fingerprint and offers a small **enrolment kit**:
+The FOG web UI has a **FOG Configuration → Secure Boot** page. It shows your
+certificate's SHA-256 fingerprint, offers a small **enrolment kit**, and
+repeats the per-client steps below as a checklist:
 
 | File | What it is |
 | --- | --- |
@@ -471,27 +527,28 @@ lives under `secureboot/` and is reached only by machines you point there.
 
 ### 3b — The FOS kernels
 
-This is the part that is genuinely yours to sign, and the installer will do it
-for you. Tell it where the key lives:
+This is the part that is genuinely yours to sign, and **the installer has
+already done it** — there is no step here unless you supplied your own key,
+in which case [Step 1](#bringing-your-own-key) covers passing it.
 
-```bash
-cd /path/to/fogproject/bin
-./installfog.sh \
-  --secure-boot-key  /root/fog-secureboot/MOK.priv \
-  --secure-boot-cert /root/fog-secureboot/MOK.der
-```
+Every install and upgrade re-signs the kernels, and it has to: the FOS
+binaries are re-copied into place unsigned on every run, so the signature is
+removed and immediately re-applied in the same pass. That is what stops an
+upgrade silently leaving you with kernels your clients will not boot — which
+is the single most common way this setup breaks.
 
-`--secure-boot-cert` takes either `MOK.der` or `MOK.pem`; the installer
-converts as needed. Both paths are stored in `.fogsettings`, so **every later
-upgrade re-signs the kernels automatically** — you do not have to pass them
-again. Verify — and note this one must be the **PEM**, because `sbverify` will
+Verify — and note the certificate must be the **PEM**, because `sbverify` will
 not read DER:
 
 ```bash
-sbverify --cert /root/fog-secureboot/MOK.pem \
+sbverify --cert /opt/fog/secureboot/MOK.pem \
   /var/www/fog/service/ipxe/bzImage
 # Signature verification OK
 ```
+
+The signer shown should match the fingerprint on the **FOG Configuration →
+Secure Boot** page; that page's SHA-256 is the digest of the same certificate
+your clients enrol.
 
 The installer keeps a `.unsigned` copy of each kernel beside the signed one,
 because `sbsign` will not cleanly re-sign an already-signed image. Leave them
@@ -511,9 +568,12 @@ alone; they are refreshed on every download.
 >your web server can ask the helper to sign a kernel of their choosing. What
 >they cannot do is walk off with the key.
 
->[!warning] Install `sbsigntool` before you enable this
->If `sbsign`/`sbverify` are missing the installer warns and carries on
->unsigned rather than aborting the whole install. Read the installer output.
+>[!warning] If `sbsigntool` could not be installed
+>The installer adds `sbsigntool` (`sbsigntools` on RHEL/Arch) to its baseline
+>package set, but if neither name exists in your distribution's repositories
+>it skips the package, then warns and carries on **unsigned** rather than
+>aborting the whole install. Read the installer output — an unsigned kernel
+>only announces itself at a client, as a `Security Policy Violation`.
 
 ---
 
@@ -532,9 +592,10 @@ is not being accepted. In order of likelihood:
 | Symptom | Cause |
 | --- | --- |
 | `Security Policy Violation` | Key not enrolled on *this* machine, or you signed with a different key than you enrolled |
-| `Security Policy Violation`, but the key *is* listed by `mokutil --list-enrolled` | The key carries the Module-signing only OID — see [Step 1](#step-1-generate-a-signing-key) |
+| `Security Policy Violation`, but the key *is* listed by `mokutil --list-enrolled` | The key carries the Module-signing only OID — see [Step 1](#step-1-the-signing-key) |
 | Fails on every machine, including enrolled ones | Shim is not in the boot chain — see [the chain](#the-chain-you-are-building) |
-| Worked yesterday, fails today | FOG was updated *before* `--secure-boot-key` was configured, so the kernels were replaced unsigned. Re-run the installer with the key set and it will not happen again |
+| Worked yesterday, fails today | Something replaced the kernels without re-signing them. On FOG 1.6.0+ the installer always re-signs, so suspect anything that copies into `service/ipxe/` outside it — check with `sbverify` and re-run the installer |
+| Every machine stops working after a key change | The signing key was regenerated. Enrolment is per-key, so all clients need re-enrolling — see [Rotating or removing a key](#rotating-or-removing-a-key) |
 | Complains about format, not signature | Kernel lacks `CONFIG_EFI_STUB` |
 
 ---
@@ -550,6 +611,9 @@ image:
   --sign-key  /root/fog-secureboot/MOK.priv \
   --sign-cert /root/fog-secureboot/MOK.pem
 ```
+
+If you are using the key the installer generated, that is
+`--sign-key /opt/fog/secureboot/MOK.key --sign-cert /opt/fog/secureboot/MOK.pem`.
 
 `--sign-cert` must be the **PEM** here — `build.sh` hands it straight to
 `sbsign`, which cannot read DER.
@@ -569,10 +633,22 @@ mokutil --delete MOK.der
 
 then reboot and confirm in MokManager, exactly as for enrolment.
 
-**There is no remote revocation.** If `MOK.priv` is compromised, every machine
-that enrolled it needs a physical visit to remove it. That is the trade you
-accept in exchange for not needing anyone else's permission — treat the private
-key accordingly.
+To rotate the **installer-generated** key, delete the directory and re-run the
+installer — it only generates when no pair is present:
+
+```bash
+rm -rf /opt/fog/secureboot
+cd /path/to/fogproject/bin && ./installfog.sh
+```
+
+That produces a new key and re-signs the kernels with it. **Every already-
+enrolled client stops booting at that moment** and needs re-enrolling by hand,
+so treat it as a deliberate estate-wide operation, not a troubleshooting step.
+
+**There is no remote revocation.** If the private key is compromised, every
+machine that enrolled it needs a physical visit to remove it. That is the trade
+you accept in exchange for not needing anyone else's permission — treat the
+private key accordingly.
 
 ---
 

--- a/docs/kb/how-tos/secure-boot-signing.md
+++ b/docs/kb/how-tos/secure-boot-signing.md
@@ -13,16 +13,16 @@ tags:
 
 # Secure Boot: signing FOS with your own key
 
-!!! warning "This is a hands-on procedure"
-    It requires **physically visiting each machine once**. If your site can
-    leave Secure Boot disabled for imaging, that remains far less work. Read
-    [Why FOG cannot do this for you](#why-fog-cannot-do-this-for-you) before
-    deciding.
-
-    The server side is automatic since FOG 1.6.0 — the installer generates a
-    signing key, signs the FOS kernels with it, and keeps them signed across
-    upgrades, with nothing to configure. The per-machine visit does **not**
-    require turning Secure Boot off. What you cannot avoid is the visit.
+>[!warning] This is a hands-on procedure
+>It requires **physically visiting each machine once**. If your site can
+>leave Secure Boot disabled for imaging, that remains far less work. Read
+>[Why FOG cannot do this for you](#why-fog-cannot-do-this-for-you) before
+>deciding.
+>
+>The server side is automatic since FOG 1.6.0 — the installer generates a
+>signing key, signs the FOS kernels with it, and keeps them signed across
+>upgrades, with nothing to configure. The per-machine visit does **not**
+>require turning Secure Boot off. What you cannot avoid is the visit.
 
 >[!info] What changed in FOG 1.6.0
 >Signing used to be opt-in, enabled by passing `--secure-boot-key` and
@@ -90,11 +90,11 @@ The alternative the firmware already provides is **MOK** (Machine Owner Key):
 a per-machine list of extra certificates that *you*, as the physical owner of
 the machine, choose to trust. That is the route this guide takes.
 
-!!! info "Why enrolment cannot be automated"
-    MOK enrolment requires a human at the physical console pressing keys. That
-    is not an oversight — it is the security property. If a remote process
-    could enrol a signing key, Secure Boot would be decorative. Budget for one
-    visit per machine, the same way you would for a firmware password.
+>[!info] Why enrolment cannot be automated
+>MOK enrolment requires a human at the physical console pressing keys. That
+>is not an oversight — it is the security property. If a remote process
+>could enrol a signing key, Secure Boot would be decorative. Budget for one
+>visit per machine, the same way you would for a firmware password.
 
 ---
 
@@ -155,20 +155,20 @@ directory it was itself loaded from; named `ipxe-shimx64.efi`, it loads
 `ipxe.efi`. Whichever you pick, the second-stage file has to be sitting beside
 it under exactly that name.
 
-!!! warning "Use upstream's signed build, not FOG's"
-    FOG's own binaries in `/tftpboot` — including those in `autoexec/` — are
-    locally built and unsigned, so the shim will reject them, even though one
-    of them is also called `snponly.efi`. Download the signed build from the
-    iPXE project. FOG's boot logic reaches it through `autoexec.ipxe` instead
-    of being compiled in.
+>[!warning] Use upstream's signed build, not FOG's
+>FOG's own binaries in `/tftpboot` — including those in `autoexec/` — are
+>locally built and unsigned, so the shim will reject them, even though one
+>of them is also called `snponly.efi`. Download the signed build from the
+>iPXE project. FOG's boot logic reaches it through `autoexec.ipxe` instead
+>of being compiled in.
 
-!!! tip "The alternative: enrol into `db` instead"
-    Many firmwares can be put into Custom or Setup mode, letting you add your
-    own certificate to `db` directly. That removes shim from the picture — sign
-    whatever you like and the firmware loads it. It is the only route if you
-    need FOG's *custom* iPXE (embedded CA for HTTPS) under Secure Boot, but the
-    menus vary enormously between vendors and some do not expose `db` editing
-    at all.
+>[!tip] The alternative: enrol into `db` instead
+>Many firmwares can be put into Custom or Setup mode, letting you add your
+>own certificate to `db` directly. That removes shim from the picture — sign
+>whatever you like and the firmware loads it. It is the only route if you
+>need FOG's *custom* iPXE (embedded CA for HTTPS) under Secure Boot, but the
+>menus vary enormously between vendors and some do not expose `db` editing
+>at all.
 
 ---
 
@@ -206,14 +206,14 @@ each file if you want to confirm that yourself.
 Nothing is served from this directory unless you point DHCP at it, so its
 presence changes nothing for your existing clients.
 
-!!! info "If the directory is missing"
-    Two reasons it would not be there. **HTTPS installs skip it** — these are
-    upstream's generic binaries, so they cannot carry your server's CA, and a
-    signed binary cannot be rebuilt without voiding the signature, which makes
-    Secure Boot and FOG's HTTPS mode mutually exclusive. See [the note on
-    enrolling into `db`](#the-chain-you-are-building) for the way round that.
-    Otherwise the download failed — it is deliberately not fatal — and the
-    installer will have said so. Re-run it.
+>[!info] If the directory is missing
+>Two reasons it would not be there. **HTTPS installs skip it** — these are
+>upstream's generic binaries, so they cannot carry your server's CA, and a
+>signed binary cannot be rebuilt without voiding the signature, which makes
+>Secure Boot and FOG's HTTPS mode mutually exclusive. See [the note on
+>enrolling into `db`](#the-chain-you-are-building) for the way round that.
+>Otherwise the download failed — it is deliberately not fatal — and the
+>installer will have said so. Re-run it.
 
 You can confirm you have a signed binary — a signed one has a non-empty
 certificate table, an unsigned one does not:
@@ -250,12 +250,12 @@ On arm64 the equivalents are `arm64-efi/snponly-shimaa64.efi` and
 >present, so a silent upstream regression to a 2011-only build fails the
 >release rather than stranding anyone on 2023-only firmware.
 
-!!! note "Verify your FOS kernel has an EFI stub"
-    Under Secure Boot the kernel is loaded by the firmware's own loader rather
-    than by iPXE's Linux loader, which requires `CONFIG_EFI_STUB=y`. Stock FOS
-    kernels are expected to have it; if boot fails immediately after signing
-    with a format complaint rather than a signature complaint, this is the
-    first thing to check.
+>[!note] Verify your FOS kernel has an EFI stub
+>Under Secure Boot the kernel is loaded by the firmware's own loader rather
+>than by iPXE's Linux loader, which requires `CONFIG_EFI_STUB=y`. Stock FOS
+>kernels are expected to have it; if boot fails immediately after signing
+>with a format complaint rather than a signature complaint, this is the
+>first thing to check.
 
 ---
 
@@ -349,10 +349,10 @@ The `-days 3650` gives ten years. Choose something you will actually remember
 to renew — an expired MOK stops machines booting. The installer-generated key
 uses the same ten years, with the CN `FOG Project Secure Boot Signing`.
 
-!!! tip "Use a descriptive CN"
-    It is shown in MokManager when someone enrols it, and again years later
-    when someone is trying to work out what that key is for. `FOG imaging -
-    fog.example.edu` beats `MOK`.
+>[!tip] Use a descriptive CN
+>It is shown in MokManager when someone enrols it, and again years later
+>when someone is trying to work out what that key is for. `FOG imaging -
+>fog.example.edu` beats `MOK`.
 
 >[!warning] Generate a fresh key — do not reuse the MOK you already have
 >If this machine has ever built a DKMS module, it already has a MOK, and it is
@@ -509,10 +509,10 @@ inode and a link count of 6.
 find /tftpboot -name autoexec.ipxe -printf '%i  links=%n  %p\n'
 ```
 
-!!! tip "If nothing seems to happen"
-    Watch the TFTP server's log during a boot — it tells you exactly which
-    filenames the client asked for and whether they were served, which beats
-    guessing every time.
+>[!tip] If nothing seems to happen
+>Watch the TFTP server's log during a boot — it tells you exactly which
+>filenames the client asked for and whether they were served, which beats
+>guessing every time.
 
 Your existing clients are unaffected — FOG's own unsigned `snponly.efi` stays
 at the TFTP root, and non-Secure-Boot machines keep booting it. The signed copy


### PR DESCRIPTION
Follows [fogproject e200d9296](https://github.com/FOGProject/fogproject/commit/e200d9296) (working-1.6) and [5d23f2030](https://github.com/FOGProject/fogproject/commit/5d23f2030) (dev-branch), which make the installer generate a Secure Boot signing key by default instead of requiring `--secure-boot-key`/`--secure-boot-cert`.

That change makes parts of these two pages **wrong**, not just incomplete — they tell readers to generate a key by hand, install `sbsigntool` themselves, and re-run the installer with flags that are no longer needed.

## `command-line-options.md`

The verbatim `--help` dump predated the Secure Boot flags entirely, so none of the three were listed. Added from the installer's actual `usage()` output, plus a section on when each option is needed.

## `secure-boot-signing.md`

- **Step 1** becomes "The signing key" — the installer already generated it, so the section documents where it lives (`/opt/fog/secureboot/`, `0700` root) and why the web server cannot read it. The manual `openssl` path moves to a **Bringing your own key** subsection, which is now the only reason to pass the flags. The `#step-1-generate-a-signing-key` cross-reference is updated to match the retitle.
- **Before you start** no longer tells people to install `sbsigntool` — it is in the installer's baseline package set now. The replacement warning covers what still bites: neither package name existing, the installer carrying on unsigned, and that only surfacing at a client as a `Security Policy Violation`.
- **Step 3b** no longer instructs passing the flags, and explains why every install re-signs — the FOS binaries are re-copied unsigned on every run, so the signature is removed and re-applied in the same pass.
- **Rotation** covers deleting `/opt/fog/secureboot` to force a new key, and states plainly that every enrolled client stops booting when it does.
- **Troubleshooting**: the "updated before `--secure-boot-key` was configured" row no longer applies as written; replaced with rows for kernels replaced outside the installer, and for a rotated key.

## Verification

`mkdocs build` exits 0. The new wikilink resolves, and all 21 same-page anchors on the how-to resolve with none left dead. The `RoamLinksPlugin` warnings in the build output are pre-existing — shell snippets like `[[ -z $var ]]` in other pages being parsed as wikilinks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)