### PR TITLE
Document the 1.6 plugin system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ debug.log
 quartz/node_modules
 quartz/public
 quartz/.quartz-cache
+quartz/quartz/.quartz-cache
 quartz/.quartz
 quartz/.turbo
 site

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,12 @@ promoted to `foo/index.html`).
   - Image: `![[image-name.ext]]` — all images live under `docs/assets/img/`
     and are referenced by filename only (no path), so names must be unique
     site-wide.
+  - **Keep each wikilink on one line.** A link wrapped across a newline to
+    respect the file's line width does not parse — it renders literally as
+    `[[page|Text]]` on the published page, and the build does not warn. Rewrap
+    the sentence around the link instead. Worth grepping the built HTML for
+    `[[` after adding links (`grep -o '\[\[' quartz/public/**/*.html`); the
+    only legitimate hits are inside code blocks.
 - **Callouts, not raw admonitions**: write Obsidian callout syntax —
   ```
   >[!note]

--- a/docs/development/plugin-development.md
+++ b/docs/development/plugin-development.md
@@ -12,14 +12,20 @@ tags:
     - plugin-development
     - customization
 ---
-
 # Building a FOG Plugin — Start to Finish
 
 This guide walks you from an empty directory to a working, installable FOG
 plugin on the **working‑1.6** framework. It uses a complete, runnable example
-plugin — **`helloworld`** — that ships alongside this document at
-[`packages/web/lib/plugins/helloworld/`](../packages/web/lib/plugins/helloworld/).
+plugin — **`helloworld`** — which lives in
+[`FOGProject/fog-plugins`](https://github.com/FOGProject/fog-plugins) and
+lands at `packages/web/lib/plugins/helloworld/` once the plugins are fetched.
 Copy that directory, rename it, and you have a head start.
+
+> The bundled plugins are no longer committed to the `fogproject` repository.
+> A fresh clone has no `packages/web/lib/plugins/` at all until
+> `bin/fetch-plugins.sh` populates it from the release `FOG_PLUGINS_VERSION`
+> pins — which the installer does for you. Run it by hand if you just want the
+> tree.
 
 > **Scope:** this targets the working‑1.6 plugin framework (the `formFields` /
 > `makeInput` page helpers, the `addPost`/`editPost` JSON pattern, and the
@@ -31,10 +37,33 @@ Copy that directory, rename it, and you have a head start.
 
 ## 1. What a plugin is
 
-A FOG plugin is just a directory under `packages/web/lib/plugins/<name>/`
-containing PHP classes that FOG auto‑discovers. There is no build step and no
-registration list to edit — drop the directory in, activate the plugin in the
-UI (**Plugin Management**), and it works.
+A FOG plugin is just a directory containing PHP classes that FOG
+auto‑discovers. There is no build step and no registration list to edit — drop
+the directory in, activate the plugin in the UI (**Plugin Management**), and it
+works.
+
+There are two places that directory can live, and which one you pick matters:
+
+| Root | For | Survives a FOG upgrade? |
+|---|---|---|
+| `packages/web/lib/plugins/<name>/` | plugins bundled with FOG itself, sourced from `FOGProject/fog-plugins` | No — the tarball re‑lays this tree |
+| `/opt/fog/plugins/<name>/` (`FOG_PLUGIN_DIR`) | **everything third‑party** | Yes |
+
+The installer's `configureHttpd()` does `rm -rf` on the web root before laying
+the new one down, so a plugin installed into `lib/plugins/` is deleted by the
+next `installfog.sh` run without warning. `FOG_PLUGIN_DIR` sits outside the web
+root precisely so that cannot happen. See
+[ADR 0009](https://github.com/FOGProject/fogproject/blob/working-1.6/docs/adr/0009-plugins-become-installable-artifacts.md).
+
+Bundling is not a route third parties take. `lib/plugins/` is filled from a
+pinned `fog-plugins` release, so putting a plugin there means opening a PR
+against that repository and waiting for FOG to pin a release containing it.
+Ship your own archive instead — see §11a.
+
+Discovery, the class autoloader and the routing all treat the two roots
+identically; the only difference an external plugin sees is that its `js/`,
+`css/` and `images/` are reached through a symlink FOG maintains for it (see
+§10).
 
 A typical plugin provides:
 
@@ -81,9 +110,9 @@ The running example, `helloworld`, manages a trivial entity with a `name` and a
 ## 3. Directory layout
 
 ```
-packages/web/lib/plugins/helloworld/
+<root>/helloworld/                  # <root> = lib/plugins (bundled) or /opt/fog/plugins
 ├── config/
