### PR TITLE
Document the new certificate installer options and unifying a fleet

### DIFF
--- a/docs/installation/server/command-line-options.md
+++ b/docs/installation/server/command-line-options.md
@@ -37,6 +37,12 @@ change the web root directory, or install to a non-default location.
               --ca-cert         Path to the intermediate CA certificate (PEM)
               --ca-key          Path to the intermediate CA private key (PEM)
               --ca-root         Path to the root CA certificate (PEM)
+              --web-ca-cert     Bring your own CA for the WEB zone: the
+                                intermediate that signs this server's
+                                vhost certificate
+              --web-ca-key      Private key matching --web-ca-cert
+              --web-ca-root     Root certificate --web-ca-cert chains to
+                                (all three are required together)
         -Y -y --autoaccept      Auto accept defaults and install
         -f    --file            Use different update file
         -c    --ssl-path        Specify the ssl path
@@ -84,9 +90,62 @@ change the web root directory, or install to a non-default location.
                                   (both are required together)
               --no-secure-boot    Do not generate a Secure Boot signing
                                   key, and leave the FOS kernels unsigned
+              --no-ca-trust       Do not add this server's CA to this
+                                  server's own system trust store
 
 The `--uninstall`, `--dry-run`, `--force` and `--purge-*` options are
 covered in detail in [Uninstalling the Fog server](uninstall-fog-server.md).
+
+## Certificate options
+
+FOG generates its own Certificate Authority at install time and uses it to sign
+this server's HTTPS certificate. These options change **which** CA does that
+signing, and whether this server trusts the result locally.
+
+| Option | Use it when |
+| --- | --- |
+| *(none)* | The default. FOG generates a CA and a Web CA beneath it, and signs the vhost certificate from that. |
+| `--web-ca-cert` + `--web-ca-key` + `--web-ca-root` | You want this server's HTTPS certificate signed by a CA **you** supply — your enterprise PKI, an internal ACME CA, or one issued by another FOG server. All three are required together. |
+| `--external-ca` with `--ca-cert`/`--ca-key`/`--ca-root` | The older spelling of the same thing. It targets the same zone, which is what it has always effectively meant. |
+| `--no-ca-trust` | You do **not** want the installer adding this server's CA to this server's own system trust store. |
+
+Passing any one of `--web-ca-*` implies `--external-ca`, so you do not need
+both. You supply the files **once** — they are imported and later upgrades
+reuse the import without the flags.
+
+All three are validated before anything is changed: the key must match the
+certificate, the certificate must be a CA (`basicConstraints CA:TRUE`), and it
+must verify against the root you supply. Any failure stops the install rather
+than producing a server signed by the wrong thing.
+
+>[!info] This does not affect fog-client
+>`--web-ca-*` replaces the CA that signs the **web** certificate and nothing
+>else. The root that fog-client pinned at registration is untouched, which is
+>what makes this safe to do on a running fleet without re-registering a single
+>machine.
+
+### `--no-ca-trust` and the local trust store
+
+By default the installer adds this server's own CA to this server's system
+trust store, so `curl`, `wget` and PHP's stream wrapper on the FOG server can
+verify the FOG server without being handed a CA file each time. The store is
+detected from the host — `/etc/pki/ca-trust/source/anchors` on the RHEL family,
+`/usr/local/share/ca-certificates` on Debian/Ubuntu/Alpine,
+`/etc/ca-certificates/trust-source/anchors` on Arch.
+
+`--no-ca-trust` skips it, and is remembered in `.fogsettings` so an upgrade
+does not quietly reverse the decision.
+
+>[!warning] This does not make your browser stop warning
+>Firefox keeps its own certificate store and Chrome reads a per-user one, so
+>neither consults what this writes — and your browser is usually on a different
+>machine entirely. Import the CA into the browser yourself; it is published at
+>`https://<your-fog-server>/fog/management/other/ca.cert.der`.
+
+For the per-zone mechanism in full see [[bringing-your-own-ca|Bringing your own
+CA]]. To point **several** FOG servers at a single CA so one import covers all
+of them, see
+[[unify-certificates-across-fog-servers|Unifying certificates across several FOG servers]].
 
 ## Secure Boot options
 

