### PR TITLE
Document site grants, and that sites are no longer a plugin

### DIFF
--- a/docs/kb/reference/csv_import_export.md
+++ b/docs/kb/reference/csv_import_export.md
@@ -399,8 +399,10 @@ import and export, without patching core:
 
 The Location plugin (`addlocationimport.hook.php`) is the reference
 implementation, registering a single-valued `location` type for hosts and
-listening for `EXPORT_ASSOCIATIONS_PRIME` to batch that label. The Site plugin
-(`addsiteimport.hook.php`) follows the same pattern for a host's `site`.
+listening for `EXPORT_ASSOCIATIONS_PRIME` to batch that label. The retired
+Site plugin used to follow the same pattern for a host's `site`; sites moved
+into FOG itself in 1.6 and that hook did not move with them, so `site` is
+currently not a CSV association label for any class.
 
 ### Export performance
 

--- a/docs/management/web/site-scoping.md
+++ b/docs/management/web/site-scoping.md
@@ -6,7 +6,8 @@ aliases:
     - Site Plugin
     - Object Scoping
     - Multi-Site
-description: How the Site plugin narrows a user's access to only the hosts, users and groups that belong to their site
+    - Site Grants
+description: How sites narrow a user's access to only the hosts, users and groups that belong to their site
 context_id: site-scoping
 tags:
     - 1_6-changes
@@ -14,7 +15,6 @@ tags:
     - users
     - roles
     - permissions
-    - plugins
     - sites
     - web-ui
     - web-management
@@ -29,25 +29,22 @@ perform — view hosts, edit images, start tasks, and so on. They do not
 control **which objects** a user sees: a role that grants Host edit
 lets that user edit *every* host on the server.
 
-The **Site** plugin adds that second dimension. It lets you group
-hosts, users, groups and user groups into **sites**, and restrict a
-user so they only see and touch the objects in their own site(s). A
-site-scoped help-desk admin at the "Chicago" site sees only Chicago's
-hosts, both in the web UI and through the [REST
-API](../../kb/integrations/api.md).
+**Sites** add that second dimension. You group hosts, users, groups and
+user groups into sites, and a site-scoped user only sees and touches
+the objects in their own site(s). A site-scoped help-desk admin at the
+"Chicago" site sees only Chicago's hosts, both in the web UI and
+through the [REST API](../../kb/integrations/api.md).
 
 Site scoping is layered **on top of** roles, not instead of them. A
-user's role still decides what they can do; their site membership
-decides which objects those actions apply to.
+user's role still decides what they can do; their sites decide which
+objects those actions apply to. Scoping only ever *narrows* — it cannot
+grant access a role does not already allow.
 
-## Enabling the plugin
-
-1. Go to **FOG Configuration → Plugin System** and enable the plugin
-   system if you have not already.
-2. On the **Plugins** tab, install and activate **Site**.
-3. A **Sites** section (globe icon) appears in the main menu.
-
-See [Plugins](plugins.md) for the general plugin workflow.
+!!! note "Sites are part of FOG in 1.6"
+    Sites used to be a plugin you installed from **FOG Configuration →
+    Plugin System**. In 1.6 they are part of FOG itself: the **Sites**
+    section is always in the main menu, and there is nothing to enable.
+    Upgrading carries your existing sites and their members across.
 
 ## Creating sites
 
@@ -57,21 +54,67 @@ See [Plugins](plugins.md) for the general plugin workflow.
 
 Repeat for each physical location or team you want to scope by.
 
-## Assigning objects to a site
+## Putting objects in a site
 
 A site can contain four kinds of object: **hosts**, **users**,
 **groups** and **user groups**. Assignment is always explicit — a
 group's site is its *own* setting, not inferred from the sites of its
 member hosts.
 
-You can assign objects from either direction:
+You can assign from either direction, and both write the same thing:
 
-- **From the site.** Open a site and use its **Associations** tab
-  (Host Association / User Association) to add or remove members in
-  bulk.
+- **From the site.** Open a site and use its **Associations** tabs —
+  Host Association, User Association, Group Association, User Group
+  Association — to add or remove members in bulk.
 - **From the object.** Open a host, user, group or user group and use
   its **Site Association** tab to choose which site it belongs to, then
   click **Update**.