-│   └── plugin.config.php          # discovery metadata ($fog_plugin[...])
+│   └── plugin.config.php          # the manifest ($fog_plugin[...])
 ├── class/
 │   ├── helloworld.class.php        # HelloWorld         (model, FOGController)
 │   └── helloworldmanager.class.php # HelloWorldManager  (manager + schema())
@@ -107,9 +136,9 @@ lowercase and use it consistently (`$fog_plugin['name']`, each hook's
 
 ## 4. Step by step
 
-### 4.1 `config/plugin.config.php`
+### 4.1 `config/plugin.config.php` — the manifest
 
-Discovery metadata. `Plugin::getPlugins()` `include`s this file and reads the
+`Plugin::readManifest()` `include`s this file during discovery and reads the
 `$fog_plugin` array.
 
 ```php
@@ -117,13 +146,48 @@ $fog_plugin = [];
 $fog_plugin['name']        = 'helloworld';           // == directory name
 $fog_plugin['description'] = 'Skeleton example plugin …';
 $fog_plugin['menuicon']    = 'fa fa-cube fa-fw';     // "fa …" => icon; else <img src>
-$fog_plugin['menuicon_hover'] = null;
-$fog_plugin['entrypoint']  = 'html/run.php';         // legacy/conventional; not shipped
+$fog_plugin['version']     = '1.0.0';                // your plugin's own version
+$fog_plugin['fog_min']     = '1.6.0';                // oldest FOG it runs on
+$fog_plugin['fog_max']     = '1.7.0';                // newest FOG it runs on
+$fog_plugin['requires']    = ['location'];           // other plugins, by directory name
+$fog_plugin['author']      = 'Your Name';
+$fog_plugin['homepage']    = 'https://example.org/my-plugin';
 ```
 
-> The `entrypoint` is vestigial — no plugin actually ships `html/run.php`;
-> routing happens through the `node` → page‑class mapping. Declare it anyway for
-> consistency with every other plugin.
+| Key | Required | What it does |
+|---|---|---|
+| `name` | yes | Machine name and routing `node`. Must equal the directory name, lowercase. |
+| `description` | no | Shown in Plugin Management. |
+| `menuicon` | no | Defaults to `fa fa-plug fa-fw`. |
+| `version` | no | Yours to number. Shown in the grid, stored in `plugins.pVersion`. Nothing compares it to anything. |
+| `fog_min` / `fog_max` | no | The FOG range you support. An absent bound is no bound. |
+| `requires` | no | Plugins that must be active first. |
+| `author`, `homepage` | no | Attribution. |
+
+**Every key except `name` is optional**, so a plugin written before the manifest
+existed keeps working untouched.
+
+#### How the compatibility range is enforced
+
+- Activating or installing a plugin outside its range is **refused**, with the
+  reason in the error toast. The whole batch is refused, not just the offending
+  plugin — a partial success reported as "Plugins activated!" is worse than a
+  clean failure.
+- If a FOG upgrade moves the server out of the range of a plugin that is
+  already active, the next boot **deactivates it** and logs why. `installed` and
+  `pSchema` are left alone, so its tables and applied migrations survive and
+  re‑activating once you ship a compatible build is one click.
+- Only the **numeric core** of a version is compared. `FOG_VERSION` is
+  `1.6.0-beta.3318` on a beta and `version_compare()` sorts that *below*
+  `1.6.0`, so comparing raw would refuse `fog_min = '1.6.0'` on the entire beta
+  branch.
+- Plugins turned on in the same batch satisfy each other's `requires`, so the
+  order you tick the checkboxes in doesn't matter.
+
+> `menuicon_hover` and `entrypoint` used to appear here. Nothing ever read
+> either one — no plugin has ever shipped the `html/run.php` that `entrypoint`
+> named, and routing goes through the `node` → page‑class mapping. Both are
+> gone; if your manifest still sets them they are simply ignored.
 
 ### 4.2 Model — `class/helloworld.class.php`
 
@@ -247,16 +311,18 @@ matching `*GeneralPost()` that mutates `$this->obj` before the shared `save()`.
 ### 4.5 Hooks — `hooks/*.hook.php`
 
 Each hook is a small class extending `Hook`, with `public $node`, that registers
-callbacks **in its constructor, guarded by the install check**:
+callbacks **in its constructor**. Use `registerInstalled()` — it applies the
+"only when this plugin is installed" guard for you and takes an ordered list of
+`[event, method]` pairs:
 
 ```php
 public function __construct()
 {
     parent::__construct();
-    if (!in_array($this->node, (array)self::$pluginsinstalled)) {
-        return;                       // do nothing unless this plugin is installed
-    }
-    self::$HookManager->register('MAIN_MENU_DATA', [$this, 'menuData']);
+    $this->registerInstalled([
+        ['MAIN_MENU_DATA', 'menuData'],
+        ['PERMISSION_REGISTRY_DATA', 'permData'],
+    ]);
 }
 ```
 
@@ -270,6 +336,34 @@ The example ships three hooks:
   the current sub‑page.
 - **API** (`AddHelloWorldAPI`) — `API_VALID_CLASSES` exposes the node over REST
   so `/fog/helloworld` reuses the same ORM as the UI.
+
+> **Name API classes after your permission node.** Access to a REST class is
+> resolved to `<node>.<action>` by matching the class name against the nodes
+> registered through `PERMISSION_REGISTRY_DATA`. A class is claimed by a node
+> when it either *is* the node (`site`) or *starts with* the node and ends in
+> `association` (`sitehostassociation`) — the same shape core uses for
+> `groupassociation` → `group`. Longest match wins.
+>
+> A class no node claims is restricted to administrators and logs a line
+> naming it. That is deliberate: an unmapped class used to be readable and
+> writable by **any** authenticated user regardless of role. If your endpoint
+> is admin-only when you did not intend it to be, check the log and rename the
+> class (or register the node) rather than working around it.
+
+> **Register your node, or your page is admin-only.** The same stance applies
+> to the management page, not just the REST classes: a node absent from the
+> permission registry resolves to `unmapped.<node>`, which no role can be
+> granted, so only a holder of `*` can reach it — and its sidebar entry is
+> hidden from everyone else. It logs one line per node per request naming
+> what to register. Firing `PERMISSION_REGISTRY_DATA` is therefore not
+> optional; a plugin that skips it is not "ungated", it is unreachable.
+>
+> ```php
+> public function permData($arguments)
+> {
+>     $arguments['registry'][$this->node] = ['view', 'create', 'edit', 'delete'];
+> }
+> ```
 
 ### 4.6 JavaScript — `js/fog.helloworld.*.js`
 
@@ -291,7 +385,8 @@ Shared helpers you'll use: `Common.node`, `Common.id`, `Common.search`,
 FOG has **no automatic per‑column migration**. `Schema::createTable()` emits
 `CREATE TABLE IF NOT EXISTS`, which does nothing on a table that already
 exists — so simply adding a column to `createSql()` will **not** reach existing
-installs. Use the **`schema()` contract** instead.
+installs. Use the **`schema()` contract** instead — covered in depth in
+[[plugin-schema-migrations|Plugin Schema Migrations]].
 
 **`schema()` returns an ordered, append‑only list of steps.** Each step is a SQL
 string (or a closure returning SQL). On install/upgrade the framework
@@ -337,16 +432,30 @@ Seed data (e.g. default `globalSettings` rows) is just another step — return t
 
 ## 6. Lifecycle
 
-1. **Discovery.** `Plugin::getPlugins()` scans the plugins directory, `include`s
-   each `config/plugin.config.php`, and upserts a row in the `plugins` table.
+1. **Discovery.** `Plugin::getPlugins()` scans **both** plugin roots, reads each
+   manifest, and upserts a row in the `plugins` table. It also maintains the
+   asset symlink for external plugins and deactivates any active plugin that
+   this FOG version has moved out of range.
 2. **Activation.** An admin enables the plugin in **Plugin Management**. Its
    `node` is added to `FOGBase::$pluginsinstalled`, which is what every hook
-   constructor checks before registering.
+   constructor checks before registering. Refused if `fog_min`/`fog_max`/
+   `requires` say it cannot run here.
 3. **Install / upgrade.** `Plugin::installdb()` runs `schema()` via
    `applyUpdates()` and tracks `pSchema`. This is idempotent and
    non‑destructive — safe to run on every upgrade.
 4. **Uninstall.** Inherited `uninstall()` drops the table; override it if you
    need to clean up settings, associations, or users you created.
+5. **Code removed.** Deleting the plugin directory does **not** delete its row.
+   Discovery only ever walks directories that exist, so nothing would visit
+   the row again to clean it up — and absence is not reliably permanent (an
+   unmounted external root, or the web tree mid-upgrade, makes every plugin
+   vanish at once). The row keeps its state and its `pSchema` count, so
+   putting the code back resumes exactly where it left off.
+
+   Plugin Management badges such a row **Missing**, refuses to activate or
+   install it, and offers **Forget selected** to delete the row deliberately.
+   Forget leaves the plugin's tables behind and says so: what to drop is
+   described by `schema()`, which is part of the code that has gone.
 
 ---
 
@@ -373,6 +482,24 @@ Global configuration lives in the `globalSettings` table.
 - **Instantiation:** prefer `self::getClass('HelloWorld')` /
   `self::getClass('HelloWorldManager')` over `new`.
 - **Translation:** wrap UI strings in `_('…')`.
+- **Secrets in your table:** if a column holds a credential — an API token, a
+  webhook URL, a bind password — declare it through `API_SENSITIVE_FIELDS` or
+  it is emitted in REST payloads and by the unauthenticated boot endpoint.
+  Two tiers:
+
+  | Tier | Stripped from | Use when |
+  |---|---|---|
+  | `fields` | lists and expanded relations | a client legitimately reads it back on a direct single GET (as fog-client does with `host.ADPass`) |
+  | `always` | everything, single GET included | nothing outside the web tier ever needs it |
+
+  ```php
+  public function declareSensitiveFields($arguments)
+  {
+      $arguments['always'][$this->node][] = 'bindPwd';
+  }
+  ```
+
+  Prefer `always` unless you can name the consumer that reads the field back.
 
 ---
 
@@ -385,7 +512,9 @@ Global configuration lives in the `globalSettings` table.
 | `SEARCH_PAGES` | make the node searchable |
 | `PAGES_WITH_OBJECTS` | enable the object (edit/delete) flow for the node |
 | `PAGE_JS_FILES` | inject JS files for the current page |
-| `API_VALID_CLASSES` | expose the node over the REST API |
+| `PERMISSION_REGISTRY_DATA` | register the node and its actions — **required**, see §4.5 |
+| `API_VALID_CLASSES` | expose the node over the REST API (name classes after your permission node — see §4.5) |
+| `API_SENSITIVE_FIELDS` | keep credential columns out of API and boot-endpoint output — see §8 |
 | `<NODE>_ADD_FIELDS` / `_GENERAL_FIELDS` | let others extend your forms |
 | `<NODE>_ADD_POST` / `_EDIT_POST` / `_ADD_SUCCESS` / `_ADD_FAIL` | extension points around your saves |
 
@@ -399,7 +528,10 @@ Fire your own events with `&`‑by‑reference args so listeners can mutate them
 - **`CREATE TABLE IF NOT EXISTS` never alters a live table.** Add columns via a
   new `schema()` step, not by editing `createSql()`.
 - **Filename = `strtolower(ClassName)` + suffix.** A mismatch means the class
-  silently won't autoload.
+  won't autoload. Silently, for most classes — but not for your manager:
+  install refuses outright if `class/<name>manager.class.php` exists and does
+  not declare `<Name>Manager`, because the fallback used to make the install
+  report success having created nothing.
 - **`menuicon`** beginning with `fa` is rendered as a font‑awesome icon;
   anything else is treated as an `<img>` `src`.
 - **`$serverFault`** must be `true` only for server‑side failures, so HTTP
@@ -408,15 +540,25 @@ Fire your own events with `&`‑by‑reference args so listeners can mutate them
   `$pluginsinstalled`, or your hooks run for a plugin that isn't enabled.
 - **List columns** in the JS must match `$headerData` order and the keys the
   router emits (`mainlink`, `id`, friendly field names).
+- **An external plugin's assets are served through a symlink FOG maintains for
+  you.** `/opt/fog/` is outside the document root, so the browser cannot reach
+  it; every discovery pass (re)creates `lib/plugins/<name>` →
+  `/opt/fog/plugins/<name>` so `../lib/plugins/<name>/js/…` resolves for a
+  bundled and an external plugin alike. You do nothing — reference your assets
+  the normal way and `Hook::injectPluginJS()` emits the right URL. Apache needs
+  `Options +FollowSymLinks` (the installer sets it); nginx follows regardless.
 
 ---
 
 ## 11. Install & test your plugin
 
-1. Copy `helloworld/` to `packages/web/lib/plugins/<yourname>/` and rename the
-   directory, the classes, the files (lowercased), every `$node`, and the
-   `$fog_plugin['name']`.
-2. Deploy to the web root (e.g. `copybacktrunk.sh "" "" "1.6"`).
+1. Copy `helloworld/` to `/opt/fog/plugins/<yourname>/` (or, for a plugin you
+   intend to bundle with FOG itself, `packages/web/lib/plugins/<yourname>/`) and
+   rename the directory, the classes, the files (lowercased), every `$node`, and
+   the `$fog_plugin['name']`.
+2. Get it into the web root — only needed for a bundled plugin, since
+   `/opt/fog/plugins/` is already live and outside the docroot on purpose.
+   Whatever you normally use to sync a working tree onto the server will do.
 3. In the UI: **Plugin System → Plugin Management → install/activate** your
    plugin.
 4. Confirm: the sidebar entry appears, **Create New** saves a row (check the
@@ -427,13 +569,87 @@ Fire your own events with `&`‑by‑reference args so listeners can mutate them
 
 ---
 
+## 11a. Shipping your plugin to other people
+
+Package it as a `.tar.gz` containing **one directory, named for the plugin**:
+
+```
+tar czf myplugin-1.0.0.tar.gz myplugin/
+```
+
+Publish the archive's `sha256sum` alongside it — Plugin Management shows the
+checksum of what was uploaded so an admin can compare the two before
+installing.
+
+Admins have two routes:
+
+- **`git clone` or untar into `/opt/fog/plugins/`** as root. Always available,
+  nothing to switch on.
+- **Plugin Management → Upload plugin.** Off by default; see below.
+
+### The archive must survive validation
+
+FOG unpacks the archive somewhere the autoloader does not look, reads the
+manifest, and shows the admin what it found *before* anything is installed. It
+is refused outright if:
+
+| | |
+|---|---|
+| it isn't a readable `.tar.gz` | opened as a tar regardless of the file name |
+| it holds anything other than exactly one top-level directory | including a stray file at the archive root |
+| an entry path is absolute or contains `..` | an interior `..` gets past PharData; FOG checks anyway |
+| there is no `<name>/config/plugin.config.php` | |
+| the manifest's `name` isn't the directory name | |
+| the plugin is outside its own `fog_min`/`fog_max` range | |
+| a **bundled** plugin already has that name | a bundled plugin always wins the collision, so the upload could never load |
+| it is over 64 MB | `post_max_size` usually bites first |
+
+Symlinks need no rule: `PharData` writes them out as empty regular files, so
+they cannot escape — but it also means **a plugin that relies on a symlink will
+install subtly broken.** Don't ship one.
+
+Uploading a plugin that is already in `/opt/fog/plugins` is an upgrade; the
+admin is warned that files will be replaced, and the old copy is only deleted
+once the new one is in place. Installing the files does **not** install or
+activate the plugin — the admin still does that from the same page, so "the
+files are here" and "this code is running" stay separate decisions.
+
+### Turning uploads on (admins)
+
+The admin-side walkthrough is on the
+[[plugins#Installing a plugin from an archive|Plugins page]]; the short version
+is two independent switches, both required:
+
+1. `FOG_PLUGIN_UI_INSTALL_ENABLED` in **FOG Configuration → FOG Settings →
+   Plugin System**.
+2. `sudo bin/fog-plugin-uploads.sh enable`, which makes `/opt/fog/plugins`
+   writable by the web server (and relabels it for SELinux). `disable` and
+   `status` do what they say.
+
+The upload route also needs the **`plugin.install`** permission, which is
+deliberately *not* part of `plugin.edit`: activating a plugin that is already
+on disk and adding new executable code to the server are different authorities.
+
+> **Understand what you are turning on.** A plugin is PHP that FOG autoloads
+> and runs as the web user. Making its directory web-writable means any
+> file-write bug anywhere in FOG can put executable code on the server. That is
+> why step 2 is a root command rather than something the settings page can do
+> for itself — and why leaving uploads off and using `git clone` is a perfectly
+> good answer.
+
+---
+
 ## 12. Reference plugins
 
 - **`helloworld`** — this guide's minimal, complete CRUD example.
 - **`subnetgroup`** — a clean real CRUD plugin (model→class relationship,
   Export/Import, `schema()`).
-- **`accesscontrol`** — a multi‑table plugin showing a richer `schema()` with
-  seed and closure steps.
+- **`site`** — a five‑table plugin, and the reference for object scoping via
+  `OBJECT_SCOPE_CHECK`. Its `schema()` shows how to retire a table you shipped
+  (steps are immutable: step 3 creates it, step 4 drops it).
+- **`persistentgroups`** — a plugin that is nothing but a `schema()` closure
+  step (it installs a MySQL trigger). No page, no model, no hooks: proof that
+  none of those are mandatory.
 - **`ldap`** — authentication/integration plugin (custom hooks beyond CRUD).
 
 When in doubt, copy the closest existing plugin and adapt it — the conventions

--- a/docs/management/web/plugins.md
+++ b/docs/management/web/plugins.md
@@ -2,47 +2,245 @@
 title: Plugins
 aliases:
     - Plugins
-description: Describes enabling and installing plugins
+    - Plugin Management
+description: Turning the plugin system on, what the bundled plugins are, and how to install a third-party plugin
 context_id: plugins
 tags:
-    - in-progress
-    - updating-content
+    - 1_6-changes
+    - management
+    - web-management
+    - plugins
 ---
-
 
 # Plugins
 
-Plugins give FOG extra functionality wanted for some users but not all.
+Plugins add functionality that some FOG sites want and others do not — LDAP
+sign-in, per-site host visibility, Slack notifications, Windows product keys.
+Each one is a directory of PHP that FOG discovers, activates on request, and
+gives its own entry in the sidebar.
 
-## Enabling Plugins
+FOG ships a set of bundled plugins, and from FOG 1.6 you can also install
+plugins written by other people.
 
-Plugins are not enabled on the FOG server by default, so this is the
-first thing we will need to do.
+>[!info] FOG 1.6
+>Most of this page is 1.6. On 1.5.x the plugin system exists but only the
+>bundled plugins are practical to use: there is no manifest, no compatibility
+>range, no upload, and a plugin installed by hand lives inside the web root
+>where the next installer run deletes it.
 
-1.  Log in to the FOG web UI.
-2.  Go to **FOG Configuration**
-3.  Go to **FOG Settings**
-4.  Scroll down and locate the section **Plugin System**
-5.  Tick on **FOG_PLUGINSYS_ENABLED**
-6.  Click "Save Changes"
+## Turning the plugin system on
 
-After reloading the FOG web UI you see a new icon (gear wheel) in the
-main menu:
+Plugins are off until you enable them.
 
-### Activate Plugins
+1. Log in to the FOG web UI.
+2. Go to **FOG Configuration → FOG Settings**.
+3. Find the **Plugin System** section.
+4. Tick **FOG_PLUGINSYS_ENABLED**.
+5. Click **Save Changes**.
 
-Lists all the available plugins to install
+Reload the UI and a **Plugins** entry (puzzle-piece icon) appears in the main
+menu. That takes you to **Plugin Management**, a single list of every plugin
+FOG can see.
 
-### Install Plugins
+## The Plugin Management list
 
-Lists all your "downloaded" plugins that are not activated yet
+| Column | What it tells you |
+|---|---|
+| **Plugin Name** | The plugin's machine name, and any status badge |
+| **Description** | From the plugin's own manifest |
+| **Version** | The plugin's version, or an em dash if it never declared one |
+| **Location** | The directory the code was found in — this is how you tell a bundled plugin from one you installed yourself |
+| **Activated** | Whether its hooks, pages and menu entry are live |
+| **Installed** | Whether its database tables have been set up |
 
-### Installed Plugins
+Tick the plugins you want to act on and use the buttons below the list:
+**Activate selected**, **Deactivate selected**, **Install selected**,
+**Uninstall selected**, **Update selected**, **Forget selected**.
 
-Lists all your installed and active plugins
+### Activated and Installed are two different things
 
-## Available Plugins
+This trips people up, so it is worth being explicit:
 
-### Capone
+- **Install** sets up the plugin's database tables. It is safe to re-run and
+  never destroys data.
+- **Activate** makes the plugin's code actually run — its hooks register, its
+  pages route, its menu entry appears.
 
-A plugin that does some stuff
+A plugin normally wants both. Deactivating a plugin stops it running but leaves
+its tables and its data alone, so you can turn it back on and pick up where you
+were.
+
+### Badges
+
+- **Update available** (amber, on the plugin name) — the plugin's code contains
+  database steps this server has not applied yet, typically after a FOG
+  upgrade. Click it, or use **Update selected**. This is the only badge that is
+  also a button.
+- **Incompatible** — the plugin says it does not support this FOG version.
+  Hover it for the reason. FOG refuses to activate or install it.
+- **Missing** — there is a row for the plugin but its directory is gone. See
+  below.
+
+## Compatibility
+
+From 1.6 a plugin declares the range of FOG versions it supports, and FOG
+enforces it:
+
+- **Activating or installing outside the range is refused**, with the reason in
+  the error message. If you ticked several plugins and one of them is out of
+  range, the whole batch is refused — a half-applied change reported as success
+  is worse than a clean failure.
+- **If a FOG upgrade moves the server out of a plugin's range**, the next page
+  load deactivates that plugin and logs why. Its tables and its applied
+  migrations are left alone, so once a compatible version of the plugin is
+  available, re-activating is one click and nothing has been lost.
+
+A plugin that declares no range is treated as compatible with everything, which
+is what keeps older plugins working.
+
+## When a plugin's code disappears
+
+Deleting a plugin's directory does not delete its row, and that is deliberate:
+absence is not reliably permanent. An unmounted volume, or a web tree caught
+mid-upgrade, makes every plugin vanish at once, and a system that reacted by
+dropping their rows would throw away real state over a temporary condition.
+
+So the row stays, badged **Missing**. It cannot be activated or installed. Put
+the code back and it resumes exactly where it left off, applied migrations and
+all.
+
+If the plugin is gone for good, tick it and use **Forget selected** to delete
+the row. Forget only works on rows whose code really is absent — if the plugin
+is still on disk, FOG tells you to uninstall it instead.
+
+>[!warning] Forget does not drop the plugin's tables
+>What to drop is described by the plugin's own code, which is exactly what is
+>no longer there. Its tables stay behind, and removing them is a manual job. If
+>you still have the code, **Uninstall** first and Forget afterwards.
+
+## Where plugins live
+
+There are two directories FOG looks in, and which one a plugin sits in decides
+whether it survives an upgrade:
+
+| Directory | Holds | Survives a FOG upgrade? |
+|---|---|---|
+| `<webroot>/lib/plugins/` | the plugins bundled with FOG | **No** — the installer re-lays this tree |
+| `/opt/fog/plugins/` | everything third-party | **Yes** |
+
+The installer deletes and rewrites the web root on every run, so a plugin
+placed in `lib/plugins/` is silently removed by your next upgrade.
+`/opt/fog/plugins/` sits outside the web root precisely so that cannot happen.
+**Install third-party plugins there.**
+
+You do not need to do anything to make an external plugin's JavaScript, CSS and
+images load — FOG maintains a symlink for it automatically.
+
+### Where the bundled plugins come from
+
+As of 1.6 the bundled plugins are no longer part of the `fogproject`
+repository. They live in
+[FOGProject/fog-plugins](https://github.com/FOGProject/fog-plugins), and each
+FOG release pins a specific plugins release. `installfog.sh` downloads and
+verifies that release during installation — there is nothing extra for you to
+run.
+
+Two consequences worth knowing:
+
+- **The installer needs to reach GitHub** for plugins, just as it already does
+  for iPXE binaries.
+- **For an offline install**, unpack the matching `fog-plugins` release into
+  `packages/web/lib/plugins/` before running the installer. The fetcher leaves
+  a hand-placed tree alone rather than overwriting it.
+
+## Installing a plugin from an archive
+
+FOG 1.6 can install a third-party plugin from a `.tar.gz` through the web UI.
+There is always the alternative of doing it yourself as root — `git clone` or
+untar into `/opt/fog/plugins/` — which needs nothing switched on and is a
+perfectly good answer.
+
+### Switching uploads on
+
+Two independent switches, both required:
+
+1. **`FOG_PLUGIN_UI_INSTALL_ENABLED`** in **FOG Configuration → FOG Settings →
+   Plugin System**.
+2. **`sudo bin/fog-plugin-uploads.sh enable`** on the server, which makes
+   `/opt/fog/plugins` writable by the web server and relabels it for SELinux.
+   The same script takes `disable` and `status`.
+
+>[!warning] Understand what you are turning on
+>A plugin is PHP that FOG loads and runs as the web server user. Making its
+>directory web-writable means any file-write bug anywhere in FOG becomes a way
+>to put executable code on your server.
+>
+>That is why the second switch is a root command rather than something the
+>settings page can do for itself: granting this authority is deliberately not
+>something the application can grant to itself. Turn it on when you need it,
+>and `disable` it again afterwards if you prefer.
+
+Uploading also needs the **`plugin.install`** permission, which is not part of
+`plugin.edit`. Activating code that is already on the server and adding new
+code to it are different authorities — see [[roles|Roles & Permissions]].
+
+### Doing the upload
+
+**Plugin Management → Upload plugin**, choose the archive, and FOG unpacks it
+somewhere it cannot run from, reads the manifest, and shows you what it found
+*before* anything is installed: the plugin's name, version, author, homepage,
+the FOG versions and other plugins it requires, its description, how many files
+it contains, and the archive's SHA-256. Compare that checksum against the one
+the author published, then confirm.
+
+FOG refuses the archive outright if:
+
+- it is not a readable `.tar.gz`;
+- it does not contain exactly one top-level directory named for the plugin;
+- any path in it is absolute or contains `..`;
+- there is no `<name>/config/plugin.config.php` manifest inside it;
+- the manifest's name does not match the directory;
+- the plugin does not support this FOG version;
+- a bundled plugin already has that name;
+- it is larger than 64 MB.
+
+Uploading a plugin that is already installed is an upgrade: you are warned that
+files will be replaced, and the old copy is only removed once the new one is in
+place.
+
+**Putting the files on the server does not activate the plugin.** You still
+install and activate it from the list, so "the code is here" and "the code is
+running" stay separate decisions.
+
+## The bundled plugins
+
+| Plugin | What it does |
+|---|---|
+| **capone** | Match a machine's DMI value against a key you define and deploy the associated image, without registering the host first |
+| **helloworld** | A skeleton example plugin — the reference for people writing their own |
+| **ldap** | Authenticate FOG users against an LDAP or Active Directory server. Needs your distribution's `php-ldap` package. See [[ldap\|LDAP Authentication]] |
+| **location** | Point hosts at the storage node local to their site, for sites with more than one place to fetch an image from |
+| **ntfy** | Notifications via ntfy.sh or your own ntfy server |
+| **ou** | Predefine Active Directory OUs and associate them with hosts |
+| **persistentgroups** | When a host joins a group, copy image, AD, printer, snapin and location settings onto it from a template host named after that group |
+| **pushbullet** | Pushbullet notifications |
+| **site** | Group hosts into sites and limit which hosts each user sees. See [[site-scoping\|Site Scoping]] |
+| **slack** | Slack notifications |
+| **subnetgroup** | Assign hosts to groups automatically based on their IP subnet |
+| **taskstateedit** | Create and edit FOG's task states |
+| **tasktypeedit** | Create and edit FOG's task types |
+| **windowskey** | Associate Windows product keys with images, applied to hosts on deploy. Keys stay with the host if the plugin is removed |
+| **wolbroadcast** | Wake-on-LAN across separate broadcast addresses, for when you cannot configure your switches to forward it |
+
+>[!note] Access Control is gone
+>The Access Control plugin was replaced by native roles and permissions in
+>1.6. For what happens to plugin-era roles on upgrade, see
+>[[roles#Upgrading from the Access Control plugin|Roles & Permissions]].
+
+## Writing your own
+
+The full guide is
+[[plugin-development|Building a FOG Plugin — Start to Finish]], which walks
+from an empty directory to a working, installable plugin using the bundled
+`helloworld` example. Database changes have their own page:
+[[plugin-schema-migrations|Plugin Schema Migrations]].

--- a/docs/management/web/roles.md
+++ b/docs/management/web/roles.md
@@ -42,6 +42,18 @@ Each permission is an **area** plus an **action**:
 - **Actions** are what can be done there: **View**, **Create**,
   **Edit**, **Delete**, and **Task** (starting imaging/snapin tasks).
 
+Not every area offers every action, and a few offer one of their own. The
+clearest example is **Plugins**, which has **View**, **Edit** and **Install**:
+
+- **Edit** activates, deactivates, installs and uninstalls plugins that are
+  already on the server.
+- **Install** uploads a *new* plugin archive.
+
+They are separate on purpose. Switching on code an administrator already chose
+to put on the server, and adding new code to it, are different authorities —
+so a role that manages plugins does not thereby get to add one. See
+[[plugins#Installing a plugin from an archive|Plugins]].
+
 For example, a help-desk role might have full Host and Printer access
 plus the ability to view Images and start imaging tasks, but no access
 to Users, Roles, or FOG Settings.


### PR DESCRIPTION
Follows the plugin work in `fogproject` (#1025–#1034 / ADR 0009). None of it was documented for admins.

## `management/web/plugins.md` — rewritten

The page described 1.5: tick a setting, look for a gear wheel, and a list of "available plugins" whose only entry was *"Capone — a plugin that does some stuff."*

Rewritten around what an admin has to decide:

- **Activated vs Installed** — different things, and the most common source of confusion on that page.
- **Where a plugin lives decides whether it survives an upgrade.** The installer rewrites the web root, so `lib/plugins` is not a safe place for your own plugin and `/opt/fog/plugins` is.
- **Compatibility ranges** — refusals, and the fact that a FOG upgrade can deactivate a plugin for you without losing its data.
- **Missing rows and Forget** — including the part that matters: Forget leaves the tables behind, because what to drop was described by the code that has gone.
- **Installing from an archive** — the review screen, the refusal rules, both switches it needs, and a straight account of what making a plugin directory web-writable costs you.
- **The bundled plugin list** — the real fifteen, with what each one does. `capone` and `persistentgroups` were read out of their code rather than their one-line manifests, both of which undersell them.
- **Where the bundled plugins come from** now that they are a pinned `fog-plugins` release, including the offline-install case.

## `development/plugin-development.md` — brought up to date

The `fogproject` copy is now 637 lines against this one's 440. Ported: the manifest and its compatibility keys, the two roots, symlinked assets for external plugins, shipping an archive to other people, and lifecycle step 5 for code that has been deleted.

It diverges from the `fogproject` copy in **three places only** — front matter, the ADR link, and one reference to a local sync script — so the next port stays a copy plus those three edits.

## `management/web/roles.md` — the Install action

Plugins is the one area with an action outside the standard five. Activating code an administrator already put on the server, and adding new code to it, are different authorities, so `plugin.install` is deliberately not part of `plugin.edit`.

## Verification

`npm run docs:build` — 104 files, no warnings, and every new cross-link checked in the emitted HTML rather than assumed.

One thing worth knowing for future edits: **a wikilink wrapped across a newline does not parse** and renders literally as `[[page|Text]]`. Three of mine did that on the first build; the build does not warn about it. Caught by grepping the output for `[[`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)