### PR TITLE
Document the two Secure Boot enrolment paths, including unattended Setup Mode

### DIFF
--- a/docs/kb/how-tos/secure-boot-signing.md
+++ b/docs/kb/how-tos/secure-boot-signing.md
@@ -2,7 +2,7 @@
 title: Secure Boot - signing FOS with your own key
 aliases:
     - Secure Boot - signing FOS with your own key
-description: How to run FOG on machines with UEFI Secure Boot enabled by signing the FOS kernel with a key you control and enrolling it as a MOK
+description: How to run FOG on machines with UEFI Secure Boot enabled by signing the FOS kernel with a key you control and enrolling it as a MOK, or unattended into db on platforms in Setup Mode
 context_id: secure-boot-signing
 tags:
     - how-to
@@ -441,8 +441,26 @@ a key and a `sudoers` rule you deliberately declined.
 
 ## Step 2 — enroll the certificate on a client
 
-Repeat per machine. **You do not need to turn Secure Boot off to do this**, and
-you should not: both routes below work with it left on.
+Repeat per machine. There are three routes, and the right one depends on what
+you can get at: whether you can stand at the machine, and whether its firmware
+can be put into Setup Mode.
+
+```mermaid
+flowchart TD
+    S{Can the firmware be<br/>put into Setup Mode?<br/><em>clear the PK — often scriptable<br/>via Dell cctk / Redfish</em>}
+    S -- Yes --> C["<b>Route C</b> — Setup Mode<br/>Schedule the task; FOS writes db/KEK/PK<br/><b>nobody at the console</b>"]
+    S -- No --> H{Standing at<br/>the machine?}
+    H -- Yes --> B["<b>Route B</b> — FOG boot menu<br/>No USB stick, no live image<br/>Keypresses at MokManager"]
+    H -- No --> A["<b>Route A</b> — Ubuntu/Debian live USB<br/>The reliable fallback when<br/>'Enroll key from disk' hangs"]
+    C --> D["Turn Secure Boot back <b>on</b><br/>in firmware — always manual"]
+    B --> D
+    A --> D
+```
+
+**Routes A and B do not require you to turn Secure Boot off**, and you should
+not: both work with it left on. Route C is different — it needs the platform in
+Setup Mode, which is not the same thing as Secure Boot being switched off (see
+that section).
 
 The FOG web UI has a **FOG Configuration → Secure Boot** page. It shows your
 certificate's SHA-256 fingerprint, offers a small **enrolment kit**, and links
@@ -597,11 +615,14 @@ are already standing at the machine when the enrolment happens.
 >console; nothing removes that.
 
 >[!tip] Which route to reach for
->Route B has far fewer moving parts and, since the network-delivery change
->above, needs neither a live image nor a USB stick — try it first if you are
->standing at the machine anyway. Route A is the fallback: `Enroll key from
->disk` is reported to hang on some firmware, and a stock live USB sidesteps
->that entirely by using the distribution's own shim.
+>If the firmware can be put into Setup Mode, **Route C below is the one that
+>scales** — it is the only route that does not end with a human pressing keys
+>on every machine. Where it is not available, Route B has far fewer moving
+>parts and, since the network-delivery change above, needs neither a live image
+>nor a USB stick — try it first if you are standing at the machine anyway.
+>Route A is the fallback: `Enroll key from disk` is reported to hang on some
+>firmware, and a stock live USB sidesteps that entirely by using the
+>distribution's own shim.
 
 >[!note] arm64 clients
 >The menu entry serves the matching MokManager automatically — `mmx64.efi` for
@@ -617,6 +638,86 @@ are already standing at the machine when the enrolment happens.
 >both states. If the screen appeared and was gone by the time you looked,
 >you likely missed MokManager's own ~10-second startup timeout — see the
 >warning above — rather than anything being misconfigured.