--- a/docs/kb/how-tos/unify-certificates-across-fog-servers.md
+++ b/docs/kb/how-tos/unify-certificates-across-fog-servers.md
@@ -1,0 +1,250 @@
+---
+title: Unifying certificates across several FOG servers
+aliases:
+    - Unifying certificates across several FOG servers
+    - One trust anchor for several FOG servers
+description: How to make several independent FOG servers share a single certificate authority, so one certificate import covers the whole fleet instead of one per server
+context_id: unify-certificates-across-fog-servers
+tags:
+    - how-to
+    - certificates
+    - fog-server
+    - advanced
+---
+
+# Unifying certificates across several FOG servers
+
+You run more than one FOG server. Each generated its own Certificate Authority
+when it was installed, so every browser and every machine that talks to them
+needs a certificate imported **per server** — five servers, five imports, and
+five things to redo whenever one is rebuilt.
+
+This guide covers the three ways to collapse that to one, and what each costs.
+It applies the Web zone options described in
+[[bringing-your-own-ca|Bringing your own CA]] across several servers at once;
+see [[pki-zones|FOG's Certificate Zones]] for what a "zone" is and
+[[pki-glossary|the PKI glossary]] if a term here is unfamiliar.
+
+---
+
+## First: which problem do you actually have?
+
+Two different things both show up as *"the certificate is invalid"*, and they
+have opposite fixes. Sort this out before changing anything.
+
+1. **The client does not trust the CA.** The certificate is fine — nothing told
+   this machine to trust who issued it. Importing the CA fixes it.
+2. **The certificate does not chain to the CA you trusted.** You trusted server
+   A's CA and you are browsing to server B, which has its own unrelated one.
+   Importing more CAs does not fix this; the servers have to be re-issued.
+
+Run this against each server, using the CA you already trust:
+
+```bash
+echo | openssl s_client -connect <ip>:443 2>/dev/null | openssl x509 -out /tmp/leaf.pem
+openssl verify -CAfile /path/to/the/ca/you/trusted.pem /tmp/leaf.pem
+```
+
+`OK` means case 1 — a distribution problem, and you may not need this guide at
+all. A verification error means case 2, and the rest of this page applies.
+
+>[!warning] Do not compare issuer names
+>Every FOG install names its CA `CN=FOG Server CA`, so two completely unrelated
+>servers look identical if you only read the name. `openssl verify` is the only
+>answer that means anything.
+
+## The three options
+
+| | Effort | One server holds signing power over another | Best when |
+| --- | --- | --- | --- |
+| **A. Import each server's CA** | One import per server, forever | No | Two or three stable servers |
+| **B. One FOG server issues to the others** | One-time setup per server | **Yes** | Several FOG servers and no existing PKI |
+| **C. Your own PKI or ACME CA** | Depends on your PKI | No | You already run a certificate authority |
+
+There is no option where the servers stay completely independent *and* share an
+anchor. Something has to sign for everyone.
+
+## Option A: import each server's CA
+
+The baseline, and genuinely fine for a small number of servers. Nothing changes
+on the FOG side — you just distribute several certificates instead of one. Each
+server publishes its own at:
+
+```
+https://<your-fog-server>/fog/management/other/ca.cert.der
+```
+
+## Option B: one FOG server issues to the others
+
+Pick one server as the **hub**. Its CA stays exactly where it is. Every other
+server gets its *own* signing CA, issued by the hub and locked to that server's
+names, and uses it to sign its own web certificate. Every server's certificate
+then rolls up to the hub's CA, so one import covers all of them.
+
+```
+     hub: FOG Server CA
+      ├── FOG Web CA - fog1.example.lan   → fog1's web certificate
+      ├── FOG Web CA - fog2.example.lan   → fog2's web certificate
+      └── FOG Web CA - fog3.example.lan   → fog3's web certificate
+```
+
+>[!info] Update every server's installer first
+>This uses `--web-ca-cert`/`--web-ca-key`/`--web-ca-root`. Pull the latest
+>installer on **every** server before you start, or the options will not be
+>recognised. See [[command-line-options|Fog installer command line options]].
+
+### Step 1 — issue a CA for each server, on the hub
+
+```bash
+sudo packages/pki/fog-mint-web-ca <hostname> <ip> [extra-dns-name ...]
+```
+
+`<hostname>` must be exactly what that server's own `hostname` command reports.
+If the server is installed with `--extra-server-name` or `--internal-domain`,
+pass those names too. They are written into the CA as restrictions, and a CA
+restricted to the wrong names cannot sign the certificate it was made for.
+
+The script checks this for you — it test-signs a certificate carrying the names
+that server will actually ask for, and refuses to produce a CA that would
+reject it. A wrong hostname fails here, on the hub, instead of on the far
+server as a web server that will not start.
+
+Each run writes `/root/fog-web-cas/<name>-webca.tar.gz` holding three files.
+
+### Step 2 — install it on that server
+
+```bash
+scp root@<hub>:/root/fog-web-cas/<name>-webca.tar.gz /root/
+cd /root && tar -xzf <name>-webca.tar.gz
+
+cd ~/fogproject/bin
+sudo ./installfog.sh --web-ca-cert /root/webca.pem \
+                     --web-ca-key  /root/webca.key \
+                     --web-ca-root /root/fog-root.pem
+```
+
+You pass these **once**. The files are imported and later upgrades reuse them
+without the options.
+
+### Step 3 — trust the hub's CA wherever you need it
+
+One certificate now covers the whole fleet. On a Linux client:
+
+```bash
+curl -k -o /tmp/fogca.der https://<hub>/fog/management/other/ca.cert.der
+openssl x509 -inform DER -in /tmp/fogca.der -out /tmp/fogca.crt
+
+# RHEL / Fedora / Rocky / Alma
+sudo cp /tmp/fogca.crt /etc/pki/ca-trust/source/anchors/fog-server-ca.crt
+sudo update-ca-trust extract
+
+# Debian / Ubuntu / Alpine
+sudo cp /tmp/fogca.crt /usr/local/share/ca-certificates/fog-server-ca.crt
+sudo update-ca-certificates
+```
+
+Browsers need their own import — see [Your browser is a separate
+problem](#your-browser-is-a-separate-problem) below.
+
+>[!warning] What this costs
+>Each server ends up holding a CA private key. That is the trade, and it is why
+>each server gets **its own** CA rather than a copy of a shared one: the name
+>restrictions mean a stolen key from `fog2` can only produce certificates for
+>`fog2`'s own names, not for your whole estate.
+>
+>Never copy the same CA to several servers, and never copy the hub's own CA key
+>anywhere. If holding signing power on a satellite is unacceptable at your site,
+>use Option C or stay on Option A.
+
+## Option C: your own PKI or ACME CA
+
+If you already run a certificate authority, issue each FOG server an
+intermediate from it and use the same three options. FOG does not care whether
+the CA came from another FOG server or from your PKI — it validates the same
+things either way.
+
+This is the better answer when it is available to you: no FOG server holds
+signing authority over another, and your existing rotation and revocation
+processes apply as normal. An internal ACME CA (such as step-ca) fits best of
+all, because the anchor stays put while the certificates beneath it renew
+automatically.
+
+[[external-ca-lets-encrypt|External CA & Let's Encrypt Certificates]] covers
+that ground in full, including the renewal model and why public Let's Encrypt
+is a poor fit for fog-client specifically.
+
+## What this does and does not change
+
+| | Unified? | |
+| --- | --- | --- |
+| Web / HTTPS certificate | **Yes** | what these options target |
+| fog-client communication | No | each server keeps its own; clients pin per server |
+| Secure Boot signing | No | see [[secure-boot-signing|Secure Boot: signing FOS with your own key]] |
+
+**fog-client is deliberately left alone.** It pins the CA of the server it
+registered against, and that CA is *not* replaced here — which is exactly what
+makes this safe to do on a live fleet without re-registering any machines.
+
+### Your browser is a separate problem
+
+FOG can add its CA to a server's own system trust store, but **browsers do not
+use that store.** Firefox keeps its own, and Chrome reads a per-user one. Import
+the hub's CA by hand, once:
+
+- **Firefox** — Settings → Privacy & Security → Certificates → View
+  Certificates → Authorities → Import, and tick *Trust this CA to identify
+  websites*.
+- **Chrome / Chromium on Linux** —
+  `certutil -d sql:$HOME/.pki/nssdb -A -t "C,," -n "FOG Server CA" -i fogca.crt`
+
+## Checking it worked
+
+Per server:
+
+```bash
+echo | openssl s_client -connect <ip>:443 2>/dev/null | grep -E '^ [0-9] s:| *i:'
+```
+
+The issuer should read `CN=FOG Web CA - <hostname>`. Then confirm it actually
+chains to the hub:
+
+```bash
+echo | openssl s_client -connect <ip>:443 2>/dev/null | openssl x509 -out /tmp/leaf.pem
+openssl verify -CAfile /tmp/fogca.crt /tmp/leaf.pem
+```
+
+You want `OK`.
+
+## Troubleshooting
+
+**The certificate did not change after I installed with the new options.**
+Older installers decided whether to re-sign the web certificate by looking only
+at the server's *names*. Switching CA left the names identical, so the
+certificate was left alone — a clean install that changed nothing. Update the
+installer and run it again; the newer version notices the CA changed and
+re-issues by itself.
+
+**The far server's web server will not start, or its certificate is
+rejected.** Its certificate carries a name its CA does not allow. Every FOG
+server's certificate includes `fogserver` and `fog-server` in addition to its
+own hostname, plus anything added with `--extra-server-name`. Re-issue the CA
+with the missing names passed as extra arguments.
+
+**The installer asks me for CA paths even though I passed them on the command
+line.** Older installers prompted anyway, and then ignored what you typed —
+pressing Enter through it was harmless. Updating the installer removes the
+prompt.
+
+**`Refusing to continue: the root ... carries pathlen:0`.** That CA is not
+allowed to have another CA beneath it, so nothing it signed would be accepted.
+Use a different CA, or Option A.
+
+## See also
+
+- [[bringing-your-own-ca|Bringing your own CA]] — the per-zone mechanism this builds on
+- [[pki-zones|FOG's Certificate Zones]]
+- [[pki-glossary|PKI & Secure Boot Glossary]]
+- [[external-ca-lets-encrypt|External CA & Let's Encrypt certificates]]
+- [[command-line-options|Fog installer command line options]]
+- `docs/MULTI_SERVER_CA.md` in the `fogproject` repository — the same ground
+  with the design reasoning, for anyone reading the installer source

--- a/docs/kb/reference/bringing-your-own-ca.md
+++ b/docs/kb/reference/bringing-your-own-ca.md
@@ -20,11 +20,14 @@ FOG generates its own certificates by default, but each zone described in
 CA or key you already run. This page is the reference for doing that; see
 [[pki-glossary|the PKI glossary]] if a term here is unfamiliar.
 
->[!info] FOG 1.6
->The general per-zone mechanism below (`--web-ca-*`, `--secureboot-ca-cert`)
->is a FOG 1.6 addition. On earlier releases, only bringing your own Secure
->Boot signing **leaf** (not a CA) is available — see [Secure Boot zone](#secure-boot-zone)
->below for what that means in practice.
+>[!info] Version support
+>`--secureboot-ca-cert` is a FOG 1.6 addition; on earlier releases only
+>bringing your own Secure Boot signing **leaf** (not a CA) is available — see
+>[Secure Boot zone](#secure-boot-zone) below for what that means in practice.
+>
+>`--web-ca-cert`/`--web-ca-key`/`--web-ca-root` are available on **both** the
+>1.6 and 1.5 lines. Update your installer before using them; the 1.5 line only
+>gained them recently.
 
 ## Web zone
 
@@ -204,3 +207,4 @@ Boot on its self-signed key. Nothing is silently broken.
 - [[pki-glossary|PKI & Secure Boot Glossary]]
 - [[external-ca-lets-encrypt|External CA & Let's Encrypt certificates]]
 - [[secure-boot-signing|Secure Boot signing]]
+- [[unify-certificates-across-fog-servers|Unifying certificates across several FOG servers]] — applying the Web zone options across a fleet


### PR DESCRIPTION
Three installer flags shipped in `fogproject` and were not reachable from the published docs.

## What is here

**`docs/installation/server/command-line-options.md`** — adds `--web-ca-cert`/`--web-ca-key`/`--web-ca-root` and `--no-ca-trust` to the `--help` block, plus a **Certificate options** section alongside the existing Secure Boot one. The page listed `--external-ca` and the `--ca-*` trio but none of these, so they were undiscoverable from the site.

It calls out explicitly what `--no-ca-trust` does *not* do: browsers keep their own certificate stores (Firefox NSS, Chrome per-user) and are unaffected by the system trust store. That is the most common misunderstanding about the feature.

**`docs/kb/how-tos/unify-certificates-across-fog-servers.md`** — new. Covers the case no existing page does: several **independent** FOG servers, not storage nodes, rolled up to one trust anchor.

Written as a decision rather than a recipe, with three options — import each CA, have one FOG server issue to the others, or use your own PKI — because the right answer depends on whether a satellite holding signing authority is acceptable at that site. The middle option's cost (each server ends up holding a CA private key, bounded by name constraints) is stated plainly rather than glossed.

It opens by separating the two failures that both present as *"the certificate is invalid"* — the client does not trust the CA, versus the certificate does not chain to the CA you trusted. They have opposite fixes, and comparing issuer **names** cannot tell them apart, since every FOG install names its CA `CN=FOG Server CA`.

**`docs/kb/reference/bringing-your-own-ca.md`** — corrects a version note. It said the whole per-zone mechanism was 1.6-only; `--web-ca-*` now exists on the 1.5 line too, and only `--secureboot-ca-cert` remains 1.6-only.

## Fits the existing PKI pages rather than repeating them

`pki-zones` and `pki-glossary` for concepts, `bringing-your-own-ca` for the mechanism, `external-ca-lets-encrypt` for the ACME workflow. The new page links into all of them and `bringing-your-own-ca` links back.

## Checks

- `mkdocs build` passes; the only remaining warnings are pre-existing and in files this branch does not touch
- every wikilink in the three changed files resolves to a real `context_id`
- no duplicate `context_id`
- rebased on current `master` (it had moved 10 commits, including the new PKI reference pages, which this reconciles with)