### PR TITLE
Document netboot transport and PKI, and retire the mutual-exclusion claim

### DIFF
--- a/docs/installation/network-setup/proxy-dhcp.md
+++ b/docs/installation/network-setup/proxy-dhcp.md
@@ -192,20 +192,31 @@ systemctl enable dnsmasq.service
 ## The client downloads iPXE but then fails to reach FOG
 
 dnsmasq's only job is to get the client to TFTP-download the iPXE binary
-(`undionly.kkpxe` / `snponly.efi`). After that, the iPXE binary chainloads
-`tftp://<fog_server_IP>/default.ipxe`, which in turn chainloads your FOG
-server's boot script over HTTP/HTTPS. If the client loads iPXE but then hangs
-or errors when contacting FOG, the dnsmasq config is usually fine and the
-problem is downstream:
+(`undionly.kkpxe` / `snponly.efi`). What happens next depends on the firmware
+mode. Every UEFI binary FOG ships is built **without** its boot script compiled
+in, so iPXE fetches `autoexec.ipxe` from the TFTP root and runs that; the BIOS
+builds carry their script internally and ignore the file — see
+[[dhcp-server-settings#How UEFI clients get their boot script|How UEFI clients get their boot script]].
+Either way the script chainloads `tftp://<fog_server_IP>/default.ipxe`, which in
+turn chainloads your FOG server's boot script over HTTP or HTTPS. Which of those
+two it is depends on `netbootproto`, not on how you reach the web interface —
+see [[netboot-transport-and-pki|Netboot Transport and PKI]].
+
+If the client loads iPXE but then hangs or errors when contacting FOG, the
+dnsmasq config is usually fine and the problem is downstream:
 
 > [!note] FOG 1.6 + HTTPS
-> If you answered **yes** to enabling HTTPS during the FOG 1.6 install, the web
-> server is configured to redirect all HTTP traffic to HTTPS (plus HSTS). The
-> installer rebuilds the iPXE binaries to trust your server's certificate so the
-> HTTPS chainload works, but this only happens for the binaries served from that
-> server's own `/tftpboot`. Make sure dnsmasq's `tftp-root` points at the FOG
-> server's `/tftpboot` (or that the files are copied from it), not an older or
-> hand-built set of binaries — otherwise the HTTPS chainload will fail with a
+> A 1.6 install serves the web interface over HTTPS by default, but **netboot
+> stays on HTTP** unless you asked for otherwise — they are separate settings.
+> The HTTP→HTTPS redirect is off by default as well, and the installer only
+> recompiles the iPXE binaries if you chose `--install-mode embed-ca` or passed
+> `--rebuild-ipxe-with-my-ca`. See
+> [[netboot-transport-and-pki|Netboot Transport and PKI]] for which combination
+> you want.
+>
+> If netboot *is* on HTTPS, make sure dnsmasq's `tftp-root` points at the FOG
+> server's own `/tftpboot` (or that the files are copied from it), not an older
+> or hand-built set of binaries — otherwise the chainload will fail with a
 > certificate error after iPXE loads.
 
 ## Serving ProxyDHCP to multiple subnets
@@ -315,11 +326,17 @@ outright rather than half-completing it, and 1.6 hides the "Enroll Secure Boot
 Key" boot-menu entry from clients that booted in BIOS/CSM mode for the same
 reason: an option that cannot succeed should not be offered.
 
-> [!warning] Secure Boot and HTTPS are mutually exclusive
-> An HTTPS FOG install rebuilds iPXE locally so the binary trusts your server's
-> CA. A signed binary cannot be rebuilt without destroying its signature, so the
-> Secure Boot binaries are upstream's generic ones and cannot carry your CA. Use
-> one or the other, not both.
+> [!note] Secure Boot and HTTPS are not mutually exclusive
+> Earlier versions of this page said they were. They are not, and FOG 1.6 stages
+> the Secure Boot binaries in **every** install mode, HTTPS included.
+>
+> An HTTPS *web interface* has no bearing on netboot at all — netboot has its own
+> protocol setting. And HTTPS *netboot* only needs a rebuilt iPXE when your
+> certificate comes from a private CA: iPXE cross-certifies public roots on its
+> own, so a publicly-issued certificate on an FQDN needs no rebuild and keeps the
+> signed shim. Where a rebuild genuinely is required, FOG signs the result with
+> this server's own Secure Boot key and shim loads it once that key is enrolled.
+> See [[netboot-transport-and-pki|Netboot Transport and PKI]].
 
 > [!important] The boot file is only half of Secure Boot
 > Getting a signed iPXE to load is the part dnsmasq controls. The FOS kernel FOG

--- a/docs/kb/integrations/external-ca-lets-encrypt.md
+++ b/docs/kb/integrations/external-ca-lets-encrypt.md
@@ -196,9 +196,10 @@ What the installer does with these files:
 4. Exports the **intermediate** as `ca.cert.der` — this is what fog-client
    pins. (Pinning the root would break client validation, because the root
    is not what directly signs the server cert.)
-5. Passes the full chain to the web server, and — if you're baking a CA
-   into iPXE for HTTPS netboot, see
-   [[pki-zones#https-and-netboot|HTTPS and netboot]] — to the iPXE build.
+5. Passes the full chain to the web server, and — only if you asked for the
+   iPXE rebuild with `--rebuild-ipxe-with-my-ca` or `--install-mode embed-ca`
+   — to the iPXE build. A public certificate needs no rebuild; see
+   [[netboot-transport-and-pki|Netboot Transport and PKI]].
 
 The relevant values are persisted to `.fogsettings` so re-running the
 installer reuses them. If the source files are no longer readable on a
@@ -345,12 +346,15 @@ trust:
      regenerated against the new CA.
   2. Have every host's fog-client **re-pin** the new `ca.cert.der` (re-run
      the client installer or whatever your re-registration flow is).
-  3. If you're using a baked-in-CA iPXE build for netboot HTTPS, have PXE
-     clients pull the **rebuilt iPXE binaries** too.
+  3. If you run `embed-ca` — a baked-in-CA iPXE build for netboot HTTPS —
+     have PXE clients pull the **rebuilt iPXE binaries** too. Sites on a
+     public certificate have nothing to rebuild.
 
-There is currently **no** automated client re-pinning or iPXE-rebuild
-trigger on renewal. Plan your CA lifetimes accordingly: long-lived, stable
-intermediates, short-lived leaves.
+There is currently **no** automated client re-pinning on renewal, and nothing
+schedules an installer run. The rebuild itself is at least self-correcting: the
+installer stamps the CA it built against, so a changed CA forces a rebuild on
+the next run rather than leaving stale binaries in place. Plan your CA
+lifetimes accordingly: long-lived, stable intermediates, short-lived leaves.
 
 ---
 
@@ -362,8 +366,9 @@ existing web certificate no longer verifies against the new chain and
 prints a warning: the web cert is regenerated under the new CA, and **any
 host whose fog-client already pinned the old certificate will not trust the
 server until it re-pins**. Re-run the fog-client installer after the
-switch. If you're also relying on a baked-in-CA iPXE build for HTTPS
-netboot, reboot PXE clients so they pull the rebuilt binary too.
+switch. If you also run `embed-ca`, reboot PXE clients so they pull the
+rebuilt binary too — the rebuild happens on that same installer run, because
+the embedded CA changed.
 
 ---
 

--- a/docs/kb/reference/compile_ipxe_binaries.md
+++ b/docs/kb/reference/compile_ipxe_binaries.md
@@ -2,146 +2,190 @@
 title: Compile iPXE binaries
 aliases:
     - Compile iPXE binaries
-description: index page for compile_ipxe_binaries
+    - Build iPXE
+    - buildipxe.sh
+description: How FOG builds its iPXE binaries, how to build your own, and what embedding a CA costs you under Secure Boot
 context_id: compile_ipxe_binaries
 tags:
-    - in-progress
+    - reference
     - ipxe
-    - how-to
+    - netboot
+    - secure-boot
     - linux
 ---
 
 # Compile iPXE binaries
 
-FOG is using the most current iPXE source code to build many different
-PXE binaries, some being undionly and others specific for NICs made by
-intel or realtek - BIOS and UEFI compatible. But still you might want to
-build your own binary to suit your needs (be it a custom script or
-debugging enabled). Here you'll find some hints on how to build your
-own iPXE binaries.
+FOG builds a set of iPXE binaries — `undionly.kkpxe` for BIOS, and `snponly`,
+`ipxe`, `snp`, `intel` and `realtek` variants for each UEFI architecture. You
+might want to build your own to embed a custom script, add a driver, or turn on
+debug output. This page covers how FOG does it and how to do it yourself.
 
-## Prerequisites
+>[!important] You almost certainly do not need to do this
+>A normal install **downloads** prebuilt binaries from the `fog-ipxe` release
+>matching this FOG version. The installer only compiles iPXE when you ask it to
+>with `--rebuild-ipxe-with-my-ca` or `--install-mode embed-ca`, which is needed
+>solely to embed a **private** CA for HTTPS netboot. A certificate from a public
+>CA needs no rebuild at all — see
+>[[netboot-transport-and-pki|Netboot Transport and PKI]].
 
-To be able to build iPXE from source you need tools to checkout and
-compile source code.
+## Where the source lives
 
-    debian/ubuntu# sudo apt-get install git build-essential zlib1g-dev binutils-dev
-    fedora/centos# sudo yum install git gcc gcc-c++ make zlib-devel binutils-devel genisoimage isomd5sum syslinux xz xz-devel
+FOG's iPXE is its own repository, **[FOGProject/fog-ipxe](https://github.com/FOGProject/fog-ipxe)**,
+pinned to an exact release tag by `FOG_IPXE_VERSION` in
+`packages/web/lib/fog/system.class.php`. The installer clones it to
+`/opt/fog/ipxe` and checks out that tag.
 
-## Build script
+It is not a fork that tracks upstream loosely. It is upstream iPXE at a fixed
+tag, plus three things:
 
--   PXE boot any computer and record the build code listed on the iPXE
-    banner. The build code is a hex number inside the brackets (e.g.
-    `iPXE 1.21.1+ (gc64d) ...`). We will compare this build code in a
-    later step to ensure your iPXE boot loader files have been updated.
--   Navigate to where you downloaded the FOG installer using git.
-    Depending on which directions you followed these files will be in
-    either /opt or /root. The parent directory we are looking for is
-    called fogproject. For the remainder of this tutorial I'll assume
-    the fogproject directory is in the /root directory, you will need to
-    adjust the file paths based on your fogproject path.
--   Navigate to `/root/fogproject/utils/FOGiPXE` directory
--   Run the compile script using this command `./buildipxe.sh`
-    (**Note:** your fog server will need internet access to recompile
-    iPXE. It should take about 10 minutes to recompile iPXE - depends on
-    the CPU/RAM in your machine.)
--   When the compile is done you will be presented with a command prompt
-    once again. Understand the buildipxe.sh script only compiles the
-    iPXE binaries. It does not install them in your production
-    environment.
--   The proper way to update your production environment is to re-run
-    the fog installer using all of the preselected options. Reinstalling
-    fog using the fog installer is not destructive, the installer
-    remembers your previous settings and just updates any new files into
-    your production environment.
--   The hacker way to update your production environment is to copy over
-    the updates files to the /tftpboot directory with this command
-    `cp -R /root/fogproject/packages/tftp/* /tftpboot` (**Note:** watch
-    the source path if your git fogproject directory is not in the
-    `/root/fogproject` directory)
--   Run the following command to ensure your iPXE files have a current
-    date on them: `ls -la /tftpboot/*.efi`
--   Now PXE boot the client and confirm that the build code (in the
-    brackets) has changed from the previous step. **Note:** The build
-    code does not change on every re-compile you do but only if there is
-    a newer version available.
+| Component | What it is |
+|---|---|
+| `src/config/` and `src-efi/config/` | Replacements for `console.h`, `general.h` and `settings.h` only |
+| `patches/` | C changes applied after a `git reset --hard`, against the pinned tag |
+| `buildipxe.sh` | The build driver FOG's installer calls |
+
+The config overlay deliberately **does not** touch `crypto.h`. That matters:
+upstream unconditionally defines a cross-signing endpoint there
+(`CROSSCERT "http://ca.ipxe.org/auto"`), which is what lets any iPXE binary —
+FOG's or upstream's — validate a publicly-issued certificate with nothing baked
+in. Replacing `crypto.h` would silently remove that.
+
+`patches/` currently carries `0001-x509-enforce-name-constraints.patch`, which
+teaches iPXE to *enforce* X.509 name constraints instead of refusing to parse
+them. Without it, FOG's own name-constrained Web CA cannot be read by iPXE at
+all and HTTPS netboot fails with `Operation not supported`. The build fails
+loudly if a patch stops applying, rather than quietly producing a binary
+without it.
+
+## Building with FOG's script
+
+```bash
+git clone https://github.com/FOGProject/fog-ipxe /opt/fog/ipxe
+cd /opt/fog/ipxe
+git checkout v2.0.0-fog.8          # match FOG_IPXE_VERSION for your install
+./buildipxe.sh <ca-certificate.pem> <output-directory>
+```
+
+The first argument is the CA certificate to embed; the second is where the
+binaries are written. The FOG installer passes its own trust anchor and its TFTP
+staging directory. Expect **10–25 minutes**; there is no incremental path.
+
+To then put the result into production, re-run the FOG installer with your
+existing options. That is non-destructive — it reuses your saved settings — and
+it also re-signs the binaries, which copying them by hand does not.
+
+## Embedding a CA, and what it costs
+
+Embedding is done with iPXE's `TRUST=` and `CERT=` build arguments. Two
+properties are worth knowing:
+
+- **`TRUST=` is additive, not exclusive.** Baking in your CA pins it as an extra
+  root; it does not remove the `ca.ipxe.org` fallback described above.
+- **A rebuilt binary is no longer Microsoft-signed.** Upstream's signed release
+  binaries are signed as-built; changing a byte voids that.
+
+>[!warning] A rebuild moves a Secure Boot machine's enrolment earlier
+>FOG signs every EFI binary in its TFTP tree with this server's own Secure Boot
+>signing key, so a rebuilt binary is not unsigned — upstream's signed shim will
+>load it once that key is enrolled as a MOK. But it has to be enrolled
+>**first**, before the machine can netboot at all, which reverses the usual
+>order. See [[secure-boot-mok-enrollment|Secure Boot MOK Enrollment]].
+
+If you build binaries yourself and copy them into `/tftpboot` by hand, they
+carry **no** FOG signature and Secure Boot clients will refuse them. Re-run the
+installer instead, or sign them yourself — see
+[[secure-boot-technical-details|Secure Boot Technical Details]].
+
+## Prerequisites for a manual build
+
+```bash
+# debian/ubuntu
+sudo apt-get install git build-essential zlib1g-dev binutils-dev liblzma-dev mtools
+# fedora/rhel
+sudo dnf install git gcc gcc-c++ make zlib-devel binutils-devel xz-devel mtools
+```
+
+Add `genisoimage`/`isomd5sum`/`syslinux` if you want the `.iso` targets, and
+`sbsigntools` if you intend to sign what you build.
 
 ## Manual compilation
 
-Checkout the code and download our config header files from github. The
-header files need to be a little different for BIOS and UEFI and
-therefore I usually checkout the source twice to have one ready for each
-platform.
+`buildipxe.sh` is the supported path. If you want to drive `make` directly, work
+inside a `fog-ipxe` checkout so you get the config overlay and the patches
+rather than assembling them yourself:
 
-    mkdir ~/projects/ipxe
-    cd ~/projects/ipxe
-    git clone git://git.ipxe.org/ipxe.git ipxe-bios
-    cd ipxe-bios/src/config
-    rm console.h general.h settings.h
-    wget -O console.h "https://github.com/FOGProject/fogproject/raw/master/src/ipxe/src/config/console.h"
-    wget -O general.h "https://github.com/FOGProject/fogproject/raw/master/src/ipxe/src/config/general.h"
-    wget -O settings.h "https://github.com/FOGProject/fogproject/raw/master/src/ipxe/src/config/settings.h"
-    cd ..
-    wget -O ipxescript "https://github.com/FOGProject/fogproject/raw/master/src/ipxe/src/ipxescript"
+```bash
+git clone https://github.com/FOGProject/fog-ipxe ~/projects/fog-ipxe
+cd ~/projects/fog-ipxe
+git checkout v2.0.0-fog.8
+```
 
-    cd ~/projects/ipxe
-    git clone git://git.ipxe.org/ipxe.git ipxe-efi
-    cd ipxe-efi/src/config
-    rm console.h general.h settings.h
-    wget -O console.h "https://github.com/FOGProject/fogproject/raw/master/src/ipxe/src-efi/config/console.h"
-    wget -O general.h "https://github.com/FOGProject/fogproject/raw/master/src/ipxe/src-efi/config/general.h"
-    wget -O settings.h "https://github.com/FOGProject/fogproject/raw/master/src/ipxe/src-efi/config/settings.h"
-    cd ..
-    wget -O ipxescript "https://github.com/FOGProject/fogproject/raw/master/src/ipxe/src-efi/ipxescript"
+BIOS targets are built from `src/` **with** the boot script compiled in:
 
-## Bake the cake
+```bash
+cd ~/projects/fog-ipxe/src
+make bin/undionly.kkpxe EMBED=ipxescript
+make bin/ipxe.pxe       EMBED=ipxescript
+make bin/intel.pxe      EMBED=ipxescript
+```
 
-Now you are ready to build your iPXE binaries from source. But how do
-you do that? One simple call but it can be heavily customized with
-parameters.
+UEFI targets are built from `src-efi/` **without** `EMBED=`:
 
-    # Build a simple BIOS binaries including an embedded script (executed right when iPXE comes up)
-    cd ~/projects/ipxe/ipxe-bios/src
-    make bin/undionly.kpxe EMBED=ipxescript
-    make bin/ipxe.pxe EMBED=ipxescript
-    make bin/undionly.kkpxe EMBED=ipxescript
-    make bin/intel.pxe EMBED=ipxescript
-    ...
+```bash
+cd ~/projects/fog-ipxe/src-efi
+make bin-x86_64-efi/snponly.efi
+make bin-x86_64-efi/ipxe.efi
+make bin-x86_64-efi/snp.efi
+make bin-i386-efi/snponly.efi
+make bin-arm64-efi/snponly.efi
+```
 
+>[!important] Do not add `EMBED=` to a UEFI target
+>Since `v2.0.0-fog.8` no EFI binary carries its script internally — they read
+>`autoexec.ipxe` from the directory they were loaded from. An `EMBED=`-marked
+>EFI binary still *downloads* `autoexec.ipxe` and then never runs it, and the
+>orphaned script gets concatenated ahead of `init.xz`, so the kernel panics with
+>`VFS: Unable to mount root fs on "/dev/ram0"`. BIOS builds have no such path
+>and still embed. See
+>[[dhcp-server-settings#How UEFI clients get their boot script|How UEFI clients get their boot script]].
 
-    # simple 32 bit EFI binaries with embedded script
-    cd ~/projects/ipxe/ipxe-efi/src
-    make bin-i386-efi/ipxe.efi EMBED=ipxescript
-    make bin-i386-efi/snponly.efi EMBED=ipxescript
-    make bin-i386-efi/intel.efi EMBED=ipxescript
-    ...
+To embed a CA by hand, add it to either command:
 
-    # simple 64 bit EFI binaries
-    cd ~/projects/ipxe/ipxe-efi/src
-    make bin-x86_64-efi/ipxe.efi EMBED=ipxescript
-    make bin-x86_64-efi/snponly.efi EMBED=ipxescript
-    make bin-x86_64-efi/intel.efi EMBED=ipxescript
-    ...
+```bash
+make bin-x86_64-efi/snponly.efi TRUST=/opt/fog/pki/root/ca/.fogCA.pem
+```
 
 ## Debugging
 
-Now we are getting to the interesting part of adding debug output to
-iPXE to be able to better find issues. Each and every c-file in the iPXE
-source can be compiled with debug enabled. Here is an example:
+Every C file in the iPXE source can be compiled with debug output enabled:
 
-    make bin/realtek.kpxe EMBED=ipxescript DEBUG=realtek
+```bash
+make bin/realtek.kpxe EMBED=ipxescript DEBUG=realtek
+```
 
-Most of the native drivers consist of just one source file. Have a look
-at src/drivers/net to see them - 3c509, bnx2, forcedeth, intel, pcnet32,
-realtek, rhine and many more.
+Most native drivers are a single source file — see `src/drivers/net` for the
+list: 3c509, bnx2, forcedeth, intel, pcnet32, realtek, rhine and many more.
 
-The most commonly used binaries ipxe.pxe and ipxe.efi include UNDI
-interface as well as all the native drivers. You can add debugging
-selectively. Check out the source code. Here are some more examples:
+`ipxe.pxe` and `ipxe.efi` include the UNDI interface as well as all native
+drivers, so you can enable debugging selectively:
 
-    make ... DEBUG=dhcp
-    make ... DEBUG=device,efi_driver,efi_init,efi_pci,efi_snp
-    make ... DEBUG=snp,snponly,snpnet,netdevice
-    make ... DEBUG=intel:4
-    make ... DEBUG=undi
-    ...
+```bash
+make ... DEBUG=dhcp
+make ... DEBUG=device,efi_driver,efi_init,efi_pci,efi_snp
+make ... DEBUG=snp,snponly,snpnet,netdevice
+make ... DEBUG=intel:4
+make ... DEBUG=undi
+```
+
+To confirm a client actually picked up a new build, note the build code in the
+iPXE banner before and after — the hex string in brackets, e.g.
+`iPXE 1.21.1+ (gc64d) ...`. It only changes when the source does, not on every
+recompile.
+
+## See also
+
+- [[netboot-transport-and-pki|Netboot Transport and PKI]] — when a rebuild is and is not needed
+- [[secure-boot-technical-details|Secure Boot Technical Details]] — how FOG signs what it builds
+- [[pki-zones|FOG PKI Infrastructure]] — the CA you would be embedding
+- [[dhcp-server-settings|DHCP server settings]] — which binary to point clients at

--- a/docs/kb/reference/index.md
+++ b/docs/kb/reference/index.md
@@ -17,6 +17,14 @@ Reference material i.e. information on settings files, command line options, etc
 - [[hardware|Supported Hardware]]
 - [[fog-security|FOG Security]]
 
+**Certificates & Secure Boot**
+
+- [[netboot-transport-and-pki|Netboot Transport and PKI]]
+- [[pki-zones|FOG PKI Infrastructure]]
+- [[pki-glossary|PKI Glossary]]
+- [[bringing-your-own-ca|Bringing Your Own CA]]
+- [[secure-boot-technical-details|Secure Boot Technical Details]]
+
 **Imaging internals**
 
 - [[lvm-imaging|LVM and Imaging]]

--- a/docs/kb/reference/netboot-transport-and-pki.md
+++ b/docs/kb/reference/netboot-transport-and-pki.md
@@ -29,6 +29,22 @@ This page covers that choice. For what the certificates themselves are and how
 they are laid out on disk, see [[pki-zones|FOG PKI Infrastructure]]. For the
 vocabulary, see [[pki-glossary|PKI Glossary]].
 
+>[!note] Terms used on this page
+>**Netboot** is the PXE/UEFI network boot: the client asks DHCP where to boot,
+>loads iPXE, and iPXE fetches FOG's boot script over HTTP or HTTPS.
+>
+>**FQDN — fully qualified domain name.** The server's complete DNS name, such
+>as `fog.example.com`, rather than a short name (`fog`) or an IP address.
+>
+>**MOK — Machine Owner Key.** A certificate enrolled into an individual
+>machine's firmware so Secure Boot will accept binaries signed by it. **shim**
+>is the Microsoft-signed loader that checks for it.
+>
+>**ACME** is the protocol certificate authorities like Let's Encrypt use to
+>issue and renew certificates automatically. **CA** is a certificate authority;
+>a **public** one is trusted out of the box by browsers and operating systems,
+>a **private** one is not.
+
 >[!info] FOG 1.6
 >Everything on this page is 1.6. In 1.5.x a single `httpproto` setting decided
 >the web protocol, the HTTP→HTTPS redirect and whether iPXE was recompiled, all

--- a/docs/kb/reference/netboot-transport-and-pki.md
+++ b/docs/kb/reference/netboot-transport-and-pki.md
@@ -1,0 +1,261 @@
+---
+title: Netboot Transport and PKI
+aliases:
+    - Netboot Transport and PKI
+    - Install Modes
+    - Netboot Transport
+    - HTTPS Netboot
+description: How FOG decides whether iPXE fetches its boot script over HTTP or HTTPS, what each install mode changes, and which certificate authority choices work alongside Secure Boot
+context_id: netboot-transport-and-pki
+tags:
+    - reference
+    - security
+    - certificates
+    - pki
+    - netboot
+    - ipxe
+    - secure-boot
+---
+
+# Netboot transport and PKI
+
+A booting client and a browser are not in the same position. Your browser can be
+told to trust FOG's certificate authority; iPXE, running out of firmware before
+any operating system exists, cannot. That single asymmetry is why FOG serves its
+web interface and its netboot fetches over **separately chosen protocols**, and
+why the certificate you put on the vhost decides what the netboot side can do.
+
+This page covers that choice. For what the certificates themselves are and how
+they are laid out on disk, see [[pki-zones|FOG PKI Infrastructure]]. For the
+vocabulary, see [[pki-glossary|PKI Glossary]].
+
+>[!info] FOG 1.6
+>Everything on this page is 1.6. In 1.5.x a single `httpproto` setting decided
+>the web protocol, the HTTP→HTTPS redirect and whether iPXE was recompiled, all
+>at once. Those are now separate settings, and the old behaviour of inferring one
+>from another is gone.
+
+## The four install modes
+
+`--install-mode` is a **preset**. It writes four independent settings in one go,
+and it is the easiest way to pick a coherent combination:
+
+| Mode | Web UI / API | Netboot | Rebuilds iPXE | Right for |
+|---|---|---|---|---|
+| `standard` *(default)* | HTTPS | HTTP | no | Almost everyone, including FOG's own CA |
+| `http-only` | HTTP | HTTP | no | Plain HTTP everywhere; what FOG did before 1.6 |
+| `public-cert` | HTTPS | **HTTPS** | no | A certificate from a public CA, on an FQDN |
+| `embed-ca` | HTTPS | **HTTPS** | **yes** | HTTPS netboot behind a private CA |
+
+The installer asks which one you want during an attended install. Under
+`-y`/`--autoaccept` it does not ask, and you get `standard` unless you passed
+something else.
+
+>[!important] A mode is a starting point, not a mode of operation
+>Nothing is locked once you pick one. Each of the four settings can be given on
+>its own, and a discrete option always overrides the preset's value for that one
+>field — `--install-mode public-cert --no-rebuild-ipxe-with-my-ca` means exactly
+>what it reads like. FOG does not record "which mode you are in" anywhere.
+
+## The settings underneath
+
+Each is an independent key in [[install-fogsettings|the .fogsettings file]], and
+no setting silently changes another:
+
+| Setting | Default | What it means |
+|---|---|---|
+| `httpproto` | `https` | The protocol FOG uses for its own **non-netboot** URLs |
+| `netbootproto` | `http` | The protocol iPXE uses to fetch `boot.php` |
+| `publicWebCert` | `no` | The web certificate chains to a **public** root |
+| `rebuildIpxeWithMyCA` | `no` | Recompile iPXE with your CA embedded in it |
+| `httpsRedirect` | `no` | Redirect HTTP to HTTPS, and send HSTS |
+| `acmeLeaf` | `no` | The leaf certificate is managed outside FOG |
+
+Two of them are statements of fact about your certificate rather than
+instructions: `publicWebCert` says **what the certificate chains to**, and
+`acmeLeaf` says **who renews it**. They are different questions and all four
+combinations are real — an internal ACME server such as step-ca is
+`acmeLeaf=yes` with `publicWebCert=no`. Either one tells FOG the certificate was
+issued somewhere else, so FOG will neither re-issue it nor lock its private key
+away from whatever renews it.
+
+### How the netboot protocol is decided
+
+1. If you passed `--netboot-proto`, that wins — and it is **remembered**, so a
+   later run without the option does not undo it.
+2. Otherwise it becomes `https` if **either** `publicWebCert=yes` **or**
+   `rebuildIpxeWithMyCA=yes`.
+3. Otherwise it is `http`.
+
+A value that FOG derived for you is re-derived on every run. That is deliberate:
+if you later turn off the thing that put netboot on HTTPS, netboot goes back to
+HTTP instead of outliving the reason it was there.
+
+You may force `--netboot-proto https` with neither trigger set. It is allowed,
+and the installer warns you, because iPXE cannot be told to trust a private CA
+at runtime — every client would fail the TLS handshake with nothing logged on
+the server.
+
+## Secure Boot is prepared in every mode
+
+**No install mode disables Secure Boot.** Every mode stages upstream's signed
+shim and loaders, and signs everything that did not arrive signed.
+
+This is worth stating plainly because FOG used to do the opposite. Until 1.6,
+enabling HTTPS caused the installer to skip staging the Secure Boot binaries
+altogether, on the reasoning that the two could not coexist. They can. The
+feature was missing precisely on the servers whose admins had gone furthest out
+of their way to configure TLS. If you have read that HTTPS and Secure Boot are
+mutually exclusive in FOG — including in older versions of these docs — that is
+the claim being corrected.
+
+What is never re-signed is upstream's own material: the shim, `mmx64.efi` /
+`mmaa64.efi`, and the signed loaders that shim vouches for. Adding FOG's
+signature to those would buy nothing. See
+[[secure-boot-technical-details|Secure Boot Technical Details]].
+
+## `public-cert`: HTTPS netboot with no rebuild
+
+If your web certificate chains to a **public** root, iPXE validates it with no
+change to the binary at all.
+
+Upstream iPXE unconditionally compiles in a cross-signing endpoint,
+`http://ca.ipxe.org/auto`. When it meets a chain it cannot otherwise validate it
+fetches a cross-signed certificate from there vouching for real-world public
+CAs, Let's Encrypt included. FOG's iPXE fork changes only iPXE's general,
+settings and console configuration — never its crypto configuration — so the
+fallback is live in every FOG-built binary. The republished Secure-Boot-signed
+binaries are upstream's own, built with no embedded CA whatsoever, so they rely
+on it entirely.
+
+That is why `public-cert` does not rebuild anything.
+
+>[!warning] It needs an FQDN, and it needs public DNS to resolve it
+>A certificate is issued to a **name**. No public CA will issue one for a private
+>IP address, and iPXE fails the handshake on a name mismatch even after the chain
+>itself validates. So HTTPS netboot addresses this server by hostname, and the
+>booting client has to resolve that name using the DNS servers DHCP hands it —
+>a prerequisite the IP-based URL never had.
+>
+>The installer refuses to write a boot script that would chain to an IP over
+>HTTPS, rather than completing cleanly and leaving you unable to boot anything.
+>The domain does not have to be reachable from the internet; a DNS-01 challenge
+>is enough to get the certificate. See
+>[[external-ca-lets-encrypt|External CA & Let's Encrypt Certificates]].
+
+>[!important] The cross-certificate is fetched by the **client**, not the server
+>`ca.ipxe.org` has to be reachable from the machine that is booting. On an
+>air-gapped network it is not, so a public certificate does not help there no
+>matter how public it is — use `embed-ca` instead.
+
+## `embed-ca`: a private CA, at the cost of an extra enrolment
+
+`embed-ca` recompiles iPXE with your certificate authority — FOG's own, or an
+external one you configured — baked in, so it can validate a chain no public
+root vouches for.
+
+It is the right answer for an air-gapped site, or anywhere HTTPS netboot must
+work behind a private CA. It is the wrong answer almost everywhere else, for
+three reasons.
+
+**It adds an enrolment step rather than removing one.** A binary carrying your
+CA is not upstream's Microsoft-signed binary any more. FOG signs it with this
+server's own Secure Boot signing key, and upstream's signed shim will happily
+load it — *once this server's MOK is enrolled in that machine's firmware*. So on
+a Secure Boot machine the MOK has to be enrolled **before** the machine can
+netboot at all, which is a different and harder ordering than the usual one,
+where a machine netboots first and enrols afterwards. See
+[[secure-boot-mok-enrollment|Secure Boot MOK Enrollment]].
+
+**It costs 10–25 minutes on every install and every update**, with no warm path.
+The rebuild is skipped only when the iPXE release, the embedded CA and the
+staged binaries are all unchanged.
+
+**It is not needed for a public certificate.** If your certificate chains to a
+public root, `public-cert` gets you the same HTTPS netboot with no rebuild and
+no extra enrolment.
+
+## If you supply your own CA, constrain it carefully
+
+FOG gives the authority that issues its web certificate a `nameConstraints`
+extension limiting which names it may issue for, and RFC 5280 requires that
+extension to be marked critical. iPXE now **enforces** name constraints rather
+than refusing to parse them, which is what makes HTTPS netboot work against
+FOG's own CA at all.
+
+The enforcement is deliberately strict, and it fails closed:
+
+- Only `dNSName` and `iPAddress` permitted subtrees are implemented. A CA
+  carrying any other subtree type — `directoryName`, `rfc822Name`, a URI — **will
+  not parse**, and the whole chain fails.
+- Any `minimum` or `maximum` on a subtree is likewise fatal at parse time.
+- Constraints bind every certificate below the constraining CA, not just the one
+  it signed directly, so a deep enterprise chain that used to work by accident
+  may now be correctly refused.
+- A separate trap: a root with `pathlen:0` cannot anchor FOG's intermediate at
+  all. The installer refuses to continue rather than issuing something that
+  cannot validate.
+
+If you are handing FOG an enterprise intermediate, either leave it unconstrained
+or constrain it with `dNSName`/`iPAddress` subtrees only. See
+[[bringing-your-own-ca|Bringing Your Own CA]].
+
+## Why the HTTPS redirect is off by default
+
+`httpsRedirect` is not part of any mode, and no mode turns it on.
+
+Trust in FOG's own certificate authority reaches a client machine when
+**fog-client installs it into that machine's trusted root store**. On a fresh
+server nothing has fog-client yet, so those machines have no inherited trust —
+and a forced redirect would break exactly the machines that cannot fix
+themselves. It is a setting to turn on once trust is in place, not a default.
+
+The redirect also carries HSTS, which is the sharper half: a browser that has
+seen an HSTS header refuses plain HTTP for months from its own cache, and no
+server-side change reaches it. Turning the redirect on is easy to undo on the
+server and hard to undo in a browser.
+
+>[!note] Port 443 always listens
+>Every install serves HTTPS whether or not the redirect is on. Turning the
+>redirect on decides whether plain HTTP is *refused*, not whether HTTPS is
+>*available*.
+
+## Set FOG_WEB_HOST before relying on HTTPS netboot
+
+The boot script the installer writes chains to this server by hostname. But once
+that first request reaches `boot.php`, FOG builds every subsequent boot URL — the
+kernel, the init, the background image, `MOK.der`, the MokManager binary — from
+the **`FOG_WEB_HOST`** setting in the web interface, not from the boot script.
+
+On a first install `FOG_WEB_HOST` is seeded with the server's IP address, and
+upgrades leave it alone. So on `public-cert` or `embed-ca` the first hop succeeds
+over HTTPS and every later fetch is attempted against `https://<IP>/`, which
+fails iPXE's name check.
+
+**Set `FOG_WEB_HOST` to the same FQDN the certificate is issued to** — FOG
+Configuration → FOG Settings → Web Server → `FOG_WEB_HOST` — whenever netboot is
+on HTTPS. Nothing in the installer does this for you.
+
+## Air-gapped networks
+
+| You have | Use |
+|---|---|
+| No route to `ca.ipxe.org` from the boot VLAN | `embed-ca`, and enrol the MOK first |
+| A public certificate but no outbound access | `standard` — netboot over HTTP |
+| No requirement for netboot TLS | `standard`. This is the default for good reason |
+
+Netboot over HTTP is not a security failure. The boot script and kernel are
+served to a machine that has no secrets yet, on a network segment you control,
+and FOG's Secure Boot signing is what establishes that the kernel is genuine —
+not the transport. See [[fog-security|FOG Security]].
+
+## See also
+
+- [[pki-zones|FOG PKI Infrastructure]] — the three certificate zones and the layout on disk
+- [[bringing-your-own-ca|Bringing Your Own CA]] — replacing FOG's authorities per zone
+- [[external-ca-lets-encrypt|External CA & Let's Encrypt Certificates]] — ACME, step-ca and public certificates
+- [[secure-boot-signing|Secure Boot Signing]] — how the signed chain is put together
+- [[secure-boot-mok-enrollment|Secure Boot MOK Enrollment]] — enrolling this server's key on a client
+- [[command-line-options|Fog installer command line options]] — every option named here
+- [[install-fogsettings|The .fogsettings file]] — where these settings persist
+- [[compile_ipxe_binaries|Compile iPXE binaries]] — building iPXE by hand

--- a/docs/kb/reference/pki-zones.md
+++ b/docs/kb/reference/pki-zones.md
@@ -316,9 +316,12 @@ FOG's own CA the way fog-client is:
 
 | Web certificate issued by | Web UI / API / fog-client | iPXE netboot |
 |---|---|---|
-| Public CA (Let's Encrypt) | HTTPS, trusted natively | **HTTPS works**, FQDN only |
-| FOG's own PKI (this page) | HTTPS once `ca.cert.der` is trusted | HTTP |
-| Your internal PKI | HTTPS once your root is trusted | HTTP |
+| Public CA (Let's Encrypt) | HTTPS, trusted natively | **HTTPS with no rebuild**, FQDN only |
+| FOG's own PKI (this page) | HTTPS once `ca.cert.der` is trusted | HTTP by default; HTTPS with `embed-ca` |
+| Your internal PKI | HTTPS once your root is trusted | HTTP by default; HTTPS with `embed-ca` |
+
+The full decision, including what each install mode sets and what `embed-ca`
+costs, is in [[netboot-transport-and-pki|Netboot Transport and PKI]].
 
 Stock iPXE ships an unconditional public-CA fallback
 (`ca.ipxe.org`) that cross-signs real-world public roots — Let's Encrypt
@@ -329,20 +332,26 @@ So a web certificate from a public CA on an FQDN gets you HTTPS netboot with
 on a fully air-gapped network with no route to `ca.ipxe.org`.
 
 Getting HTTPS netboot to work with FOG's own or your internal (non-publicly
-trusted) CA instead means rebuilding iPXE with that CA baked in
-(`TRUST=`) — and that rebuilt binary is not upstream's signed one, so it
-forfeits the signed Secure Boot shim. The only way to get HTTPS netboot,
-Secure Boot, and an internal CA all at once is enrolling that CA directly
-into UEFI firmware (`db`/`KEK`/`PK`, "Setup Mode" — see
-[[secure-boot-signing|the Secure Boot guide]]), bypassing shim entirely.
-There is no mechanism for signing a custom-rebuilt iPXE binary with FOG's
-own Secure Boot signing certificate — the signed chain only ever covers
-upstream's unmodified binaries.
+trusted) CA instead means rebuilding iPXE with that CA baked in (`TRUST=`),
+which is what `--install-mode embed-ca` does. That rebuilt binary is not
+upstream's *Microsoft-signed* one — but it is not unsigned either. FOG signs
+every EFI binary in its own TFTP tree with this server's Secure Boot signing
+key, and upstream's signed shim will load it once that key has been enrolled
+as a MOK on the machine. So the trade is not "lose Secure Boot"; it is **enrol
+this server's key before the machine can netboot**, which reverses the usual
+order in which a machine netboots first and enrols afterwards. See
+[[secure-boot-mok-enrollment|Secure Boot MOK Enrollment]].
 
-On a **fresh** install with HTTPS enabled and FOG's own PKI, netboot stays
-on HTTP automatically while everything else is HTTPS, avoiding that trade
-by default. An **existing** server keeps whatever it's already doing.
-Override either way with `--netboot-proto http|https`.
+Enrolling your CA directly into UEFI firmware (`db`/`KEK`/`PK`, "Setup Mode" —
+see [[secure-boot-setup-mode-enrollment|Secure Boot Setup Mode Enrollment]]) is
+an alternative that bypasses shim entirely, not the only route.
+
+Netboot stays on HTTP unless something asks otherwise, on fresh installs and
+existing servers alike. It moves to HTTPS when the web certificate is declared
+public (`publicWebCert`) or the rebuild is requested (`rebuildIpxeWithMyCA`).
+A value FOG derived is re-derived on every run, so turning the trigger back off
+returns netboot to HTTP. Override either way with `--netboot-proto http|https`,
+which is remembered.
 
 >[!note]
 >Public Let's Encrypt for netboot works only on an FQDN in a domain you


### PR DESCRIPTION
Part of `FOGProject/fogproject#1120` (Phase 3).

Adds `docs/kb/reference/netboot-transport-and-pki.md` and corrects the pages that contradict it.

## Why

FOG 1.6 split what 1.5 conflated into a single `httpproto`: the web protocol, the HTTP→HTTPS redirect and whether iPXE is recompiled are now independent keys with `--install-mode` as a preset over them. None of that was documented, and several pages still told admins the opposite.

## The flat contradiction

`proxy-dhcp.md` carried a callout titled **"Secure Boot and HTTPS are mutually exclusive"**. They are not. Every 1.6 install mode stages the Secure Boot binaries — the old installer skipped them on any HTTPS install, so the feature was missing precisely on the servers whose admins had gone furthest to configure TLS.

`pki-zones.md` said a rebuilt iPXE "forfeits the signed Secure Boot shim" and that there is no mechanism for signing a custom build with FOG's own key. FOG signs every EFI binary in its TFTP tree, and upstream's shim loads the result once the MOK is enrolled — so `embed-ca` moves the enrolment *earlier* rather than giving Secure Boot up, and Setup Mode is an alternative rather than the only route.

## Also

`compile_ipxe_binaries.md` had not been touched since 2024: cloned over `git://`, pointed its config-header `wget`s at fogproject's 1.5 tree rather than the `fog-ipxe` repo that now holds them, built 1.5-era target names, and said nothing about `TRUST=`. It now also warns against `EMBED=` on a UEFI target, which since `v2.0.0-fog.8` produces the `/dev/ram0` panic.

`kb/reference/index.md` was missing `pki-zones`, `pki-glossary`, `bringing-your-own-ca` and `secure-boot-technical-details`, so four existing pages were unreachable from their own index.

## The new page states plainly

- The FQDN and public-DNS prerequisite for `public-cert`, and why.
- `ca.ipxe.org` is fetched by the **booting client**, so air-gapped sites need `embed-ca` however public their certificate is.
- No mode disables Secure Boot.
- `embed-ca` **adds** an enrolment step.
- fog-client is what puts FOG's root into a client's trust store — the reason the redirect is off by default.
- `FOG_WEB_HOST` must be set to the certificate's FQDN before HTTPS netboot works past the first hop.

## Verified

Full Quartz build against this worktree: 108 files, no errors. Unparsed-wikilink count in the built HTML still 12 — all pre-existing, none in a file touched here.

**Merge this first** — the other four docs branches forward-reference the new page.
