### PR TITLE
Document local ESP boot, and stop saying FOG cannot sign its own iPXE

### DIFF
--- a/docs/installation/server/migrating-fog-server.md
+++ b/docs/installation/server/migrating-fog-server.md
@@ -334,8 +334,8 @@ re-enrolling.
 `--secure-boot-key`/`--secure-boot-cert`): make those same files available to
 the new server — copied to the same path, or anywhere else — and pass the same
 flags when installing it. Post-PKI those two flags name the code-signing
-**leaf**, and `--secureboot-ca-cert` (working-1.6) names the intermediate that
-is actually enrolled in firmware:
+**leaf**, and `--secureboot-ca-cert` names the intermediate that is actually
+enrolled in firmware:
 
 ```bash
 cd /path/to/fogproject/bin

--- a/docs/kb/how-tos/index.md
+++ b/docs/kb/how-tos/index.md
@@ -26,3 +26,12 @@ More advanced/situational guides:
 - [[deploy-dual-boot-multi-disk-image|Deploying a Dual-Boot Multi-Disk Image]]
 - [[add-extend-a-2nd-virtual-hdd|Add & Extend a 2nd Virtual HDD]]
 - [[post-download-scripts|Post Download Scripts]]
+- [[local-esp-boot|Local ESP Boot]]
+- [[firewall|Firewall configuration for a FOG server]]
+
+Secure Boot:
+
+- [[secure-boot-signing|Secure Boot - signing FOS with your own key]]
+- [[secure-boot-mok-enrollment|Secure Boot - MOK enrollment (Routes A and B)]]
+- [[secure-boot-setup-mode-enrollment|Secure Boot - Setup Mode enrollment (Route C)]]
+- [[unify-certificates-across-fog-servers|Unifying certificates across several FOG servers]]

--- a/docs/kb/how-tos/local-esp-boot.md
+++ b/docs/kb/how-tos/local-esp-boot.md
@@ -17,12 +17,32 @@ tags:
 
 # Local ESP boot
 
-Some machines cannot netboot. The NIC has no PXE option ROM, the switch takes
-too long to bring the link up, DHCP belongs to someone who will not add option
-66, or the firmware's PXE stack is simply broken. For those, FOG publishes a
-set of ready-made archives you copy onto the machine's own **EFI System
-Partition**. The machine then boots iPXE from its own disk and joins FOG from
-there — everything after that first hop is identical to a PXE boot.
+Some machines cannot netboot. The network card has no PXE option ROM, the
+switch takes too long to bring the link up, DHCP belongs to someone who will not
+add option 66, or the firmware's PXE stack is simply broken. For those, FOG
+publishes a set of ready-made archives you copy onto the machine's own **EFI
+System Partition (ESP)**. The machine then boots iPXE from its own disk and
+joins FOG from there — everything after that first hop is identical to a network
+boot.
+
+>[!note] Terms used on this page
+>**ESP — EFI System Partition.** A small FAT32 partition every UEFI machine has,
+>which the firmware reads boot loaders from. It is usually the first partition
+>on the disk and is normally not mounted while the operating system is running.
+>
+>**UEFI** is the firmware interface that replaced the traditional BIOS.
+>**PXE** is the network-boot mechanism this page is an alternative to.
+>
+>**shim** is a small, Microsoft-signed loader that Secure Boot machines will
+>accept, whose only job is to check and load the next stage.
+>
+>**MOK — Machine Owner Key.** A certificate you enrol into a machine's firmware
+>so Secure Boot will accept things signed by it — here, the binaries this FOG
+>server signed. **MokManager** is the little blue-screen tool shim launches to
+>let you enrol one.
+>
+>**SNP — Simple Network Protocol.** The UEFI firmware's own network driver.
+>Binaries named `snp`/`snponly` use it instead of iPXE's built-in drivers.
 
 >[!info] FOG 1.6
 >These archives are new in 1.6 and replace an earlier arrangement that published

--- a/docs/kb/how-tos/local-esp-boot.md
+++ b/docs/kb/how-tos/local-esp-boot.md
@@ -1,0 +1,177 @@
+---
+title: Local ESP Boot
+aliases:
+    - Local ESP Boot
+    - Boot FOG from the EFI System Partition
+    - ESP boot kits
+    - fog-esp archives
+description: Boot a machine into FOG from files on its own EFI System Partition when PXE is unavailable, using the fog-esp archives FOG publishes
+context_id: local-esp-boot
+tags:
+    - how-to
+    - netboot
+    - ipxe
+    - secure-boot
+    - uefi
+---
+
+# Local ESP boot
+
+Some machines cannot netboot. The NIC has no PXE option ROM, the switch takes
+too long to bring the link up, DHCP belongs to someone who will not add option
+66, or the firmware's PXE stack is simply broken. For those, FOG publishes a
+set of ready-made archives you copy onto the machine's own **EFI System
+Partition**. The machine then boots iPXE from its own disk and joins FOG from
+there — everything after that first hop is identical to a PXE boot.
+
+>[!info] FOG 1.6
+>These archives are new in 1.6 and replace an earlier arrangement that published
+>the same binaries loose in a browsable directory.
+
+## Getting the archives
+
+They are static files under your FOG server's web root:
+
+```
+<http|https>://<your-fog-server>/fog/service/localboot/manifest.json
+<http|https>://<your-fog-server>/fog/service/localboot/fog-esp-x86_64.zip
+```
+
+There is no index page and no directory listing — start from `manifest.json`,
+which names every archive the server actually built.
+
+| Archive | For |
+|---|---|
+| `fog-esp-x86_64.zip` | 64-bit UEFI, the usual case |
+| `fog-esp-arm64.zip` | ARM64 UEFI |
+| `fog-esp-i386.zip` | 32-bit UEFI |
+
+If the `zip` command was not installed when FOG last ran, the same content is
+published as `.tar.gz` instead. The manifest records the real filename either
+way, which is why you should read it rather than guessing the extension.
+
+>[!warning] The `-10sec` archives are currently not usable
+>The manifest also lists `fog-esp-x86_64-10sec` and `fog-esp-arm64-10sec`,
+>intended to carry binaries that wait ten seconds before their first DHCP
+>attempt. As of the current release those two archives ship **without** FOG's
+>own EFI binaries — the build they are sourced from is no longer produced — so
+>the `autoexec.ipxe` inside them refers to files that are not there. Use the
+>plain archive for your architecture. `--boot-delay` does not help here either;
+>it adjusts the TFTP server's boot script, not an ESP.
+
+>[!note] Kernels are listed, not shipped
+>`manifest.json` has a `kernels` array describing `bzImage` and `init.xz` for
+>each architecture, with paths relative to the manifest. Those are **not** in
+>the archives — the machine fetches them from the FOG server at boot, as it
+>would over PXE. The archive only has to get iPXE running.
+
+## Installing onto the ESP
+
+Mount the EFI System Partition and copy the **contents** of the extracted
+folder into a directory on it. `\EFI\FOG\` is the conventional place:
+
+```bash
+sudo mount /dev/sda1 /mnt/esp          # your ESP, usually the small FAT32 one
+sudo mkdir -p /mnt/esp/EFI/FOG
+sudo cp -r fog-esp-x86_64/* /mnt/esp/EFI/FOG/
+sudo umount /mnt/esp
+```
+
+Then add a firmware boot entry pointing at one of the entry points below — see
+[[uefi-boot-entries|Managing UEFI Boot Entries (efibootmgr)]] — or copy the
+entry point to `\EFI\BOOT\bootx64.efi` if you want it to be the machine's
+default.
+
+Do not extract two archives into the same folder. The FOG binaries in each are
+named identically, so they would overwrite each other.
+
+## Which entry point
+
+| Situation | Point the firmware at |
+|---|---|
+| Secure Boot **off** | `fogipxe.efi` |
+| Secure Boot **on**, via shim + MOK | `snponly-shimx64.efi` (or `ipxe-shimx64.efi`) |
+| Secure Boot **on**, via firmware Setup Mode | `fogipxe.efi`, after enrolling the `.auth` files |
+
+On arm64 the shim is `snponly-shimaa64.efi`. On i386 there is no shim at all —
+Microsoft signs none for 32-bit UEFI — so only the Secure Boot **off** and
+Setup Mode routes exist there.
+
+### The chain, once shim starts
+
+Shim establishes trust, then loads one of upstream's signed loaders from the
+same folder. That loader reads `autoexec.ipxe` out of the folder it was loaded
+from, and the script chains FOG's own build.
+
+>[!note] Which loader shim picks is not worth worrying about
+>Over the network, shim chooses its second stage by rewriting its own
+>`-shim<arch>` suffix — so `snponly-shimx64.efi` loads `snponly.efi`. That
+>rename happens on shim's network and HTTP boot paths; booted off a local
+>filesystem it may instead fall back to its compiled-in default, `ipxe.efi`.
+>Both loaders are in the archive precisely so that either behaviour works.
+
+The first time on a given machine, shim will not be able to verify FOG's binary
+and launches **MokManager** instead. Choose *Enroll key from disk*, select
+`MOK.der` from the same folder, and reboot. It boots unattended from then on.
+See [[secure-boot-mok-enrollment|Secure Boot MOK Enrollment]].
+
+For the Setup Mode route, put the firmware into Setup Mode and enrol `PK.auth`,
+`KEK.auth` and `db.auth` from the archive; the firmware then verifies FOG's
+signed binaries directly and shim is not involved. See
+[[secure-boot-setup-mode-enrollment|Secure Boot Setup Mode Enrollment]].
+
+## What is in an archive
+
+| File | What it is |
+|---|---|
+| `snponly-shim<arch>.efi`, `ipxe-shim<arch>.efi` | Upstream's Microsoft-signed shim, under two names |
+| `snponly.efi`, `ipxe.efi` | Upstream's signed iPXE loaders, which shim vouches for |
+| `mmx64.efi` / `mmaa64.efi` | MokManager, for enrolling the key |
+| `fogipxe.efi` | FOG's build, all NIC drivers |
+| `fogsnp.efi` | FOG's build, firmware SNP |
+| `fogintel.efi`, `fogrealtek.efi` | FOG's build, single-vendor drivers |
+| `fogsnponly.efi` | FOG's build, SNP on the load device only |
+| `autoexec.ipxe` | The script the signed loader runs |
+| `MOK.der`, `PK.auth`, `KEK.auth`, `db.auth` | Enrolment material for each route |
+| `fog-enroll-mok.sh`, `fog-enroll-mok.desktop` | Helpers for enrolling from a running Linux |
+| `MANIFEST.json`, `README.txt` | Inventory and instructions for this archive |
+
+The `fog` prefix is not cosmetic. `snponly.efi` and `ipxe.efi` are reserved for
+upstream's signed loaders, because those are the exact bytes shim's embedded
+certificate vouches for — FOG's own builds cannot use those names.
+
+`MANIFEST.json` records a `sha256`, a `role` and an `origin` for every file, and
+a `fogSigned` boolean that is *measured* from the file rather than assumed.
+
+## If the network never comes up
+
+Try the binaries in this order: `fogipxe.efi`, `fogsnp.efi`, `fogintel.efi`,
+`fogrealtek.efi`, `fogsnponly.efi`. `fogsnponly.efi` is last on purpose — it
+binds only the device iPXE was loaded from, which off an ESP is the disk, so it
+usually finds no NIC at all.
+
+>[!important] The fallback chain covers missing files, not wrong drivers
+>`autoexec.ipxe` already tries those five in order, but `chain X || goto Y`
+>branches **only when an image fails to load** — absent, malformed, or rejected
+>by shim. Once a binary loads and runs, control never returns: one that starts
+>cleanly and then binds no NIC stops at its own prompt, and the next branch is
+>never reached.
+>
+>So the ladder tells you which files got copied, not which driver works. **If it
+>is the wrong driver you have to change which file is there** — point the
+>firmware directly at the one you want.
+
+## What you give up
+
+Because these are archives rather than individual published files, **no single
+binary has a URL of its own** any more. Nothing under `service/localboot/` can
+be used as a UEFI HTTP Boot target or as an iPXE `chain` destination. If you
+need that, serve the file yourself from somewhere you control.
+
+## See also
+
+- [[secure-boot-mok-enrollment|Secure Boot MOK Enrollment]] — the shim + MokManager route
+- [[secure-boot-setup-mode-enrollment|Secure Boot Setup Mode Enrollment]] — the `db`/`KEK`/`PK` route
+- [[secure-boot-signing|Secure Boot Signing]] — what FOG signs, and with which key
+- [[uefi-boot-entries|Managing UEFI Boot Entries (efibootmgr)]] — adding the boot entry
+- [[netboot-transport-and-pki|Netboot Transport and PKI]] — the PXE path this replaces

--- a/docs/kb/how-tos/local-esp-boot.md
+++ b/docs/kb/how-tos/local-esp-boot.md
@@ -20,10 +20,15 @@ tags:
 Some machines cannot netboot. The network card has no PXE option ROM, the
 switch takes too long to bring the link up, DHCP belongs to someone who will not
 add option 66, or the firmware's PXE stack is simply broken. For those, FOG
-publishes a set of ready-made archives you copy onto the machine's own **EFI
-System Partition (ESP)**. The machine then boots iPXE from its own disk and
-joins FOG from there — everything after that first hop is identical to a network
-boot.
+publishes a set of ready-made archives holding everything needed to start iPXE
+from local storage — the machine's own **EFI System Partition (ESP)**, or a USB
+stick. It boots iPXE from there and joins FOG; everything after that first hop is
+identical to a network boot.
+
+The archive is deliberately more than one route. Depending on what the machine
+lets you do, you can lay it on the ESP, run it off a stick from a UEFI shell,
+have rEFInd present it as a menu entry, or use it purely to enrol a Secure Boot
+key on a machine that cannot reach the network yet.
 
 >[!note] Terms used on this page
 >**ESP — EFI System Partition.** A small FAT32 partition every UEFI machine has,
@@ -91,10 +96,48 @@ way, which is why you should read it rather than guessing the extension.
 >`service/localboot/` is deleted and regenerated each time the installer runs.
 >It is a publication point, not somewhere to keep anything.
 
-## Installing onto the ESP
+## Where to put the files
 
-Mount the EFI System Partition and copy the **contents** of the extracted
-folder into a directory on it. `\EFI\FOG\` is the conventional place:
+**This is a kit, not a procedure.** The same files work from the machine's own
+ESP, from a USB stick, or launched by a boot manager — the point is that you can
+pick whichever route the machine in front of you actually allows.
+
+Whatever you choose: copy the **contents** of the extracted folder, keep the
+`local/` and `refind/` subdirectories, and put them somewhere identifiable.
+`\EFI\FOG\` is the conventional place.
+
+>[!warning] Do not flatten the layout
+>The subdirectories are load-bearing. The archive root and `local/` each hold
+>their own `autoexec.ipxe`, and merging them stops the machine booting — see
+>[why there are two](#why-there-are-two-autoexecipxe-files).
+
+### On Windows, with FogApi
+
+Windows does not mount the ESP by default. The
+[FogApi](https://github.com/darksidemilk/FogApi) PowerShell module has a helper
+for it:
+
+```powershell
+Install-Module -Name FogApi -Scope AllUsers     # once, from the PowerShell Gallery
+
+Mount-WinEfi                                    # mounts the ESP at A:
+New-Item -ItemType Directory A:\EFI\FOG -Force
+Copy-Item .\fog-esp-x86_64\* A:\EFI\FOG\ -Recurse -Force
+Dismount-WinEFI
+```
+
+`Mount-WinEfi` defaults to `A:` and takes `-mountLtr` for a different letter. It
+wraps `mountvol.exe /S`, and if the ESP is already mounted somewhere else it
+dismounts and remounts it where you asked. `Get-EfiMountLetter` reports where it
+currently is. Without the module, `mountvol A: /S` from an elevated prompt does
+the mounting part and the rest is an ordinary copy.
+
+>[!note] A single command for this is planned, not released
+>A FogApi command to do the whole job — lay the kit down and point the firmware
+>at it — is expected, in the same shape as its host-boot helpers. It does not
+>exist yet, so use the steps above.
+
+### On Linux
 
 ```bash
 sudo mount /dev/sda1 /mnt/esp          # your ESP, usually the small FAT32 one
@@ -103,13 +146,39 @@ sudo cp -r fog-esp-x86_64/* /mnt/esp/EFI/FOG/
 sudo umount /mnt/esp
 ```
 
-Keep the `local/` and `refind/` subdirectories — the layout is load-bearing, and
-flattening it stops the machine booting. See below for why.
+### On a USB stick
 
-Then add a firmware boot entry pointing at one of the entry points below — see
-[[uefi-boot-entries|Managing UEFI Boot Entries (efibootmgr)]] — or copy the
-entry point to `\EFI\BOOT\bootx64.efi` if you want it to be the machine's
-default.
+Format it FAT32 and unpack the archive onto it. Nothing needs mounting and
+nothing on the machine's own disk changes — this is the route for a machine you
+cannot log into, or whose ESP you would rather not touch. Two ways to use it:
+
+- **From a UEFI shell**, if the firmware offers one: change to the stick's
+  filesystem and run the entry point directly.
+- **From the firmware boot menu**, if it will boot removable media: copy the
+  entry point to `\EFI\BOOT\bootx64.efi` on the stick and it shows up as a
+  bootable device.
+
+A USB copy is also the most direct way to **enrol Secure Boot material on a
+machine that cannot netboot at all**. `MOK.der` and the `.auth` files travel
+inside the archive, so one stick carries both the enrolment material and
+something to boot in order to enrol it.
+
+### Letting rEFInd choose
+
+If you can get rEFInd running — from the ESP, from the stick, or because it is
+already the machine's boot manager — it scans for EFI binaries and lists them as
+a menu. That includes the shim, so you can **select `snponly-shimx64.efi` and get
+into FOG without adding a firmware boot entry or touching the boot order**.
+
+Useful when the firmware's own boot menu is awkward, locked down, or simply will
+not show a file you added by hand.
+
+### Making it permanent
+
+To turn any of the above into a real boot entry, see
+[[uefi-boot-entries|Managing UEFI Boot Entries (efibootmgr)]] — or copy the entry
+point to `\EFI\BOOT\bootx64.efi`, which is the path firmware falls back to when
+nothing else is configured.
 
 ## Which entry point
 

--- a/docs/kb/how-tos/local-esp-boot.md
+++ b/docs/kb/how-tos/local-esp-boot.md
@@ -43,6 +43,9 @@ boot.
 >
 >**SNP — Simple Network Protocol.** The UEFI firmware's own network driver.
 >Binaries named `snp`/`snponly` use it instead of iPXE's built-in drivers.
+>
+>**rEFInd** is a third-party boot manager FOG can chainload when you *leave* the
+>FOG menu to boot the machine's installed operating system.
 
 >[!info] FOG 1.6
 >These archives are new in 1.6 and replace an earlier arrangement that published
@@ -70,20 +73,15 @@ If the `zip` command was not installed when FOG last ran, the same content is
 published as `.tar.gz` instead. The manifest records the real filename either
 way, which is why you should read it rather than guessing the extension.
 
->[!warning] The `-10sec` archives are currently not usable
->The manifest also lists `fog-esp-x86_64-10sec` and `fog-esp-arm64-10sec`,
->intended to carry binaries that wait ten seconds before their first DHCP
->attempt. As of the current release those two archives ship **without** FOG's
->own EFI binaries — the build they are sourced from is no longer produced — so
->the `autoexec.ipxe` inside them refers to files that are not there. Use the
->plain archive for your architecture. `--boot-delay` does not help here either;
->it adjusts the TFTP server's boot script, not an ESP.
-
 >[!note] Kernels are listed, not shipped
 >`manifest.json` has a `kernels` array describing `bzImage` and `init.xz` for
->each architecture, with paths relative to the manifest. Those are **not** in
->the archives — the machine fetches them from the FOG server at boot, as it
->would over PXE. The archive only has to get iPXE running.
+>each architecture. Those are **not** in the archives — the machine fetches them
+>from the FOG server at boot, as it would over PXE. The archive only has to get
+>iPXE running.
+
+>[!note] The directory is rebuilt on every install
+>`service/localboot/` is deleted and regenerated each time the installer runs.
+>It is a publication point, not somewhere to keep anything.
 
 ## Installing onto the ESP
 
@@ -97,42 +95,29 @@ sudo cp -r fog-esp-x86_64/* /mnt/esp/EFI/FOG/
 sudo umount /mnt/esp
 ```
 
+Keep the `local/` and `refind/` subdirectories — the layout is load-bearing, and
+flattening it stops the machine booting. See below for why.
+
 Then add a firmware boot entry pointing at one of the entry points below — see
 [[uefi-boot-entries|Managing UEFI Boot Entries (efibootmgr)]] — or copy the
 entry point to `\EFI\BOOT\bootx64.efi` if you want it to be the machine's
 default.
 
-Do not extract two archives into the same folder. The FOG binaries in each are
-named identically, so they would overwrite each other.
-
 ## Which entry point
 
 | Situation | Point the firmware at |
 |---|---|
-| Secure Boot **off** | `fogipxe.efi` |
+| Secure Boot **off** | `local/fogipxe.efi` |
 | Secure Boot **on**, via shim + MOK | `snponly-shimx64.efi` (or `ipxe-shimx64.efi`) |
-| Secure Boot **on**, via firmware Setup Mode | `fogipxe.efi`, after enrolling the `.auth` files |
+| Secure Boot **on**, via firmware Setup Mode | `local/fogipxe.efi`, after enrolling the `.auth` files |
 
 On arm64 the shim is `snponly-shimaa64.efi`. On i386 there is no shim at all —
 Microsoft signs none for 32-bit UEFI — so only the Secure Boot **off** and
 Setup Mode routes exist there.
 
-### The chain, once shim starts
-
-Shim establishes trust, then loads one of upstream's signed loaders from the
-same folder. That loader reads `autoexec.ipxe` out of the folder it was loaded
-from, and the script chains FOG's own build.
-
->[!note] Which loader shim picks is not worth worrying about
->Over the network, shim chooses its second stage by rewriting its own
->`-shim<arch>` suffix — so `snponly-shimx64.efi` loads `snponly.efi`. That
->rename happens on shim's network and HTTP boot paths; booted off a local
->filesystem it may instead fall back to its compiled-in default, `ipxe.efi`.
->Both loaders are in the archive precisely so that either behaviour works.
-
 The first time on a given machine, shim will not be able to verify FOG's binary
 and launches **MokManager** instead. Choose *Enroll key from disk*, select
-`MOK.der` from the same folder, and reboot. It boots unattended from then on.
+`MOK.der` from the archive root, and reboot. It boots unattended from then on.
 See [[secure-boot-mok-enrollment|Secure Boot MOK Enrollment]].
 
 For the Setup Mode route, put the firmware into Setup Mode and enrol `PK.auth`,
@@ -140,53 +125,136 @@ For the Setup Mode route, put the firmware into Setup Mode and enrol `PK.auth`,
 signed binaries directly and shim is not involved. See
 [[secure-boot-setup-mode-enrollment|Secure Boot Setup Mode Enrollment]].
 
+## Why there are two `autoexec.ipxe` files
+
+This is the part worth understanding, because it explains the whole layout.
+
+Since fog-ipxe `v2.0.0-fog.8`, **no EFI binary carries FOG's boot script inside
+it**. Each one *reads* a file called `autoexec.ipxe`, and iPXE resolves that
+name against the directory the running binary was loaded from. Two different
+binaries need two different scripts, so they live in two different directories:
+
+| File | Read by | What it does |
+|---|---|---|
+| `autoexec.ipxe` *(archive root)* | upstream's signed loader, after shim | A chain ladder. Tries `local/fogipxe.efi`, then `fogsnp`, `fogintel`, `fogrealtek`, `fogsnponly` |
+| `local/autoexec.ipxe` | whichever `local/fog*.efi` runs | **FOG's real boot logic** — walks `net0`/`net1`/`net2` for DHCP, handles proxyDHCP and `next-server`, then chains `default.ipxe` |
+
+Neither binary can reach the other's script, which is exactly the point. A flat
+archive gave the FOG binaries the *ladder* instead of the boot logic, so
+`fogipxe.efi` read `chain fogipxe.efi` — itself — and via shim came up with no
+FOG script at all.
+
+>[!important] `ipxe.efi` in the archive root is upstream's, not FOG's
+>It carries iPXE's own NIC drivers, and booted locally off an ESP it **does not
+>load them**. It works only as a chain stage on the way to `local/fog*.efi`.
+>Nothing in either source tree predicts this; it took a machine to find. This is
+>the single most likely thing to trip you up if you rearrange the archive.
+
+>[!tip] `local/autoexec.ipxe` is a plain text file you can edit
+>It is FOG's boot logic sitting on the ESP, not baked into a binary. Change it
+>and the next boot picks it up — nothing to rebuild and nothing to re-download.
+
 ## What is in an archive
+
+**Archive root** — upstream's signed material and the enrolment kit:
 
 | File | What it is |
 |---|---|
 | `snponly-shim<arch>.efi`, `ipxe-shim<arch>.efi` | Upstream's Microsoft-signed shim, under two names |
 | `snponly.efi`, `ipxe.efi` | Upstream's signed iPXE loaders, which shim vouches for |
 | `mmx64.efi` / `mmaa64.efi` | MokManager, for enrolling the key |
-| `fogipxe.efi` | FOG's build, all NIC drivers |
-| `fogsnp.efi` | FOG's build, firmware SNP |
-| `fogintel.efi`, `fogrealtek.efi` | FOG's build, single-vendor drivers |
-| `fogsnponly.efi` | FOG's build, SNP on the load device only |
-| `autoexec.ipxe` | The script the signed loader runs |
+| `autoexec.ipxe` | The chain ladder the signed loader runs |
 | `MOK.der`, `PK.auth`, `KEK.auth`, `db.auth` | Enrolment material for each route |
 | `fog-enroll-mok.sh`, `fog-enroll-mok.desktop` | Helpers for enrolling from a running Linux |
-| `MANIFEST.json`, `README.txt` | Inventory and instructions for this archive |
+| `README.txt`, `MANIFEST.json` | Instructions and inventory for this archive |
 
-The `fog` prefix is not cosmetic. `snponly.efi` and `ipxe.efi` are reserved for
-upstream's signed loaders, because those are the exact bytes shim's embedded
-certificate vouches for — FOG's own builds cannot use those names.
+**`local/`** — FOG's own builds and FOG's boot script:
+
+| File | Driver set |
+|---|---|
+| `fogipxe.efi` | All NIC drivers |
+| `fogsnp.efi` | Firmware SNP |
+| `fogintel.efi`, `fogrealtek.efi` | Single vendor |
+| `fogsnponly.efi` | SNP on the load device only |
+| `autoexec.ipxe` | FOG's boot logic |
+
+**`refind/`** — `refind.efi` (or the right arch's variant) plus `refind.conf`,
+in its own directory because rEFInd reads its config from wherever it was
+loaded from.
+
+>[!note] What is missing, and when
+>An **i386** archive has no shim, no upstream loader, no MokManager and **no
+>root `autoexec.ipxe`** — nothing in it would read one. It does have
+>`local/autoexec.ipxe`, because its `fog*.efi` still needs a boot script. The
+>same shape appears on any architecture if the server's Secure Boot download
+>failed. A server with no rEFInd simply has no `refind/` directory rather than
+>an empty one, and a server with Secure Boot declined ships neither `MOK.der`
+>nor the `.auth` files.
+
+The `fog` prefix on FOG's builds is historical — `snponly.efi` and `ipxe.efi`
+are reserved at the root for upstream's signed copies. The names are kept
+because they are in every bug report since GH-1117.
 
 `MANIFEST.json` records a `sha256`, a `role` and an `origin` for every file, and
 a `fogSigned` boolean that is *measured* from the file rather than assumed.
+Paths in it are relative to the archive root, so `local/fogipxe.efi` appears in
+full.
+
+## Adding a delay before DHCP
+
+If the switch runs STP or port power-save, the link may not be up by the time
+iPXE first asks for DHCP. Install with:
+
+```bash
+./installfog.sh --boot-delay 15        # whole seconds, 0-120
+```
+
+That writes a live `sleep` into `local/autoexec.ipxe` **and** into the server's
+own netboot copy, so one option covers both paths. With no delay configured the
+same two lines are present but commented out, so you can also fix it on a single
+machine at 2am by editing the file on its ESP.
+
+>[!note] BIOS clients always get exactly ten seconds
+>Any non-zero value gives BIOS clients ten seconds, because
+>`10secdelay/undionly.kkpxe` is the only pre-built BIOS binary with a delay. EFI
+>and ESP boot get the value you asked for. The installer says so when the two
+>differ.
 
 ## If the network never comes up
 
-Try the binaries in this order: `fogipxe.efi`, `fogsnp.efi`, `fogintel.efi`,
-`fogrealtek.efi`, `fogsnponly.efi`. `fogsnponly.efi` is last on purpose — it
-binds only the device iPXE was loaded from, which off an ESP is the disk, so it
-usually finds no NIC at all.
+Try the binaries in this order: `local/fogipxe.efi`, `local/fogsnp.efi`,
+`local/fogintel.efi`, `local/fogrealtek.efi`, `local/fogsnponly.efi`.
+`fogsnponly.efi` is last on purpose — it binds only the device iPXE was loaded
+from, which off an ESP is the disk, so it usually finds no NIC at all.
 
 >[!important] The fallback chain covers missing files, not wrong drivers
->`autoexec.ipxe` already tries those five in order, but `chain X || goto Y`
->branches **only when an image fails to load** — absent, malformed, or rejected
->by shim. Once a binary loads and runs, control never returns: one that starts
->cleanly and then binds no NIC stops at its own prompt, and the next branch is
->never reached.
+>The root `autoexec.ipxe` already tries those five in order, but
+>`chain X || goto Y` branches **only when an image fails to load** — absent,
+>malformed, or rejected by shim. Once a binary loads and runs, control never
+>returns: one that starts cleanly and then binds no NIC stops at its own prompt,
+>and the next branch is never reached.
 >
 >So the ladder tells you which files got copied, not which driver works. **If it
 >is the wrong driver you have to change which file is there** — point the
 >firmware directly at the one you want.
 
+## Leaving FOG
+
+From 1.6, a UEFI host exiting the FOG boot menu uses iPXE's own `sanboot`,
+which hands control back to firmware to boot the next entry. That needs nothing
+on the ESP.
+
+rEFInd is still in the archive because `refind_efi` remains selectable, including
+**per host**, and because an ESP assembled by hand may never talk to this server
+again — so the kit carries every route off FOG rather than only the one this
+server happens to be configured for today.
+
 ## What you give up
 
 Because these are archives rather than individual published files, **no single
-binary has a URL of its own** any more. Nothing under `service/localboot/` can
-be used as a UEFI HTTP Boot target or as an iPXE `chain` destination. If you
-need that, serve the file yourself from somewhere you control.
+binary has a URL of its own**. Nothing under `service/localboot/` can be used as
+a UEFI HTTP Boot target or as an iPXE `chain` destination. If you need that,
+unpack the archive and serve the file yourself.
 
 ## See also
 

--- a/docs/kb/how-tos/local-esp-boot.md
+++ b/docs/kb/how-tos/local-esp-boot.md
@@ -47,9 +47,17 @@ boot.
 >**rEFInd** is a third-party boot manager FOG can chainload when you *leave* the
 >FOG menu to boot the machine's installed operating system.
 
->[!info] FOG 1.6
->These archives are new in 1.6 and replace an earlier arrangement that published
->the same binaries loose in a browsable directory.
+>[!info] New in FOG 1.6
+>This is a **new capability**, not a change to an existing one — there is nothing
+>to migrate from. Booting FOG off a machine's own disk was previously something
+>you assembled yourself: find an iPXE binary that drives the hardware, write a
+>boot script for it, put both on the ESP, and keep them in step with the server
+>by hand. FOG now builds and publishes that for you, per architecture, signed,
+>with the enrolment material alongside.
+>
+>If you already have a hand-rolled ESP setup, it keeps working. These archives
+>are worth switching to mainly because the server regenerates them on every
+>upgrade, so the binaries and the boot script cannot drift out of step with it.
 
 ## Getting the archives
 
@@ -249,12 +257,12 @@ rEFInd is still in the archive because `refind_efi` remains selectable, includin
 again — so the kit carries every route off FOG rather than only the one this
 server happens to be configured for today.
 
-## What you give up
+## What the archives cannot do
 
-Because these are archives rather than individual published files, **no single
-binary has a URL of its own**. Nothing under `service/localboot/` can be used as
-a UEFI HTTP Boot target or as an iPXE `chain` destination. If you need that,
-unpack the archive and serve the file yourself.
+Everything is published inside an archive, so **no individual binary has a URL of
+its own**. Nothing under `service/localboot/` can be used as a UEFI HTTP Boot
+target or as an iPXE `chain` destination. If you need either, unpack the archive
+and serve the file yourself from somewhere you control.
 
 ## See also
 

--- a/docs/kb/how-tos/secure-boot-signing.md
+++ b/docs/kb/how-tos/secure-boot-signing.md
@@ -79,19 +79,25 @@ iPXE** boots under Secure Boot with nothing for you to sign.
 The catch is specific to FOG, and it is worth being precise about, because it
 is the whole reason this guide exists:
 
-**FOG does not ship stock iPXE binaries.** FOG builds its own, with the boot
-script compiled in (`EMBED=ipxescript`) and — on HTTPS installs using FOG's
-own internal CA — the server's CA baked in (`TRUST=`). Those are by
-definition custom binaries, they carry no signature, and iPXE's signed shim
-will refuse them, exactly as it should. A shim that loaded any binary calling
-itself iPXE would be worthless.
+**FOG does not ship stock iPXE binaries.** FOG builds its own — the BIOS
+targets with the boot script compiled in (`EMBED=ipxescript`), and, when you
+ask for it with `--rebuild-ipxe-with-my-ca`, with your CA baked in (`TRUST=`).
+Those are by definition custom binaries, so upstream's signed shim will not
+accept them on the strength of iPXE's vendor certificate alone, exactly as it
+should. A shim that loaded any binary calling itself iPXE would be worthless.
 
-FOG could not fix this by signing its own builds either. The shim only trusts
-iPXE's vendor certificate, so a FOG-signed binary would need every machine to
-enroll FOG's key first — the same physical visit this guide already asks for,
-while making one key compromise everyone's problem at once. There is no
-mechanism, on any FOG release, for signing a custom-rebuilt iPXE binary with
-FOG's own Secure Boot certificate so that shim would accept it.
+What FOG *does* do is sign them itself. Every `.efi` in FOG's TFTP tree is
+signed with this server's own Secure Boot key, and shim will load one once that
+key has been enrolled as a MOK on the machine — which is the physical visit
+this guide is about. So the choice is not "signed shim or custom binary"; it is
+whether you need a custom binary badly enough to enrol a key before the machine
+can netboot. Most sites do not, which is why the section below matters.
+
+>[!note] Only your own tree is signed
+>`secureboot/` is left strictly alone — that is upstream's Microsoft-signed
+>shim, its loaders and MokManager, and adding a second signature to them buys
+>nothing. Binaries you build and copy into `/tftpboot` by hand are not signed
+>either; re-run the installer so it signs them.
 
 The way out is to stop needing a custom binary. FOG's embedded boot script is
 entirely generic, and iPXE 2.0 can fetch that script from the TFTP server
@@ -272,13 +278,13 @@ Nothing is served from this directory unless you point DHCP at it, so its
 presence changes nothing for your existing clients.
 
 >[!info] If the directory is missing
->Two reasons it would not be there. **HTTPS-netboot installs using FOG's own
->CA skip it** — these are upstream's generic binaries, so they cannot carry
->your server's CA, and a signed binary cannot be rebuilt without voiding the
->signature. See [[pki-zones#https-and-netboot|HTTPS and netboot]] for the way
->round that, and note that a public CA on the vhost avoids the tradeoff
->entirely. Otherwise the download failed — it is deliberately not fatal —
->and the installer will have said so. Re-run it.
+>There is one reason now: the download failed. It is deliberately not fatal, so
+>the install completed and said so in its output — re-run it.
+>
+>Earlier releases also skipped this directory on any HTTPS install, on the
+>reasoning that Secure Boot and HTTPS could not coexist. They can, and FOG 1.6
+>stages it in **every** install mode. See
+>[[netboot-transport-and-pki|Netboot Transport and PKI]].
 
 You can confirm you have a signed binary — a signed one has a non-empty
 certificate table, an unsigned one does not:
@@ -504,19 +510,20 @@ would put a root password; see [The signing key](#the-signing-key).
   together than you'd expect.** A web certificate from a **public CA** (e.g.
   Let's Encrypt) on an FQDN gets you HTTPS netboot with no rebuild and no
   loss of the signed Secure Boot shim — see
-  [[pki-zones#https-and-netboot|HTTPS and netboot]] for why. It's only
-  FOG's own or your internal (non-publicly-trusted) CA that forces a choice
-  between a `TRUST=`-rebuilt iPXE (HTTPS netboot, no signed shim) and the
-  signed shim (Secure Boot, netboot stays HTTP) — unless you use
-  [[secure-boot-setup-mode-enrollment|Setup Mode enrollment]] to skip shim's
-  involvement entirely.
+  [[netboot-transport-and-pki|Netboot Transport and PKI]] for why. With FOG's
+  own or your internal CA, a `TRUST=`-rebuilt iPXE is needed, and that binary
+  is signed by this server rather than by iPXE — so it costs you a MOK
+  enrolment *before* the machine can netboot, not the signed shim itself.
+  [[secure-boot-setup-mode-enrollment|Setup Mode enrollment]] skips shim's
+  involvement entirely if you would rather.
 - **A Secure Boot USB stick does not work the same way.** The filename trick
   the shim uses to find its second stage — `automatic_next_path()` — is called
   only from shim's network and HTTP boot paths. There is no local-filesystem
   equivalent, so a shim booted from a USB stick or an ESP ignores the `-shim`
   rename entirely and falls back to its compiled-in default, `ipxe.efi`. If you
   build a Secure Boot USB from these instructions, name the second stage
-  `ipxe.efi` or it will not be found.
+  `ipxe.efi` or it will not be found. FOG's ready-made ESP archives sidestep
+  this by shipping both loaders — see [[local-esp-boot|Local ESP Boot]].
 
 >[!warning] Turning Secure Boot on can break existing Windows Hello for Business sign-in
 >If a machine already has users signed in with Windows Hello for Business


### PR DESCRIPTION
Part of `FOGProject/fogproject#1120` (Phase 3). Depends on #124 for the `netboot-transport-and-pki` link target.

Adds `docs/kb/how-tos/local-esp-boot.md` — the `fog-esp` archives had **no documentation at all**. Nothing under `docs/` mentioned `localboot`, `fog-esp` or the manifest, so the only way to find the feature was to already know the URL.


## Windows first, and every route the kit supports

The install steps were Linux-only — `sudo mount /dev/sda1` — which is the
audience least likely to apply. Windows now leads, using FogApi's `Mount-WinEfi`
(defaults to `A:`, wraps `mountvol.exe /S`, remounts if the ESP is already
mounted elsewhere), with `mountvol A: /S` as the no-module fallback. A single
FogApi command for the whole job is noted as **planned and not released**, since
it does not exist yet.

More importantly the page prescribed one path when the kit's value is that it
does not need one. Now documented:

- **USB stick** — nothing mounted, machine's disk untouched. From a UEFI shell,
  or as `\EFI\BOOT\bootx64.efi` so firmware offers it as removable media. Also
  the most direct way to enrol Secure Boot material on a machine that cannot
  netboot at all, since `MOK.der` and the `.auth` files travel in the archive.
- **rEFInd as a selector** — it lists EFI binaries including the shim, so you can
  pick it and reach FOG without adding a firmware boot entry or changing boot
  order. The answer when firmware's own menu is locked down.
- **A permanent boot entry** — now one option among several rather than the
  assumed end of the procedure.

## This is a new feature, not a replacement

An earlier draft said the archives "replace an earlier arrangement that published
the same binaries loose in a browsable directory". They do not — that loose set
existed for about a day inside the 1.6 beta and nobody ran it. Telling an admin
their setup was replaced, when they never had the thing being replaced, sends
them looking for something to change.

The real prior art is admins hand-assembling an ESP themselves. The page says
that, says a hand-rolled setup keeps working, and gives the actual reason to
switch: the server regenerates the archives on every upgrade, so the binaries
and the boot script cannot drift out of step with it.

## Written twice

The page was drafted against the five-archive layout, then `FOGProject/fogproject@046fe81e9` landed and changed most of it. The version here describes what actually ships:

- **Three archives**, not six. The `-10sec` variants were deleted, not repaired.
- **`--boot-delay` covers ESP boot too** — it writes a live `sleep` into `local/autoexec.ipxe` as well as the server's netboot copy. The first draft said it could not help.
- **The layout is load-bearing.** Since `v2.0.0-fog.8` no EFI binary carries FOG's boot script; each reads `autoexec.ipxe` resolved against its own directory. Two binaries need two scripts, hence two directories: the root one is a chain ladder read by upstream's signed loader, `local/autoexec.ipxe` is FOG's real DHCP/proxyDHCP/next-server logic. A flat archive gave FOG's binary the ladder, so it chained itself.
- rEFInd in `refind/`, and why it is still there now UEFI hosts exit via `sanboot`.
- Manifest schema 2; i386 has no root ladder but does have `local/autoexec.ipxe`.
- The trap most likely to bite: `ipxe.efi` at the root is **upstream's**, and booted off an ESP it does not load its own NIC drivers — it is only ever a chain stage.

## Corrections to `secure-boot-signing.md`

Two claims were wrong rather than stale.

It said FOG's builds "carry no signature" and that there is **"no mechanism, on any FOG release, for signing a custom-rebuilt iPXE binary with FOG's own Secure Boot certificate"**. FOG signs every `.efi` in its TFTP tree, and shim loads the result once the key is enrolled. The same page's own summary bullet 400 lines below already said the milder version, so the page contradicted itself.

It also said `secureboot/` would be missing on "HTTPS-netboot installs using FOG's own CA". True of the old gate; every mode stages it now.

## Also

A branch name had leaked into published prose on `migrating-fog-server.md`, and `kb/how-tos/index.md` was missing five how-tos including all three Secure Boot guides.

## Verified

Full Quartz build: 108 files, no errors, unparsed-wikilink count still 12.