+
+### Route C — Setup Mode, with nobody at the console
+
+Routes A and B both end at a human pressing keys, because MOK enrolment is
+*designed* to require one. Route C sidesteps that by not using MOK at all: if
+the platform is in **Setup Mode**, the running OS can write the real Secure Boot
+databases directly, and FOS does it unattended.
+
+Schedule the **Enroll Secure Boot Key** task exactly as in Route B. FOS decides
+which route to take by itself — it reads the firmware state at boot, and only
+takes this path if it finds Setup Mode. Anything else falls back to staging a
+MOK request, so scheduling the task against a mixed fleet is safe.
+
+What it writes, in this order and no other:
+
+| Variable | Contents |
+| --- | --- |
+| `db` | Microsoft's five published CAs **plus** your `CN=FOG Project Secure Boot Signing` certificate |
+| `KEK` | Microsoft's two KEK CAs plus this server's Key Exchange Key |
+| `PK` | this server's Platform Key, alone |
+
+The order is load-bearing. Writing `PK` is what takes the platform *out* of
+Setup Mode, and every write after it must carry a signature the firmware
+checks — so `PK` goes last. FOS also fetches all three blobs before writing any
+of them, so a web server hiccup cannot leave a machine half-enrolled, and it
+aborts on the first failure rather than pressing on to the write that closes the
+door. A run that fails partway leaves the platform still in Setup Mode, still
+booting anything, exactly as it was found.
+
+Success is confirmed by `SetupMode` flipping 1 → 0 — the firmware accepting the
+`PK`. Note that `SecureBoot` stays 0 until the next boot regardless, because the
+firmware computes it during POST.
+
+>[!warning] Microsoft's certificates are in that `db` on purpose
+>It is tempting to read "your own trusted `db`" as "only your certificate".
+>Removing Microsoft's CAs breaks Windows — and it breaks FOG, because the shim
+>at the head of your own boot chain is Microsoft-signed. A `db` without them is
+>a machine that no longer PXE boots.
+
+>[!note] What still needs a human
+>*Getting into* Setup Mode means clearing the `PK` at the firmware screen, and
+>turning Secure Boot back **on** afterwards is a firmware toggle too. Neither is
+>reachable from a running OS by design. So Route C trades "a visit with a live
+>USB, or keypresses at MokManager" for "a firmware visit" — the win is that the
+>firmware half is scriptable through vendor tooling (Dell `cctk`, Redfish) where
+>Routes A and B never were, and that once done it is permanent.
+
+>[!danger] The task cannot run on a machine already enforcing Secure Boot
+>iPXE 2.0.0 verifies both the kernel *and* the initrd through shim. On a machine
+>with Secure Boot enforcing and your certificate not yet trusted, both are
+>refused — `Verification failed: Security Policy Violation` — so FOS never
+>starts and no task of any kind runs. This is a property of the boot chain, not
+>of the enrolment task. Secure Boot must be off, or the platform in Setup Mode,
+>for the machine to get far enough to enroll.
+
+#### Requirements
+
+- **FOS release `20260804` or newer.** Earlier inits have no `fog.enrollsb`.
+- **`efitools` on the server.** The installer installs it and builds the signed
+  variable updates automatically. If it is missing the installer says so and
+  skips building them — enrolment then falls back to the MOK routes rather than
+  failing silently.
+- **FOG 1.6.** The blobs are published at
+  `<web-root>/service/secureboot/{db,KEK,PK}.auth` by the 1.6 installer only.
+  FOS is shared between 1.5 and 1.6, so a 1.5 server ships an init that *has*
+  `fog.enrollsb` — the MOK staging path still works there, but Route C cannot,
+  because there are no `.auth` blobs to fetch.
+
+The server's `PK`, `KEK` and signing keys are generated once and **never
+regenerate** on later installs. The `.auth` blobs are rebuilt every install, but
+from those same keys, so re-running the installer does not invalidate machines
+you have already enrolled.
+
+>[!note] Validation status
+>Route C has been validated end to end in VirtualBox: Setup Mode → task
+>completes unattended → firmware holds exactly the certificates in the table
+>above → Secure Boot switched on → the same machine PXE boots FOG's signed chain
+>and images normally. Per-model validation on *physical* firmware is still
+>outstanding, and a mistake there is not reversible from the OS — it needs a
+>firmware trip. Treat the first machine of any model as a test.
 
 ---
 

--- a/docs/management/fos/using-fog-boot-menu.md
+++ b/docs/management/fos/using-fog-boot-menu.md
@@ -113,13 +113,31 @@ tags:
 > -   Added in FOG 1.6.0, and only relevant to clients booting with UEFI
 >     Secure Boot enabled.
 >
-> -   This command hands off to MokManager so you can enrol FOG's signing
->     certificate on the client, which is what allows the machine to boot
->     the FOS kernel with Secure Boot left on.
+> -   This command enrols FOG's signing certificate on the client, which is
+>     what allows the machine to boot the FOS kernel with Secure Boot left
+>     on.
 >
