### PR TITLE
Use US spellings throughout the docs

### DIFF
--- a/docs/installation/network-setup/proxy-dhcp.md
+++ b/docs/installation/network-setup/proxy-dhcp.md
@@ -70,7 +70,7 @@ Ideal scenarios for dnsmasq include:
 2.  A regular DHCP server responds with a DHCP Offer, which contains possible values for network settings requested by the client. Usually a possible IP address, subnet mask, router (gateway) address, dns domain name, etc.
 3.  Because the client identified itself as a PXEClient, the proxyDHCP server also responds with a DHCP Offer with additional information, but not IP address info. It leaves the IP address assigning to the regular DHCP server. The proxyDHCP server provides the next-server-name and boot file name values, which is used by the client during the upcoming TFTP transaction.
 4.  The PXE Client responds to the DHCP Offer with a DHCP Request, where it officially requests the IP configuration information from the regular DHCP server.
-5.  The regular DHCP server responds back with an ACK (acknowledgement), letting the client know it can use the IP configuration information it requested.
+5.  The regular DHCP server responds back with an ACK (acknowledgment), letting the client know it can use the IP configuration information it requested.
 6.  The client now has its IP configuration information, TFTP Server name, and boot file name and it initiate a TFTP transaction to download the boot file.
 
   
@@ -310,7 +310,7 @@ renamed on the server.
 
 There is no Microsoft-signed 32-bit shim and no signed 32-bit iPXE, so there is
 nothing signed to point an ia32 UEFI client at. Such machines must have Secure
-Boot **disabled** to network boot. FOG refuses Secure Boot enrolment on them
+Boot **disabled** to network boot. FOG refuses Secure Boot enrollment on them
 outright rather than half-completing it, and 1.6 hides the "Enroll Secure Boot
 Key" boot-menu entry from clients that booted in BIOS/CSM mode for the same
 reason: an option that cannot succeed should not be offered.
@@ -323,7 +323,7 @@ reason: an option that cannot succeed should not be offered.
 
 > [!important] The boot file is only half of Secure Boot
 > Getting a signed iPXE to load is the part dnsmasq controls. The FOS kernel FOG
-> boots afterwards must also be trusted by the machine, which is a separate
+> boots afterward must also be trusted by the machine, which is a separate
 > setup step — see [Secure Boot signing](../../kb/how-tos/secure-boot-signing.md).
 > A correct DHCP configuration with an untrusted kernel gets you a signed iPXE
 > and then a failure one step later.

--- a/docs/installation/server/command-line-options.md
+++ b/docs/installation/server/command-line-options.md
@@ -151,7 +151,7 @@ of them, see
 
 Since FOG 1.6.0 the installer **generates a Secure Boot signing key by
 default** and signs the FOS kernels with it, so a stock server always has a
-certificate fingerprint to check and an enrolment kit to hand out. The three
+certificate fingerprint to check and an enrollment kit to hand out. The three
 options above only matter if you want to change that:
 
 | Option | Use it when |
@@ -164,11 +164,11 @@ options above only matter if you want to change that:
 hand back a key and a `sudoers` rule you deliberately declined.
 
 >[!warning] The generated key is never regenerated, and that is deliberate
->A new signing key silently invalidates enrolment on **every machine that
+>A new signing key silently invalidates enrollment on **every machine that
 >already trusted the old one**, and nothing reports that until a client fails
 >to boot — long after the install that caused it. `--recreate-keys` and
 >`--recreate-CA` deliberately do not touch it. To rotate deliberately, remove
->`/opt/fog/secureboot/` and re-run the installer, then re-enrol every client.
+>`/opt/fog/secureboot/` and re-run the installer, then re-enroll every client.
 
 The private key lives at `/opt/fog/secureboot/MOK.key`, `0600` inside a `0700`
 directory owned by root. It is never copied into the web root and the web

--- a/docs/installation/server/requirements.md
+++ b/docs/installation/server/requirements.md
@@ -20,7 +20,7 @@ the ports and firewall rules FOG needs to actually talk to clients, see
 
 Before diving right into the installation of FOG you need to decide
 which server OS you are going to use. FOG is made to install on RedHat
-based distro CentOS, Fedora, RHEL amongst others as well as Debian,
+based distro CentOS, Fedora, RHEL among others as well as Debian,
 Ubuntu and Arch Linux.
 
 Choose whichever you like most and have knowledge about! FOG is known to

--- a/docs/installation/server/uninstall-fog-server.md
+++ b/docs/installation/server/uninstall-fog-server.md
@@ -83,7 +83,7 @@ genuine pre-FOG original — newer ones are just FOG's own earlier versions. The
 version FOG was using is kept as `<file>.fog-uninstall.<timestamp>` rather than
 deleted, so nothing is lost.
 
