### PR TITLE
Document the API Documentation page and the OpenAPI spec

### DIFF
--- a/docs/kb/integrations/api-openapi-reference.md
+++ b/docs/kb/integrations/api-openapi-reference.md
@@ -1,0 +1,123 @@
+---
+title: API Documentation Page & OpenAPI Spec
+description: The built-in Swagger UI reference, and the OpenAPI document FOG generates from its own routing and model metadata
+context_id: api-openapi-reference
+aliases:
+    - OpenAPI
+    - Swagger
+    - Swagger UI
+    - API Documentation Page
+    - swagger.json
+tags:
+    - 1_6-changes
+    - kb
+    - integrations
+    - api
+---
+
+# API Documentation Page & OpenAPI Spec
+
+FOG 1.6 describes its own REST API. The server generates an
+[OpenAPI 3.1](https://spec.openapis.org/oas/v3.1.0) document from its live routing and model
+metadata, and renders it in the web UI with Swagger UI, so you can read every endpoint and try
+calls against your own server without leaving it.
+
+> [!note] FOG 1.6 and newer
+> The generator relies on the schema manifest introduced in 1.6. There is no equivalent on 1.5.
+
+## Where to find it
+
+**API Documentation** in the main menu. The page needs the API switched on — see
+[[api|API]] for that — and, like the rest of the API, it is unavailable while
+`FOG_API_ENABLED` is off. The page will tell you so rather than showing you an empty panel.
+
+Use **Authorize** to enter your tokens before trying a call:
+
+- the server-wide token is under **FOG Configuration → FOG Settings → API System**
+- your personal token is on the **API** tab of your own user account, which needs API access enabled
+
+Paste both exactly as the UI shows them. See [[api|API]] for the detail on why.
+
+The reference follows the light/dark toggle in the header along with the rest of the UI.
+
+## The raw document
+
+Two paths serve the same document:
+
+| Path | Notes |
+|---|---|
+| `https://your-fog-server/fog/system/openapi` | Canonical, alongside the other `system/*` endpoints |
+| `https://your-fog-server/fog/swagger.json` | The filename most tooling looks for first |
+
+Both are unauthenticated, so a client can discover the server before it has credentials. They expose
+only the *shape* of the API — class names, field names and types — and no data.
+
+Replace `/fog/` with your own web root if you changed it at install time.
+
+### It describes *your* server
+
+The document is generated per request rather than shipped as a file, which means it describes the
+server serving it — including any classes a plugin has added. A file baked at build time would
+describe the classes FOG ships with instead, which on a server running plugins is a different list.
+
+A typical install produces around 390 paths across 50-odd classes.
+
+## Using it with other tools
+
+Any OpenAPI-aware tool can consume it, which is the point of publishing a machine-readable
+description at all. Point the tool at the URL above, or download the document first if the tool
+cannot reach your server directly.
+
+**Generate a client** in whatever language you are working in:
+
+```bash
+npx @openapitools/openapi-generator-cli generate \
+  -i https://your-fog-server/fog/swagger.json \
+  -g python -o fog-client
+```
+
+`openapi-generator` supports 50+ languages. Swap `-g python` for `go`, `java`, `csharp`, `rust` and
+so on.
+
+**Import into Postman or Insomnia** — both read an OpenAPI URL directly and build a request
+collection from it.
+
+**Read it offline** in [Swagger Editor](https://editor.swagger.io/) or
+[Redocly](https://redocly.com/), by pasting the downloaded document in.
+
+> [!tip] Self-signed certificates
+> A default FOG install uses a self-signed certificate, so a tool fetching the URL may refuse it.
+> Either trust the FOG CA on the machine running the tool, or download the document with
+> `curl -k` and feed the tool the local file.
+
+## What the document does and does not cover
+
+Generated from three sources that FOG already reads at runtime, so they cannot drift from the
+behaviour they describe:
+
+- the router's class list and route table, for every path and method
+- each model's field metadata, for property names, required fields and types
+- the permission registry, for the permission each operation needs, published as `x-fog-permission`
+
+Some things are described in prose on the operations they affect rather than as strict schema,
+because no metadata backs them:
+
+- a handful of classes gain extra fields in responses (`image` returns `os`, `osname`,
+  `imagetypename` and `storagegroupname`, for instance) from hand-written code rather than from the
+  model definition
+- some classes accept extra fields on create and edit that are not columns — `host` takes `macs`,
+  `primac`, `snapins`, `printers`, `modules` and `groups`
+- a field with no type information in the schema manifest is described as a string and says so,
+  rather than being given a guessed type
+
+Fields withheld from list responses but returned on a single GET by id are marked
+`x-fog-sensitive: list` and say as much in their description.
+
+Every property is also addressable by its raw database column name, since the model layer accepts
+either spelling. The document uses the property name and records the column as `x-fog-column`.
+
+## Related
+
+- [[api|API]] — authentication, tokens, and worked examples
+- [[api-expansion-and-pagination|API Pagination, Expansion & Plugin Items]] — paging parameters and
+  the response envelope, which the document describes but that page explains

--- a/docs/kb/integrations/api.md
+++ b/docs/kb/integrations/api.md
@@ -17,6 +17,18 @@ tags:
 In here you'll find some practical API examples. But first, let's explain how
 to authenticate.
 
+> [!tip] Looking for the full endpoint list?
+> On FOG 1.6 and newer the server describes its own API. **API Documentation** in
+> the main menu renders every endpoint your install exposes, with field types, the
+> permission each one needs, and a working *try it* console. The same document is
+> machine-readable at `/fog/swagger.json`, so you can generate a client from it in
+> any language. See [[api-openapi-reference|API Documentation Page & OpenAPI Spec]].
+>
+> That reference is generated from the running server, so it stays accurate as
+> classes and routes change. The examples below are still the best starting point
+> for *how* to call the API; the generated document is where to look up *what* is
+> callable.
+
 ## Basics
 
 To be able to use the API via external calls it needs to be enabled in the FOG

--- a/docs/kb/integrations/index.md
+++ b/docs/kb/integrations/index.md
@@ -14,5 +14,6 @@ tags:
 This sections contains articles related to known integrations with fog, especially with the API.
 
 - [[api|API]]
+- [[api-openapi-reference|API Documentation Page & OpenAPI Spec]]
 - [[api-expansion-and-pagination|API Pagination, Expansion & Plugin Items]]
 - [[external-ca-lets-encrypt|External CA & Let's Encrypt Certificates]]


### PR DESCRIPTION
FOG 1.6 now describes its own REST API — an OpenAPI 3.1 document generated from the live routing and model metadata, served at `/system/openapi` and `/swagger.json`, and rendered in the web UI with Swagger UI (FOGProject/fogproject#1042, #1044, #1045). None of that was written down anywhere.

## New page

`kb/integrations/api-openapi-reference.md` — **API Documentation Page & OpenAPI Spec**

- where the page is, and that it needs `FOG_API_ENABLED`
- authorising against it, and where each token lives
- the two URLs, and that both serve the same document
- that it is generated per request, so it describes *that* server including plugin-added classes
- using the document with other tooling: `openapi-generator` to build a client in any language, Postman/Insomnia import, Swagger Editor
- a self-signed-certificate note, since a default install will trip tools fetching the URL

A machine-readable description is only worth publishing if people know they can feed it to something, so the tooling section is deliberately concrete rather than a link.

It is also explicit about the limits. A generated document that quietly overstates itself is worse than prose, so the page says which parts are prose-described rather than schema: the handful of classes that gain response fields from hand-written code, the create/edit fields that are not columns (`host` taking `macs`, `primac`, `snapins`…), and that a column with no type information is described as a string and says so.

## Existing pages

**`api.md`** gets a pointer at the top rather than a rewrite. Its examples are still the best explanation of *how* to call the API. What it should no longer be is where someone goes to find out *what* is callable — that list is now generated from the server and cannot go stale, where a hand-maintained table can.

**`index.md`** lists the new page between `api` and `api-expansion-and-pagination`, which is the order someone would read them in.

## One thing worth a separate look

I used `> [!tip]` rather than the `!!!` admonition syntax also present in this repo. Quartz renders Obsidian callouts through `obsidian-flavored-markdown`; it has no handler for MkDocs `!!!` blocks, so those are almost certainly rendering as plain indented paragraphs since the migration.

There are **eleven** of them across the docs (`!!! note` ×5, `!!! warning` ×3, `!!! tip` ×3, plus `info` and `danger`). Not touched here — it is unrelated to this change and wants its own pass — but worth knowing.

## Checked

Wikilink targets resolve, frontmatter parses, `context_id` values are unique across `docs/`.
