### PR TITLE
Document bin/updatefog.sh as an additional update method

### DIFF
--- a/docs/installation/server/install-fog-server.md
+++ b/docs/installation/server/install-fog-server.md
@@ -19,7 +19,7 @@ tags:
 
 Before rushing into installing FOG you want to make sure you check the [[requirements]] 
 The installation instructions here assume that you have a freshly installed server available that only contains the minimal set of packages.
-Updating fog is essentially the same process, just instead of creating a fresh clone of the repo, you do a `git pull` and run the installer again.
+Updating fog is essentially the same process, just instead of creating a fresh clone of the repo, you do a `git pull` and run the installer again — or let [`bin/updatefog.sh`](#updating-an-existing-install) do both steps for you.
 
 ## Prerequisite
 
@@ -97,6 +97,48 @@ You can see a list of current branches here:
 > If you have issues with `git pull` saying you have pending changes, use
 > `git reset --hard origin/{branchName}`
 >  to undo file changes within your repo folder that sometimes occur during the install then run `git pull` again to ensure your on the latest.
+
+### Updating an existing install
+
+The manual `git fetch`/`git checkout`/`git pull` steps above still work exactly
+as described, and give you the most control — useful if you want to inspect
+changes before pulling them, update to a specific commit or tag, or otherwise
+customize the process.
+
+If you'd rather not do that by hand every time, `bin/updatefog.sh` wraps the
+same steps into one command:
+
+    cd /root/fogproject/bin
+    ./updatefog.sh
+
+It fetches and checks out the branch mapped from the update channel this
+server is configured to track (`stable`, `dev`, or `beta` — mapping to the
+`stable`, `dev-branch`, and `working-1.6` branches respectively), backs up the
+PXE background, kernel set, and rEFInd files that the installer's asset sync
+can overwrite, re-runs `installfog.sh` for you, and automatically reverts the
+git checkout and those backed-up files (then re-installs) if anything fails
+partway through.
+
+Options:
+
+    ./updatefog.sh --help
+    Usage: ./updatefog.sh [-h?y] [--channel stable|dev|beta] [--git-path </path>] [--no-revert]
+        -h -? --help       Display this info
+              --channel    Update channel to track: stable, dev, or beta
+                            defaults to whatever this server already tracks
+              --git-path   Override the git checkout path this server records
+              --no-revert  On failure, leave the system as-is instead of
+                            automatically reverting to the previous commit
+        -y    --yes        Skip the confirmation prompt (for cron/GUI use)
+
+The channel you choose is remembered for next time, the same way `.fogsettings`
+already remembers your other install choices — see
+[[install-fogsettings|The .fogsettings file]]. It's also mirrored into the
+database as `FOG_GIT_PATH`/`FOG_UPDATE_CHANNEL` under the **FOG Update**
+category on the Settings page in the web UI, so you can see which checkout and
+channel a server is tracking without SSHing in. That copy is informational
+only — editing it there has no effect on the next update; change the channel
+with `--channel` instead.
 
 ### Alternatives
 


### PR DESCRIPTION
## Summary
- Documents `bin/updatefog.sh` (FOGProject/fogproject#1005) in install-fog-server.md as an additional, opt-in way to update an existing FOG install.
- Keeps the existing manual `git fetch`/`checkout`/`pull` instructions unchanged for admins who want full control.
- Notes that `FOG_GIT_PATH`/`FOG_UPDATE_CHANNEL` now show up under the "FOG Update" category on the Settings page.

Related: FOGProject/fogproject#1005

🤖 Generated with [Claude Code](https://claude.com/claude-code)