### PR TITLE
Document what happens to a directory account's password

### DIFF
--- a/docs/management/web/local-login.md
+++ b/docs/management/web/local-login.md
@@ -91,6 +91,12 @@ An account can sign in here if it has a **local password**. In practice:
 That distinction is the whole of your break-glass plan, and it is worth
 checking rather than assuming.
 
+You can change it. On a user's **General** tab, tick **Return To Local
+Login** and press **Update**, then set a password on the Password tab that
+appears. See
+[[users#Returning an account to a FOG password|Returning an account to a FOG password]]
+— including which providers keep working afterwards and which do not.
+
 ## Make sure at least one account can use it
 
 FOG enforces a floor, and you will meet it as a refusal:

--- a/docs/management/web/users.md
+++ b/docs/management/web/users.md
@@ -56,6 +56,41 @@ FOG accounts can be modified from within the users section.
         -   Use the tabbed navigation to find the general, password, and
             api settings
 
+## Accounts that sign in through a directory
+
+An account created by — or handed to — an identity provider does not have
+a **Password** tab. FOG refuses a local password for those accounts by
+design, so a password typed there could only ever be one that nothing
+would accept, and being told *"User updated!"* about it is worse than not
+being offered the box.
+
+Instead, the **General** tab shows a read-only **Signs In With** field
+naming the source, so you can tell at a glance which accounts these are.
+
+### Returning an account to a FOG password
+
+On that same tab, tick **Return To Local Login** and press **Update**. The
+Password tab appears on the next page load, and you can set a password.
+
+>[!warning] Set the password straight afterwards
+>Whether the account can still sign in through its provider once you do
+>this depends on the provider:
+>
+>- **[[ldap|LDAP]]** sign-in **stops working**. FOG only accepts LDAP's
+>  word for an account that carries the source stamp — that restriction is
+>  what stops a plugin authenticating a local account — so removing the
+>  stamp removes the LDAP login too.
+>- **[[oidc|OpenID Connect]]** sign-in is **unaffected**. It never goes
+>  through FOG's password check at all.
+>
+>Either way, an account with no auth source and no password set cannot
+>sign in with a password. Do both steps in one sitting.
+
+There is no way to go the other direction from this page. Handing an
+account *to* a directory takes its local password away, which is how an
+install locks itself out, and that is not something a general-details form
+should do as a side effect. See [[local-login|The Local Login Page]].
+
 ## Restricting what a user can do
 
 Starting with FOG 1.6, each user account has a **Roles** tab where you


### PR DESCRIPTION
Covers [fogproject#1182](https://github.com/FOGProject/fogproject/pull/1182)
(the Password tab is gone for accounts that sign in through a directory) and
[#1183](https://github.com/FOGProject/fogproject/pull/1183) (the way back).

Both need saying, because the visible symptom is **a tab that is missing with no
obvious reason**, and the recovery is a checkbox somebody has to know to look
for.

## The warning matters more than the instructions

Whether the account can still sign in through its provider after returning it to
local login depends on which provider it is, and the answers are **opposite**:

- **LDAP** sign-in stops. FOG only takes LDAP's word for an account carrying the
  source stamp — that restriction is what stops a plugin authenticating a local
  account — so removing the stamp removes the LDAP login with it.
- **OIDC** is unaffected. It never reaches FOG's password check at all.

Both end at the same instruction, so the callout leads with that: set a password
in the same sitting.

## Also says what the page deliberately cannot do

Handing an account *to* a directory takes its local password away — the direction
that locks an install out of itself — and that is not something a
general-details form should do as a side effect.

`local-login.md`'s "who can actually use it" section links across to the recovery,
since it is that page's own answer to *"so this account cannot reach the
break-glass login — now what?"*

## Verification

`npm run docs:build` → 107 files, 927 emitted, no errors. Confirmed the new
cross-page heading anchor resolves in the built HTML
(`users#returning-an-account-to-a-fog-password`) and that no `[[` survives into
either page.