-!!! note "Check these afterwards"
+!!! note "Check these afterward"
     If you edited any of those files yourself after installing FOG, those edits
     are in the `.fog-uninstall.` copy, not in the restored file. Review them
     before restarting the affected service.

--- a/docs/kb/how-tos/deploy-an-image.md
+++ b/docs/kb/how-tos/deploy-an-image.md
@@ -77,7 +77,7 @@ For now we will say 'N' here.
 
 You are asked if you would like to associate snapins with this host.
 Snapins are tasks that are executed by the FOG Client and are mostly
-used to install applications afterwards. Snapins for this machine can
+used to install applications afterward. Snapins for this machine can
 later be managed in the Web UI.
 
 For now we will say 'N' here.

--- a/docs/kb/how-tos/firewall.md
+++ b/docs/kb/how-tos/firewall.md
@@ -99,7 +99,7 @@ packet of the actual transfer. PXE clients get as far as asking for a file and
 then time out.
 
 The fix is a connection-tracking helper, `nf_conntrack_tftp`, which teaches the
-firewall to recognise the data connection as related to the request it already
+firewall to recognize the data connection as related to the request it already
 allowed.
 
 !!! warning "Helpers are no longer automatic"
@@ -196,7 +196,7 @@ ufw allow 63100:63228/udp
 Note ufw writes ranges with a **colon**, not a hyphen.
 
 ufw's stock `before.rules` already accepts `RELATED,ESTABLISHED`, so once
-`nf_conntrack_tftp` is loaded the TFTP data transfer is recognised and allowed.
+`nf_conntrack_tftp` is loaded the TFTP data transfer is recognized and allowed.
 Without the module, PXE stalls after the first packet — and nothing in FOG's
 logs will say so.
 

--- a/docs/kb/how-tos/fog-client-example-tasks.md
+++ b/docs/kb/how-tos/fog-client-example-tasks.md
@@ -109,7 +109,7 @@ Now go to your machine and wait for the next poll of the FOG Client.
 When the task starts, you should get a notification that the task has
 started.
 
-Afterwards, you will get a notification that the task has ended.
+Afterward, you will get a notification that the task has ended.
 
 By now the application 7-zip should be installed.
 

