### PR TITLE
Say when Keycloak needs no post-logout URI registered at all

### DIFF
--- a/docs/management/web/oidc.md
+++ b/docs/management/web/oidc.md
@@ -363,6 +363,15 @@ Where to put it: **Keycloak** — the client's *Valid post logout redirect
 URIs*. **Entra ID** — the app registration's *Front-channel logout URL*.
 **Okta** — the application's *Sign-out redirect URIs*.
 
+>[!tip] Keycloak may already accept it
+>Leave *Valid post logout redirect URIs* **empty** and Keycloak treats it
+>as `+`, meaning "the same list as the sign-in redirect URIs". So a client
+>registered with `https://fog.example.com/fog/*` already accepts this
+>value, and there is nothing to add. Fill the field in and that
+>inheritance stops — from then on the list is exactly what you typed, and
+>the sign-out value has to be in it. Check before you go looking for a
+>problem you do not have.
+
 >[!warning] This value changed in plugin v1.6.10
 >On v1.6.9 it was `…/management/login.php`. If you turned Single Logout on
 >at that version, re-register the new value — providers that follow the


### PR DESCRIPTION
The OIDC page told everyone to go and register the sign-out URI. On Keycloak that is often a wasted trip: leaving *Valid post logout redirect URIs* empty makes it `+`, which inherits the sign-in redirect URIs — so a client registered with a `/fog/*` wildcard already accepts the value FOG shows.

Verified against the live Keycloak 26 lab client with the field empty:

| `post_logout_redirect_uri` | Result |
|---|---|
| `https://10.255.20.1/fog/management/index.php` | 302, accepted |
| `https://10.255.20.1/fog/management/login.php` | 302, accepted |
| `https://example.com/nope` | 400, rejected |

So the validation is genuinely on and genuinely inheriting — this is not "Keycloak doesn't check".

The note also states the part that bites later: filling the field in ends the inheritance, so an install that adds one entry by hand has to add the sign-out value too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aBSWrDArXHTpKWkkN27LR