### PR TITLE
Correct the OpenAPI page: 3.0.3, current counts, and what is hand-written

### DIFF
--- a/docs/kb/integrations/api-openapi-reference.md
+++ b/docs/kb/integrations/api-openapi-reference.md
@@ -18,7 +18,7 @@ tags:
 # API Documentation Page & OpenAPI Spec
 
 FOG 1.6 describes its own REST API. The server generates an
-[OpenAPI 3.1](https://spec.openapis.org/oas/v3.1.0) document from its live routing and model
+[OpenAPI 3.0.3](https://spec.openapis.org/oas/v3.0.3) document from its live routing and model
 metadata, and renders it in the web UI with Swagger UI, so you can read every endpoint and try
 calls against your own server without leaving it.
 
@@ -60,7 +60,20 @@ The document is generated per request rather than shipped as a file, which means
 server serving it — including any classes a plugin has added. A file baked at build time would
 describe the classes FOG ships with instead, which on a server running plugins is a different list.
 
-A typical install produces around 390 paths across 50-odd classes.
+A typical install produces around 510 paths and 716 operations across some 69 classes.
+
+### Why 3.0.3 and not 3.1
+
+The document uses no JSON Schema feature that 3.0.3 cannot express, and declaring 3.1 costs about a
+second of frozen page every time you expand an operation: Swagger UI resolves a 3.1 document through
+its JSON-Schema-2020-12 resolver, which re-resolves the whole document on each subtree request, so
+the cost tracks the size of the document rather than the size of the thing you clicked. On a
+document this size that is 1798ms per expansion against 156ms. Nullable fields are therefore spelled
+3.0's `nullable: true`, and the handful of genuinely multi-type fields as `oneOf`.
+
+The side benefit is reach: client generators still have open bugs handling 3.1's
+`type: [x, "null"]`, so a 3.0.3 document generates working clients in more places than a 3.1 one
+would.
 
 ## Using it with other tools
 
@@ -92,12 +105,22 @@ collection from it.
 
 ## What the document does and does not cover
 
-Generated from three sources that FOG already reads at runtime, so they cannot drift from the
-behaviour they describe:
+Three things are read live at generation time, so they cannot drift from the behaviour they
+describe:
 
-- the router's class list and route table, for every path and method
+- the router's class lists, for which classes appear and which of them accept tasks or expose an
+  active list
 - each model's field metadata, for property names, required fields and types
 - the permission registry, for the permission each operation needs, published as `x-fog-permission`
+
+Add a class to the router and its whole set of operations appears here with no further work,
+including a class contributed by a plugin.
+
+The *shape* of each operation is written by hand, though — the ten generic routes every class gets,
+and the fixed `system/*` endpoints. An endpoint that follows neither pattern has to be described
+deliberately, so a route added without that step is served but not documented. Two are in that
+state today: `POST /snapin/createwithfile` and `POST /storagegroup/{id}/uploadsnapinfiles`, both
+multipart uploads rather than the JSON bodies the rest of the API takes.
 
 Some things are described in prose on the operations they affect rather than as strict schema,
 because no metadata backs them:


### PR DESCRIPTION
The API Documentation / OpenAPI page went in yesterday (#110) and three things in it have since gone stale or were overstated. One file, `docs/kb/integrations/api-openapi-reference.md`.

## 1. The document is 3.0.3, not 3.1

FOGProject/fogproject#1066 landed today and switched `OAS_VERSION`. The page still said 3.1 and linked the 3.1 spec.

Rather than just swapping the number, this adds a short **Why 3.0.3 and not 3.1** section, because a reader who knows 3.1 exists will otherwise read 3.0.3 as neglect. Two reasons, both from that PR:

- Swagger UI resolves a 3.1 document through its JSON-Schema-2020-12 resolver, which re-resolves the whole document on every subtree request — so expanding any operation cost 1798ms against 156ms, regardless of which operation.
- Client generators still have open bugs on 3.1's `type: [x, "null"]`, so the 3.0.3 spelling generates working clients in more places. That matters here because the page's headline example is `openapi-generator`.

## 2. The counts were low

"around 390 paths across 50-odd classes" → 510 paths and 716 operations across some 69 classes, per the measurements in #1066.

## 3. "cannot drift from the behaviour they describe" was too strong

True of the three things read live at generation time — class lists, model field metadata, the permission registry. Not true of the shape of each operation, which is hand-written PHP: the ten generic routes every class gets, plus the fixed `system/*` endpoints. A route that matches neither pattern is served without being described.

Two are in that state today, so the page now names them instead of implying full coverage: `POST /snapin/createwithfile` and `POST /storagegroup/{id}/uploadsnapinfiles`, both multipart uploads rather than the JSON bodies the rest of the API takes.

The section keeps the useful half of the original claim — add a class to the router and its whole operation set appears with no further work, plugin classes included — and is explicit about which half is which.

## Notes

- Prose only, no front matter, links or `context_id` touched, so no redirect or nav impact.
- No new wikilinks added, so nothing to check for the line-wrap trap.
- Not built locally — this container has no Node toolchain for `npm run docs:build`. The change is body prose inside existing sections, so there is nothing for the build to resolve that it was not already resolving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xipz1kLXVrFzGdaDWP9g27

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xipz1kLXVrFzGdaDWP9g27)_