+
+## Granting a site to a role or a user group
+
+Listing every user on every site works, but it means maintaining the
+same list twice: once as "who is in the help-desk role" and once as
+"who is in the Chicago site". **Grants** remove the second list.
+
+A site can be granted to:
+
+- a **role** — everyone holding that role gets the site, whether they
+  hold it directly or through a user group;
+- a **user group** — every member of that group gets the site.
+
+Set them up from either end, exactly like the associations above:
+
+- **From the site.** Open a site and use its **Granted To** tabs —
+  **Roles** and **User Groups**.
+- **From the role or the user group.** Open a role or a user group and
+  use its **Site Grants** tab.
+
+A grant is inherited the moment it applies. Add someone to the
+"Chicago Techs" user group and they are in the Chicago site on their
+next request; remove them and they are out of it. Nothing is copied, so
+the two never drift.
+
+### A grant is not a membership
+
+The distinction matters, and it is why they are separate tabs:
+
+|  | What it means |
+|---|---|
+| **Association** (Host / User / Group / User Group) | This object *is in* the site. It is one of the things a scoped user at that site can see. |
+| **Grant** (Roles / User Groups) | Holders of this role, or members of this user group, *get* the site. It is what puts a person in scope. |
+
+So putting the "Chicago Techs" user group in a site's **User Group
+Association** tab makes that group an object Chicago's staff can open
+and edit. Putting it in the site's **Granted To → User Groups** tab
+gives its members Chicago's hosts. They are different questions about
+the same two things, and you may well want one without the other.
+
+### Grants only ever add
+
+A user's sites are the union of everything that reaches them —
+their own assignment, plus every grant they inherit. There is no grant
+that takes a site away, so adding one can never narrow what somebody
+already sees.
 
 ## Restricting a user to their site
 