-> -   You must have `MOK.der` on a FAT-formatted USB stick in the machine
->     first — MokManager reads it from local media, not over the network.
->     Get that file from **FOG Configuration → Secure Boot**.
+> -   **No USB stick is needed.** `MOK.der` is delivered over the network,
+>     so the certificate no longer has to be staged on local media before
+>     you start. You can still get the file from **FOG Configuration →
+>     Secure Boot** if you want it by hand.
+>
+> -   It also does not have to be driven from this menu. **Enroll Secure
+>     Boot Key** is a task type, schedulable from **Task Scheduling**
+>     against one host or a whole group — a host with it pending skips the
+>     menu and runs it on the next PXE boot.
+>
+> -   What happens next depends on the client's firmware state, and FOS
+>     decides by itself:
+>
+>     :   -   **Setup Mode** — FOS writes the real Secure Boot databases
+>             (`db`, `KEK`, `PK`) directly and finishes **unattended**.
+>             Added in FOG 1.6; requires FOS release `20260804` or newer.
+>
+>         -   **Anything else** — FOS stages a MOK request and hands off to
+>             MokManager, which needs someone at the console to confirm it.
+>             MOK enrolment is designed to require physical presence and
+>             there is no way around that.
 >
 > -   fog.enrollsecureboot is the command used to reference this action in
 >     pxe menu settings.


### PR DESCRIPTION
The Secure Boot guide documented two enrolment routes, both ending at a human pressing keys at the console — MOK enrolment is *designed* to require physical presence. FOG 1.6 adds a third that does not, and it has been shipping since FOS release `20260804` with no documentation at all.

## `secure-boot-signing.md`

**New "Route C — Setup Mode, with nobody at the console".** If the platform is in Setup Mode, FOS writes the real Secure Boot databases directly and the scheduled task completes unattended. Covers:

- **What it writes and in what order** — `db` (Microsoft's five CAs + your signing cert), `KEK`, then `PK`. The order is load-bearing: writing `PK` leaves Setup Mode, so every write after it must be signature-checked. Also notes FOS fetches all three blobs before writing any, so a web-server hiccup cannot half-enroll a machine.
- **How success is confirmed** — `SetupMode` flipping 1 → 0. `SecureBoot` stays 0 until the next boot regardless, because firmware computes it during POST.
- **Requirements** — FOS `20260804`+, `efitools` on the server, and FOG 1.6. Since FOS is shared between 1.5 and 1.6, a 1.5 server ships an init that *has* `fog.enrollsb`: the MOK path still works there, Route C cannot, because the `.auth` blobs are published by the 1.6 installer only.

Three warnings stated plainly, because each is expensive to get wrong:

- Microsoft's CAs are in that `db` **deliberately** — removing them breaks Windows *and* stops the machine PXE booting, since the shim heading FOG's own chain is Microsoft-signed.
- Entering Setup Mode and re-enabling Secure Boot are both still firmware-screen work. The honest claim is "a firmware visit instead of a console visit" — the win being that the firmware half is scriptable via vendor tooling (Dell `cctk`, Redfish) where MOK never was.
- **The task cannot run on a machine already enforcing Secure Boot.** iPXE 2.0.0 verifies kernel *and* initrd through shim and refuses both, so FOS never starts. A property of the boot chain, not of the task.

Also adds a **mermaid decision diagram** for picking a route (renders natively — `pymdownx.superfences` already has mermaid configured), updates the "which route" tip to point at C where available, and records that per-model validation on *physical* firmware is still outstanding — a mistake there needs a firmware trip, so the first machine of any model should be treated as a test.

## `using-fog-boot-menu.md`

The **Enroll Secure Boot Key** entry still said `MOK.der` must be on a FAT-formatted USB stick because "MokManager reads it from local media, not over the network". That stopped being true when the certificate moved to network delivery. Fixed, plus: the entry is schedulable as a task type against a host or group, and FOS picks the MOK or Setup Mode path by itself from the firmware state.

## Not included

UI screenshots — those need an authenticated session on a FOG server, which I don't have credentials for. The mermaid diagram covers the route-selection decision, which was the part hardest to follow in text. Happy to add captures of the **FOG Configuration → Secure Boot** page and the Task Scheduling type list on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0118K24WnGbnn2kfyy8vyiRL