--- a/docs/kb/how-tos/secure-boot-mok-enrollment.md
+++ b/docs/kb/how-tos/secure-boot-mok-enrollment.md
@@ -29,13 +29,13 @@ and you should not: both routes below work with it left on.
 The FOG web UI has a **FOG Configuration → Secure Boot** page. It shows your
 certificate's fingerprint (SHA-256, and SHA-1 for MokManager's own "view key"
 screen — see [[pki-glossary#fingerprint-aka-thumbprint|fingerprint]]), offers a
-small **enrolment kit**, and links back to this guide for the full per-client
+small **enrollment kit**, and links back to this guide for the full per-client
 steps below:
 
 | File | What it is |
 | --- | --- |
 | `MOK.der` | your public certificate — this is the thing being enrolled |
-| `fog-enroll-mok.sh` | does the enrolment, checks the fingerprint first |
+| `fog-enroll-mok.sh` | does the enrollment, checks the fingerprint first |
 | `fog-enroll-mok.desktop` | double-click launcher for the above |
 
 Leave that page open on another screen — you are going to compare the
@@ -70,7 +70,7 @@ Reboot. The machine stops in a blue **MOK Manager** screen instead of booting:
 5. Enter the password you just chose
 6. `Reboot`
 
-Confirm afterwards:
+Confirm afterward:
 
 ```bash
 mokutil --list-enrolled | grep -A2 "FOG"
@@ -95,7 +95,7 @@ in `Enroll key from disk` without you carrying anything to the machine.
 
 >[!warning] Why the menu item exists, rather than "just PXE-boot the shim"
 >**A plain PXE boot through the shim never shows MokManager.** Shim only hands
->control to MokManager when a *pending* MOK enrolment request already exists —
+>control to MokManager when a *pending* MOK enrollment request already exists —
 >normally staged by `mokutil --import`, which is what Route A does. With
 >nothing staged, the shim boots straight through to `snponly.efi` and the blue
 >MokManager screen never appears, however long you wait.
@@ -112,9 +112,9 @@ in `Enroll key from disk` without you carrying anything to the machine.
 
 You do **not** need Secure Boot currently enabled to do this, either — tested
 on physical hardware with Secure Boot off, enrolled, then switched back on
-afterward, with no difference in behaviour either way. MokManager's enrolment
+afterward, with no difference in behavior either way. MokManager's enrollment
 does not depend on the firmware currently enforcing anything, only on shim
-having loaded it. That means you can stage enrolment across a fleet before
+having loaded it. That means you can stage enrollment across a fleet before
 ever flipping Secure Boot on: run this while it is still off, and every
 machine already trusts your key by the time enforcement begins.
 Or you can leave secure boot on for a new machine, enroll it then register it
@@ -132,7 +132,7 @@ and you're off without needing to touch secure boot settings.
    >[!warning] If it is not listed
    >Not every firmware/MokManager combination is confirmed to expose a plain
    >`imgfetch`ed file the same way it exposes a kernel/initrd. Fall back to a
-   >FAT-formatted USB stick with `MOK.der` on it (from the enrolment kit) —
+   >FAT-formatted USB stick with `MOK.der` on it (from the enrollment kit) —
    >it will appear in the same browser, the same way Route A's stick does.
 5. `Continue` → `Yes`. Check the CN is yours, **and compare the fingerprint
    MokManager shows against the FOG Secure Boot page before confirming** —
@@ -146,11 +146,11 @@ and you're off without needing to touch secure boot settings.
 >
 >- If you do not press a key within roughly **10 seconds** of the screen
 >  appearing, MokManager gives up waiting and continues booting normally —
->  silently skipping enrolment. Be at the console before you select the
+>  silently skipping enrollment. Be at the console before you select the
 >  menu item or schedule the task, not after.
 >- Once you are inside the tool, an **idle timeout of a couple of minutes**
 >  reboots the machine if you stop responding partway through. Finish the
->  walkthrough once you start it; do not step away mid-enrolment.
+>  walkthrough once you start it; do not step away mid-enrollment.
 
 >[!note] Why the fingerprint isn't checked automatically
 >iPXE could in principle hash the file it just fetched and compare it
@@ -164,14 +164,14 @@ and you're off without needing to touch secure boot settings.
 
 The client now trusts your key and will boot the signed FOS kernel on its
 next PXE boot. Unlike Route A there is no one-time password step, because you
-are already standing at the machine when the enrolment happens.
+are already standing at the machine when the enrollment happens.
 
 >[!tip] Push it as a task instead of hunting for the menu item
 >"Enroll Secure Boot Key" is also a task type, schedulable from **Task
 >Scheduling** against a single host or a whole group, the same way you would
 >schedule a Deploy or a Capture. A host with this task pending skips the
 >interactive boot menu entirely and chains straight into the flow above on
->its next PXE boot — useful for pushing enrolment across many machines
+>its next PXE boot — useful for pushing enrollment across many machines
 >without walking a tech through which menu item to pick on each one. The
 >final `Enroll key from disk` → `Yes` step still has to happen at the
 >console; nothing removes that.
@@ -212,7 +212,7 @@ server at all:
 mokutil --delete MOK.der
 ```
 
-then reboot and confirm in MokManager, exactly as for enrolment.
+then reboot and confirm in MokManager, exactly as for enrollment.
 
 ## Verified
 
@@ -256,9 +256,9 @@ firmware would refuse to launch it directly — but shim's verification protocol
 is what the load actually goes through, and shim trusts it. This is the same
 mechanism that lets a MOK-signed kernel boot, so if one works the other does.
 
-The same client also confirmed that enrolment does not require Secure Boot to
+The same client also confirmed that enrollment does not require Secure Boot to
 be currently enabled: enrolling with it off, then switching Secure Boot back
-on afterward, produced no difference in behaviour from enrolling with it left
+on afterward, produced no difference in behavior from enrolling with it left
 on throughout.
 
 ## See also

--- a/docs/kb/how-tos/secure-boot-setup-mode-enrollment.md
+++ b/docs/kb/how-tos/secure-boot-setup-mode-enrollment.md
@@ -24,7 +24,7 @@ tags:
 Many firmwares support **Setup Mode** — a state that lets you write
 certificates directly into UEFI's own trust database (`PK`, `KEK`, `db`),
 bypassing shim and MokManager entirely. This is Route C: [[secure-boot-mok-enrollment|Routes
-A and B]] both end at a human pressing keys, because MOK enrolment is
+A and B]] both end at a human pressing keys, because MOK enrollment is
 *designed* to require one. Route C sidesteps that by not using MOK at all: if
 the platform is in Setup Mode, the running OS can write the real Secure Boot
 databases directly, and FOS does it unattended.
@@ -75,7 +75,7 @@ firmware computes it during POST.
 
 >[!note] What still needs a human
 >*Getting into* Setup Mode means clearing the `PK` at the firmware screen, and
->turning Secure Boot back **on** afterwards is a firmware toggle too. Neither is
+>turning Secure Boot back **on** afterward is a firmware toggle too. Neither is
 >reachable from a running OS by design. So Route C trades "a visit with a live
 >USB, or keypresses at MokManager" for "a firmware visit" — the win is that the
 >firmware half is scriptable through vendor tooling (Dell `cctk`, Redfish) where
@@ -86,7 +86,7 @@ firmware computes it during POST.
 >with Secure Boot enforcing and your certificate not yet trusted, both are
 >refused — `Verification failed: Security Policy Violation` — so FOS never
 >starts and no task of any kind runs. This is a property of the boot chain, not
->of the enrolment task. Secure Boot must be off, or the platform in Setup Mode,
+>of the enrollment task. Secure Boot must be off, or the platform in Setup Mode,
 >for the machine to get far enough to enroll.
 
 ## Requirements
@@ -95,7 +95,7 @@ firmware computes it during POST.
 - **`efitools` on the server.** The installer installs it and builds the signed
   variable updates (`PK.auth`, `KEK.auth`, `db.auth`, via
   `cert-to-efi-sig-list`, `sign-efi-sig-list`, `efi-updatevar`) automatically.
-  If it is missing the installer says so and skips building them — enrolment
+  If it is missing the installer says so and skips building them — enrollment
   then falls back to the MOK routes rather than failing silently.
 - **FOG 1.6.** The blobs are published at
   `<web-root>/service/secureboot/{db,KEK,PK}.auth` by the 1.6 installer only.
@@ -130,7 +130,7 @@ regenerate** on later installs. The `.auth` blobs are rebuilt every install, but
 from those same keys, so re-running the installer does not invalidate machines
 you have already enrolled.
 
-MOK enrolment via MokManager works exactly the same regardless of whether
+MOK enrollment via MokManager works exactly the same regardless of whether
 Setup Mode is also used — the two are independent enrollment routes for the
 same Secure Boot CA, not alternatives that conflict. Confirmed on real UEFI
 hardware: machines boot FOG's leaf-signed kernels while trusting only the

--- a/docs/kb/how-tos/secure-boot-signing.md
+++ b/docs/kb/how-tos/secure-boot-signing.md
@@ -96,15 +96,15 @@ FOG's own Secure Boot certificate so that shim would accept it.
 The way out is to stop needing a custom binary. FOG's embedded boot script is
 entirely generic, and iPXE 2.0 can fetch that script from the TFTP server
 instead (`autoexec.ipxe`). That lets you run **upstream's signed `snponly.efi`**
-and still get FOG's boot behaviour — which is the approach FOG takes.
+and still get FOG's boot behavior — which is the approach FOG takes.
 
 The alternative the firmware already provides is **MOK** (Machine Owner Key):
 a per-machine list of extra certificates that *you*, as the physical owner of
 the machine, choose to trust. That is what [[secure-boot-mok-enrollment|MOK
 enrollment]] uses.
 
->[!info] Why enrolment usually cannot be automated
->MOK enrolment requires a human at the physical console pressing keys. That
+>[!info] Why enrollment usually cannot be automated
+>MOK enrollment requires a human at the physical console pressing keys. That
 >is not an oversight — it is the security property. If a remote process
 >could enroll a signing key, Secure Boot would be decorative. Budget for one
 >visit per machine, the same way you would for a firmware password. FOG 1.6
@@ -230,7 +230,7 @@ Fedora and Arch) is part of the installer's baseline package set, alongside
 carries on, leaving the kernels unsigned — read the installer output rather
 than assuming.
 
-On each client machine you intend to enrol via MOK, you need a way to run
+On each client machine you intend to enroll via MOK, you need a way to run
 `mokutil` — most simply, boot it once from any Linux live USB. Setup Mode
 enrollment needs no client-side tooling at all.
 
@@ -345,7 +345,7 @@ so none of it is reachable over HTTP. **The web server cannot read either
 private key**: kernel downloads from the web UI are signed by a small
 root-only helper (`/opt/fog/bin/fog-sign-kernel`) that takes no arguments,
 rather than in the web server itself. Only the public certificate is
-published, as `MOK.der` in the enrolment kit.
+published, as `MOK.der` in the enrollment kit.
 
 Back up the whole `pki/secureboot/` directory somewhere you would put a root
 password. Anyone holding the CA key can mint a new signer your machines will
@@ -354,7 +354,7 @@ full stop.
 
 >[!warning] The CA is never regenerated, on purpose
 >Re-running the installer reuses the existing CA. A fresh CA silently
->invalidates enrolment on **every machine that already trusted the old one**,
+>invalidates enrollment on **every machine that already trusted the old one**,
 >and nothing surfaces that until a client fails to boot. `--recreate-keys` and
 >`--recreate-CA` deliberately do not reach it. To rotate the CA on purpose,
 >delete `pki/secureboot/`, re-run the installer, and re-enroll every client —
@@ -427,7 +427,7 @@ cd /path/to/fogproject/bin
 ```
 
 That one run re-signs the FOS kernels with your key and republishes the
-enrolment kit — `MOK.der` and the fingerprint on the **Secure Boot** page —
+enrollment kit — `MOK.der` and the fingerprint on the **Secure Boot** page —
 from your certificate, in the same pass. Remember this switches you to the
 **flat model** (see [[bringing-your-own-ca|Bringing your own CA]]) unless
 you also pass FOG 1.6's `--secureboot-ca-cert`, so every already-enrolled
@@ -473,7 +473,7 @@ key from one machine]].
 generated leaf, rotate it per [above](#rotating-fogs-own-auto-generated-leaf-the-normal-case)
 and nothing else needs to happen. If the compromised key is the CA itself
 (or a flat admin-supplied key), every machine that enrolled it needs a
-physical visit to remove it and enrol the replacement's fingerprint, exactly
+physical visit to remove it and enroll the replacement's fingerprint, exactly
 like a planned rotation, just unplanned. That per-machine visit is the trade
 you accept for not needing anyone else's permission to sign your own
 kernels — treat the private key accordingly, and back it up somewhere you
@@ -487,7 +487,7 @@ would put a root password; see [The signing key](#the-signing-key).
   unaffected and need none of this.
 - **One visit per machine, always** — for MOK enrollment. There is no
   supported way to enroll a MOK without physical presence — that is the
-  security property, not an oversight. The enrolment kit makes the visit
+  security property, not an oversight. The enrollment kit makes the visit
   short; it cannot remove it. [[secure-boot-setup-mode-enrollment|Setup Mode
   enrollment]] enrolls into the firmware's own `db` instead, still
   per-machine, but without the shim/MokManager detour — in practice only
@@ -544,9 +544,9 @@ would put a root password; see [The signing key](#the-signing-key).
 >[!note] Clearing the TPM does not touch enrolled keys
 >Separately from the above: clearing a machine's TPM removes what is sealed
 >*to* the TPM (BitLocker keys, the Windows Hello for Business container,
->etc.), but MOK enrolment is not TPM-backed at all — MokList lives in
+>etc.), but MOK enrollment is not TPM-backed at all — MokList lives in
 >ordinary UEFI (NVRAM) variables that shim reads directly. Clearing the TPM
->neither enrols nor un-enrols a MOK, and does not interact with anything else
+>neither enrolls nor un-enrolls a MOK, and does not interact with anything else
 >in this guide.
 
 ## Still unverified

--- a/docs/kb/how-tos/unify-certificates-across-fog-servers.md
+++ b/docs/kb/how-tos/unify-certificates-across-fog-servers.md
@@ -91,7 +91,7 @@ then rolls up to the hub's CA, so one import covers all of them.
 >[!info] Update every server's installer first
 >This uses `--web-ca-cert`/`--web-ca-key`/`--web-ca-root`. Pull the latest
 >installer on **every** server before you start, or the options will not be
->recognised. See [[command-line-options|Fog installer command line options]].
+>recognized. See [[command-line-options|Fog installer command line options]].
 
 ### Step 1 — issue a CA for each server, on the hub
 
@@ -154,7 +154,7 @@ sudo ./installfog.sh --web-ca-cert /root/webca/webca.pem \
 Unpacking as root into `/root/webca` keeps `webca.key` out of reach of every
 other account on the machine — it is a CA private key, and it stays on this
 server permanently, so where it lands matters. Delete the tarball from your
-home directory afterwards.
+home directory afterward.
 
 You pass these three options **once**. The files are imported into the web zone
 and later upgrades reuse the import without the options being given again.

--- a/docs/kb/integrations/external-ca-lets-encrypt.md
+++ b/docs/kb/integrations/external-ca-lets-encrypt.md
@@ -133,7 +133,7 @@ its trust is whatever CA FOG happened to bake in at build time. It isn't:
 **Net effect:** a FOG web vhost with a real Let's Encrypt certificate
 validates fine for iPXE's netboot fetches (`boot.php`, kernel, initrd) with
 **no FOG-side change**, on both FOG's own build and the republished
-Secure-Boot-signed binaries, and independent of Secure Boot enrolment
+Secure-Boot-signed binaries, and independent of Secure Boot enrollment
 status. This assumes the booting client can reach `ca.ipxe.org`, which holds
 for most sites — outbound internet access is the common case, not the
 exception. Only on a fully air-gapped network does that fallback not fire,
@@ -235,7 +235,7 @@ better.
 
 Point your ACME client's install/renew hook at the two paths FOG's vhost
 reads — `sslpubcert` and `sslprivkey` from `/opt/fog/.fogsettings` — and
-reload the web server afterwards:
+reload the web server afterward:
 
 ```bash
 acme.sh --issue --server https://step-ca.internal/acme/acme/directory \

--- a/docs/kb/reference/SFTP.md
+++ b/docs/kb/reference/SFTP.md
@@ -60,7 +60,7 @@ If you get an error when capturing an image or updating your kernel in the web u
 Message: ssh2_sftp(): Unable to startup SFTP subsystem: Timeout waiting for response from SFTP subsystem
 ```
 
-Then you may need to adjust `/etc/ssh/sshd_config` manually to have this line towards the end of the file, replacing any existing `Subsystem sftp` lines
+Then you may need to adjust `/etc/ssh/sshd_config` manually to have this line toward the end of the file, replacing any existing `Subsystem sftp` lines
 
 ```
 # override default of no subsystems

--- a/docs/kb/reference/bringing-your-own-ca.md
+++ b/docs/kb/reference/bringing-your-own-ca.md
@@ -59,7 +59,7 @@ page only covers the mechanism, that page covers the workflow around it.
 replacement, the same shape as FOG's own auto-generated pair. Without it,
 `--secure-boot-key`/`--secure-boot-cert` on their own hand the installer a
 **leaf with no CA above it**, and that certificate becomes both the signer
-and the thing you enrol — the flat model, same as before the CA/leaf split
+and the thing you enroll — the flat model, same as before the CA/leaf split
 existed for FOG's own key. Rotating a flat key later means re-enrolling
 every machine — see
 [[secure-boot-signing#rotating-or-removing-a-key|Rotating or removing a
@@ -95,7 +95,7 @@ cd /path/to/fogproject/bin
   somewhere you would put a root password, not somewhere you would put a
   config file.
 - `MOK.der` — the public certificate, DER-encoded. This is what you distribute
-  to clients and what `mokutil` enrols; it is not sensitive.
+  to clients and what `mokutil` enrolls; it is not sensitive.
 - `MOK.pem` — the same certificate, PEM-encoded. This is what `sbsign` and
   `sbverify` read.
 
@@ -115,7 +115,7 @@ unsigned on a server whose admin believes they are signed.
 >```
 >
 >`mokutil` and MokManager want the opposite. Neither tool tells you which
->format it wanted, so keep both files and use `MOK.der` for enrolment and
+>format it wanted, so keep both files and use `MOK.der` for enrollment and
 >`MOK.pem` for signing. The installer's `--secure-boot-cert` accepts either and
 >converts internally, so this only bites you when running `sbsign`/`sbverify`
 >by hand.
@@ -126,13 +126,13 @@ uses a longer lifetime, on the logic that a CA is meant to sit still for
 years while the leaf underneath it does the rotating.
 
 >[!tip] Use a descriptive CN
->It is shown in MokManager when someone enrols it, and again years later
+>It is shown in MokManager when someone enrolls it, and again years later
 >when someone is trying to work out what that key is for. `FOG imaging -
 >fog.example.edu` beats `MOK`.
 
 ### Getting the CA/leaf split by hand, without `--secureboot-ca-cert`
 
-Nothing above requires your key to be self-signed. If your organisation
+Nothing above requires your key to be self-signed. If your organization
 already runs an internal CA (AD Certificate Services or similar) and can
 issue a code-signing certificate, `--secure-boot-key`/`--secure-boot-cert`
 (or `--sign-key`/`--sign-cert` in `fos/build.sh`) accept that leaf
@@ -153,7 +153,7 @@ with your own CA means signing and publishing by hand: follow
 kernels]] with `--addcert` added to the `sbsign` call, and enroll the CA's
 certificate rather than a leaf.
 
-One thing this does **not** get you: a way to skip enrolment entirely by
+One thing this does **not** get you: a way to skip enrollment entirely by
 piggybacking on infrastructure your fleet might already have. There is no
 generic Intune/GPO mechanism to push an arbitrary org CA into UEFI `db` —
 what exists there is only Microsoft's own certificate rollover. If your CA

--- a/docs/kb/reference/csv_import_export.md
+++ b/docs/kb/reference/csv_import_export.md
@@ -75,7 +75,7 @@ Each object type has an **Export** page (for example *Hosts
 
 >[!tip]
 >Type in the table's **search box first** to scope the export. **CSV (All)**
->honours the active search, so you can export just the matching subset — for
+>honors the active search, so you can export just the matching subset — for
 >example, every host whose name contains `lab`.
 
 The exported columns — and the optional trailing `associations` column — are
@@ -92,7 +92,7 @@ maps each subsequent row **by name**:
 - **Partial** — include only the columns you want to set; omitted columns keep
   their defaults. (The identity columns are still required: `name` for every
   class, plus `primac` for hosts.)
-- **Auto‑detected** — a first row whose cells are *all* recognised column names
+- **Auto‑detected** — a first row whose cells are *all* recognized column names
   is treated as a header automatically. The *"First row is a header"* checkbox
   forces header mode (and reports any unrecognised header names as ignored).
 - **Names are matched case‑insensitively** (`ProductKey` == `productkey`).
@@ -129,7 +129,7 @@ position**, in the exact order Export produces (the per‑class tables below).
 
 ### A note on sensitive / special fields
 
-| Field | Class | Behaviour |
+| Field | Class | Behavior |
 |-------|-------|-----------|
 | `primac` | Host | **Required**, first column. Pipe‑separated MAC list; the first MAC becomes primary, the rest are added as additional MACs. |
 | `productKey` | Host | Auto‑detected: accepts plaintext, base64, or the AES‑encrypted form an export produces. |

--- a/docs/kb/reference/lvm-imaging.md
+++ b/docs/kb/reference/lvm-imaging.md
@@ -42,7 +42,7 @@ content, so it works regardless of the partition's type ID), it:
    below).
 2. With a resizable image type, shrinks each ext logical volume's
    filesystem before capture — the same "Resizing filesystem" step flat
-   partitions get — and expands it back on the source machine afterwards.
+   partitions get — and expands it back on the source machine afterward.
    This is what lets the image deploy to smaller disks (see
    [Sizing](#sizing-deploying-to-different-disk-sizes) below).
 3. Records the PV/VG/LV layout — names, UUIDs, sizes, and how small each

--- a/docs/kb/reference/secure-boot-technical-details.md
+++ b/docs/kb/reference/secure-boot-technical-details.md
@@ -143,7 +143,7 @@ $ sbverify --list /var/www/fog/service/ipxe/bzImage
 
 The signer shown should match the fingerprint on the **FOG Configuration →
 Secure Boot** page; that page's fingerprint is the digest of the certificate
-your clients enrol — the CA, not the leaf.
+your clients enroll — the CA, not the leaf.
 
 The installer keeps a `.unsigned` copy of each kernel beside the signed one,
 because `sbsign` will not cleanly re-sign an already-signed image. Leave them
@@ -209,7 +209,7 @@ is not being accepted. In order of likelihood:
 | `Security Policy Violation`, but the certificate *is* listed by `mokutil --list-enrolled` | The key carries the Module-signing only OID — see [[secure-boot-signing#bringing-your-own-key|Bringing your own key]] |
 | Fails on every machine, including enrolled ones | Shim is not in the boot chain — see [[secure-boot-signing#the-chain-you-are-building|the chain]] |
 | Worked yesterday, fails today | Something replaced the kernels without re-signing them. The installer always re-signs on install/upgrade — suspect anything that copies into `service/ipxe/` outside it — check with `sbverify` and re-run the installer |
-| Every machine stops working after a change | Either the CA was regenerated, or you switched to a different admin-supplied flat key. Enrolment is per-CA (or per-flat-key), so all clients need re-enrolling — see [[secure-boot-signing#rotating-or-removing-a-key|Rotating or removing a key]] |
+| Every machine stops working after a change | Either the CA was regenerated, or you switched to a different admin-supplied flat key. Enrollment is per-CA (or per-flat-key), so all clients need re-enrolling — see [[secure-boot-signing#rotating-or-removing-a-key|Rotating or removing a key]] |
 | Complains about format, not signature | Kernel lacks `CONFIG_EFI_STUB` |
 
 ## See also

--- a/docs/management/fos/using-fog-boot-menu.md
+++ b/docs/management/fos/using-fog-boot-menu.md
@@ -116,7 +116,7 @@ entries and background on top of the built-in commands below.
 > -   Added in FOG 1.6.0, and only relevant to clients booting with UEFI
 >     Secure Boot enabled.
 >
-> -   This command enrols FOG's signing certificate on the client, which is
+> -   This command enrolls FOG's signing certificate on the client, which is
 >     what allows the machine to boot the FOS kernel with Secure Boot left
 >     on.
 >
@@ -139,7 +139,7 @@ entries and background on top of the built-in commands below.
 >
 >         -   **Anything else** — FOS stages a MOK request and hands off to
 >             MokManager, which needs someone at the console to confirm it.
->             MOK enrolment is designed to require physical presence and
+>             MOK enrollment is designed to require physical presence and
 >             there is no way around that.
 >
 > -   fog.enrollsecureboot is the command used to reference this action in

--- a/docs/management/web/dashboard.md
+++ b/docs/management/web/dashboard.md
@@ -56,7 +56,7 @@ tags:
 -   This section updates in real time.
 -   It will display all the queued, running, etc\... tasks and updates
     at the same interval as the Bandwidth graph.
--   You can also edit which type of tasks get counted towards the "queue".
+-   You can also edit which type of tasks get counted toward the "queue".
       -   This edit can be performed by going to 
         **FOGConfiguration** ![[Config.png]]\-:octicons-arrow-right-24: **FOG Settings**\-:octicons-arrow-right-24: **General Settings** \-:octicons-arrow-right-24:**FOG_USED_TASKS**.
         -   The text field is numeric values (so you'll need to know which task id's are which type.

--- a/docs/management/web/ldap.md
+++ b/docs/management/web/ldap.md
@@ -247,7 +247,7 @@ nesting works and what it costs depends on the directory:
 
 | **Nested Groups** | What it does |
 |---|---|
-| **Off - direct membership only** | Today's behaviour. Direct members only. |
+| **Off - direct membership only** | Today's behavior. Direct members only. |
 | **Expand - walk the chain (any directory)** | FOG walks up the group tree itself, one query per level. Works on **every** directory. |
 | **Chain - LDAP_MATCHING_RULE_IN_CHAIN (AD only)** | The directory resolves the whole chain server-side, in a single query. |
 
@@ -396,6 +396,6 @@ still carries only their role's permissions — see
   a full administrator. If that is not what you want, the role mapping
   is where you fix it.
 - **Certificate verification does not change on upgrade.** Existing
-  servers come through set to **Inherit**, which is the behaviour they
+  servers come through set to **Inherit**, which is the behavior they
   already had — whatever `TLS_REQCERT` on the FOG server says. Nothing
   starts failing because the setting arrived.

--- a/docs/management/web/plugins.md
+++ b/docs/management/web/plugins.md
@@ -116,7 +116,7 @@ is still on disk, FOG tells you to uninstall it instead.
 >[!warning] Forget does not drop the plugin's tables
 >What to drop is described by the plugin's own code, which is exactly what is
 >no longer there. Its tables stay behind, and removing them is a manual job. If
->you still have the code, **Uninstall** first and Forget afterwards.
+>you still have the code, **Uninstall** first and Forget afterward.
 
 ## Where plugins live
 
@@ -178,7 +178,7 @@ Two independent switches, both required:
 >That is why the second switch is a root command rather than something the
 >settings page can do for itself: granting this authority is deliberately not
 >something the application can grant to itself. Turn it on when you need it,
->and `disable` it again afterwards if you prefer.
+>and `disable` it again afterward if you prefer.
 
 Uploading also needs the **`plugin.install`** permission, which is not part of
 `plugin.edit`. Activating code that is already on the server and adding new

--- a/docs/management/web/roles.md
+++ b/docs/management/web/roles.md
@@ -110,7 +110,7 @@ their dashboard, the client-facing pages, and log out.
     of arriving without a role.
 
     The upgrade converts every account that was relying on the old
-    behaviour into an explicit role, so nobody's access changes silently
+    behavior into an explicit role, so nobody's access changes silently
     — see [What the upgrade does to existing users](#what-the-upgrade-does-to-existing-users).
 
 ## What restricted users see


### PR DESCRIPTION
The docs are written by and for a US project and mostly already use US spellings — the Briticisms in them were inconsistency rather than a house style.

`pki-glossary.md` had in fact already declared the rule:

> Written "enrollment" (US) throughout current docs, matching FOG's own identifiers and filenames (`fog-enroll-mok.sh`, "Enroll Secure Boot Key").

…while 42 other places spelled it the British way, including the pages that glossary entry points at.

## What changed

**70 replacements across 23 files:** `enrolment`/`enrol`/`enrols`, `behaviour`, `recognise(d)`, `afterwards`, `towards`, `organisation`, `honours`, `acknowledgement`, `amongst`.

**Prose only.** Code fences, inline code, link targets, wikilink slugs, front matter and URLs were masked out before matching, so no identifier, filename or anchor moved. Separately verified that no heading changed and that nothing links to an anchor built from one of these words — a renamed heading would have broken incoming links silently.

## Three deliberate exceptions

| Left alone | Why |
|---|---|
| `forwards` in `api.md`, `network-and-firewall-requirements.md` | It's the **verb** — "nginx forwards only a fixed parameter list". "forward" would be ungrammatical. |
| `cancelled` in `fos-release-workflows.md` | Names the GitHub Actions job result value, quoted from the workflow. An external identifier, not our prose. |
| `backwards` in `plugin-development.md` | That page is a mirror of `fogproject/docs/plugin-development.md`. One adverb isn't worth the divergence. |

The glossary line quoting "enrolment" as the spelling you may still meet in older text is left as it is, for obvious reasons.

`npm run docs:build`: 104 files, no warnings.

`wikiArchive/` is untouched — it's the pre-migration export, isn't built, and shouldn't be rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)