@@ -81,37 +124,78 @@ Two things make a user site-scoped:
    **Administrator (full access)** bypasses site scoping entirely. A
    user with *no* role has no access at all and so is never scoped
    either — see [Users without a role](roles.md#users-without-a-role).
-2. **They are assigned to one or more sites**, via their **Site
-   Association** tab.
+2. **They reach one or more sites**, through their own **Site
+   Association**, through a role they hold, or through a user group
+   they belong to.
 
 Once both are true, that user only sees the hosts, users, groups and
-user groups that belong to their site(s) — in list views, in search,
-on edit pages, and over the API. Trying to open an out-of-scope object
-directly returns them to the dashboard with a permission error.
+user groups in those sites — in list views, in search, on edit pages,
+and over the API. Trying to open an out-of-scope object directly
+returns them to the dashboard with a permission error.
+
+Tasks follow their host: a scheduled or active task is in scope if the
+host it runs against is. Images, snapins and printers are **not**
+scoped — they are shared resources, and every user who can see them at
+all sees all of them.
+
+## The catch-all site
+
+One site can be marked **Catch-All**, on its General tab. Its members
+are in scope for **everything**, including hosts registered after they
+were added — it is a flag, not a copied list, so it cannot go stale.
+
+Upgrading to 1.6 creates a catch-all site and puts every existing
+account in it, which is why an upgrade changes nothing about who sees
+what. New accounts join it too, but only for as long as the catch-all
+is the *only* site on the server: once you create a real site, which
+site a new user belongs to becomes an administrative decision rather
+than a default.
+
+Only one site can be the catch-all at a time. Ticking the box on a
+second site moves the flag.
+
+!!! tip "Scoping switches itself on when you start using it"
+    While the catch-all is the only site that exists, scoping is
+    inactive and everyone sees everything. Creating your first real
+    site is what turns it on. That is deliberate: it means the upgrade
+    does not silently start restricting a feature nobody has set up.
 
 ## Deny-all: a role but no site
 
-!!! warning "A restricted user with no site sees nothing"
-    Once the Site plugin is active, any user who holds a role (other
-    than a full-access one) and has **no site assignment** sees an
+!!! warning "A restricted user who reaches no site sees nothing"
+    Once real sites exist, any user who holds a role (other than a
+    full-access one) and reaches **no site at all** — no assignment, no
+    grant through a role, no grant through a user group — sees an
     **empty list** of hosts, users, groups and user groups. This is
-    deliberate — scoping fails closed, so a user is never shown objects
-    you did not explicitly grant.
+    deliberate: scoping fails closed, so a user is never shown objects
+    you did not grant.
 
     If a user should see everything, give them a role with
-    **Administrator (full access)** ticked. Otherwise, make sure every
-    scoped user is assigned to at least one site.
+    **Administrator (full access)** ticked, or add them to the
+    catch-all site. Otherwise make sure every scoped user reaches at
+    least one site.
 
 ## Who is never scoped
 
 - **Full-access roles** — any role with **Administrator (full access)**
   ticked bypasses site scoping entirely.
+- **Members of the catch-all site.**
 
 Users with no role are not "unscoped" — they have no access to scope in
 the first place.
 
-Site scoping only ever *narrows* a user who already holds a restricting
-role. It cannot grant access a role does not already allow.
+## Who can change all this
+
+Site pages and tabs follow the ordinary [role
+permissions](roles.md) for the **Site** node: `view` to see them,
+`edit` to change them, `create` to add a site, `delete` to remove one.
+
+The **Site Grants** tabs on the Role and User Group pages are the one
+place worth calling out. They take the **Site** permissions, not the
+Role or User Group ones — granting a site to a role widens what every
+holder of that role can see, so being able to edit roles is not by
+itself enough to hand out access. Someone with role edit but no site
+edit will not see those tabs at all.
 
 ## The REST API respects sites
 
@@ -124,9 +208,12 @@ authenticate as a user holding a full-access role.
 
 ## Removing scoping
 
-- **Unassign the user** from their site(s) to change what they see, or
-  give them a full-access role to make them an administrator again.
-- **Uninstalling the Site plugin** removes the object boundary
-  entirely; every user's role permissions
-  ([Roles & Permissions](roles.md)) are unchanged, and all users can
-  again see every object their role allows.
+- **Change what one user sees** — unassign them from their site(s), and
+  remove any grant that reaches them. Check the role and user group
+  grants too; an assignment removed on its own leaves an inherited site
+  in place.
+- **Make somebody an administrator again** — give them a full-access
+  role, or add them to the catch-all site.
+- **Turn scoping off entirely** — delete every site except the
+  catch-all. Scoping goes inactive on its own, and every user's role
+  permissions ([Roles & Permissions](roles.md)) are unchanged.


### PR DESCRIPTION
`site-scoping.md` still opened with **"Enabling the plugin"** and a walk to *FOG Configuration → Plugin System*. Sites moved into FOG itself in 1.6 and there is nothing to enable, so the first thing the page told you to do could not be done. (`plugins.md` already said sites were core — the two disagreed.)

Rewritten around what 1.6 actually has:

- **Grants.** A site can be granted to a role or to a user group, and everyone who holds the role or belongs to the group inherits it. This is the feature that stops you maintaining the same list twice — once as "who is in the help-desk role" and once as "who is in the Chicago site".
- **Grant vs association, as a table**, because they are separate tabs naming the same two things and this is the one thing a reader will get wrong:

  | | What it means |
  |---|---|
  | Association | This object *is in* the site. |
  | Grant | Holders of this role, or members of this user group, *get* the site. |

- **Grants only ever add**, so turning one on cannot narrow what somebody already sees.
- **The catch-all site** — what it is, that upgrading creates one and enrolls every existing account, and that creating your first real site is what switches scoping on. That last point is why an upgrade changes nothing about who sees what.
- **Tasks are scoped through their host; images, snapins and printers are not scoped at all.**
- **The Site Grants tabs on the Role and User Group pages take the Site permissions**, not the Role or User Group ones — granting a site to a role widens what every holder of that role can see, so role edit alone does not open it. Somebody without site edit will not see those tabs.

The deny-all warning now says "reaches no site" rather than "has no site assignment" — with grants, an assignment is no longer the only way in, and removing one on its own can leave an inherited site behind. The removal section says the same thing the other way round.

### Separately: a stale reference, and what it turned up

`csv_import_export.md` named `addsiteimport.hook.php` as the second reference implementation of a plugin-registered association label. That file went away with the plugin (fog-plugins `14fa6da`, "Retire the site plugin; core owns sites now") and **nothing in core replaced it** — `FOGPage::getAssociationConfig('Host')` registers `groups`, `snapins`, `printers` and `modules`, and no hook adds `site`.

So a host's site is currently not a CSV label at all: export a host and re-import it and the site assignment is silently dropped. Corrected here to say that, rather than point at a file that no longer exists. **Whether core should re-register it is a fogproject question, not a docs one** — it would let a CSV change which site a host is in, and therefore who can see it, so it wants a deliberate decision rather than a quiet restoration.

`npm run docs:build` → 106 files parsed, 916 emitted, no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR