### PR TITLE
Carry the .fogsettings key rename into the docs, and clear the pre-rename PR backlog

### DIFF
--- a/docs/development/install-script-architecture.md
+++ b/docs/development/install-script-architecture.md
@@ -55,7 +55,7 @@ flowchart TD
         direction LR
         F{"Upgrading with a prior<br/>.fogsettings?"} -->|yes| G["source .fogsettings<br/>+ doOSSpecificIncludes()"]
         F -->|no| H
-        G --> H{"fogupdateloaded<br/>already set?"}
+        G --> H{"FOG_installed<br/>already set?"}
         H -->|no, fresh install| I["input.sh<br/>(incl. OS choice)"]
         I --> J["newinput.sh"]
         H -->|yes, already populated| J
@@ -67,21 +67,21 @@ flowchart TD
     end
     subgraph S4["4 · Install-type branch + shared services"]
         direction LR
-        P{installtype} -->|Normal server| Q["configureMySql → configureHttpd<br/>→ checkWebTier → backupDB → updateDB"]
+        P{FOG_install_type} -->|Normal server| Q["configureMySql → configureHttpd<br/>→ checkWebTier → backupDB → updateDB"]
         P -->|Storage node| R["checkDatabaseConnection<br/>→ backupReports → configureMinHttpd"]
         Q --> Sn["storage / DHCP / TFTP / FTP<br/>/ snapin / UDPCast setup"]
         R --> Sn
     end
     subgraph S5["5 · Services + finish"]
         direction LR
-        T["init scripts + FOG<br/>services + NFS"] --> U["writeUpdateFile<br/>→ linkOptFogDir"] --> V{installtype}
+        T["init scripts + FOG<br/>services + NFS"] --> U["writeUpdateFile<br/>→ linkOptFogDir"] --> V{FOG_install_type}
         V -->|Normal server| W["updateStorageNodeCredentials<br/>→ setupFogReporting"]
         V -->|Storage node| X["registerStorageNode<br/>→ updateStorageNodeCredentials"]
     end
     S1 --> S2 --> S3 --> S4 --> S5
 ```
 
-The two `installtype` branches diverge for a reason: a **Normal server**
+The two `FOG_install_type` branches diverge for a reason: a **Normal server**
 owns the database (`configureMySql`, `checkWebTier`, `backupDB`, `updateDB`
 deploy/verify the schema itself), while a **Storage Node** talks to an
 *existing* master instead (`checkDatabaseConnection` just pings it,
@@ -127,12 +127,13 @@ so a value already set (by a CLI flag, or by a prior `.fogsettings` on
 upgrade) is always left alone rather than overwritten. The variables every
 one of them defines:
 
-`packageQuery`, `packages`, `packageinstaller`, `packagelist`,
+`packageQuery`, `FOG_packages`, `packageinstaller`, `packagelist`,
 `packageupdater`, `packmanUpdate`, `langPackages`, `dhcpname`,
-`webdirdest`/`docroot`, `webredirect`, `apacheuser`, `apachelogdir`,
-`apacheerrlog`, `apacheacclog`, `etcconf`, `storageLocation`,
+`webdirdest`/`WEB_docroot`, `webredirect`, `apacheuser`, `apachelogdir`,
+`apacheerrlog`, `apacheacclog`, `etcconf`, `STORAGE_image_share_path`,
 `storageLocationCapture`, `dhcpconfig`, `dhcpconfigother`, `tftpdirdst`,
-`ftpconfig`, `snapindir`, `dhcpd`, `iscservice`, `keapackage`, `keaservice`.
+`ftpconfig`, `snapindir`, `DHCP_service_name`, `iscservice`, `keapackage`,
+`keaservice`.
 
 A few variables are **not** universal — an implementation adding a fourth
 OS should treat these as optional extras the other files happen to need,
@@ -172,9 +173,9 @@ passed, or `-y`/`--autoaccept` skips the prompt altogether).
 `input.sh` is the bulk of the interactive flow: network interface, router,
 DNS, DHCP range, install language, install type, storage-node DB
 credentials, HTTPS. But it's only sourced when
-`[[ ! $doupdate -eq 1 || ! $fogupdateloaded -eq 1 ]]` — i.e. it's **skipped
+`[[ ! $doupdate -eq 1 || ! $FOG_installed -eq 1 ]]` — i.e. it's **skipped
 entirely on an upgrade** where the loaded `.fogsettings` already has
-`fogupdateloaded=1`.
+`FOG_installed=1`.
 
 `newinput.sh` has no such guard — `installfog.sh` always sources it. It
 exists specifically so a prompt introduced *after* someone's `.fogsettings`
@@ -328,7 +329,7 @@ reading before changing the surrounding code:
 - **External/unprivileged database mode short-circuits several functions.**
   `backupDB()`, `updateDB()`'s `fogstorage`-grant step, and
   `checkDatabaseConnection()`'s local-auth path all explicitly skip work
-  when `$snmysqlexternal == 1`, rather than trying to make root-requiring
+  when `$DB_external == 1`, rather than trying to make root-requiring
   operations degrade gracefully.
 
 ## Debugging the installer

--- a/docs/installation/network-setup/proxy-dhcp.md
+++ b/docs/installation/network-setup/proxy-dhcp.md
@@ -199,7 +199,7 @@ builds carry their script internally and ignore the file — see
 [[dhcp-server-settings#How UEFI clients get their boot script|How UEFI clients get their boot script]].
 Either way the script chainloads `tftp://<fog_server_IP>/default.ipxe`, which in
 turn chainloads your FOG server's boot script over HTTP or HTTPS. Which of those
-two it is depends on `netbootproto`, not on how you reach the web interface —
+two it is depends on `BOOT_url_proto`, not on how you reach the web interface —
 see [[netboot-transport-and-pki|Netboot Transport and PKI]].
 
 If the client loads iPXE but then hangs or errors when contacting FOG, the

--- a/docs/installation/server/command-line-options.md
+++ b/docs/installation/server/command-line-options.md
@@ -2,112 +2,244 @@
 title: Fog installer command line options
 aliases:
     - Fog installer command line options
-description: Fog installer command line options
+    - installfog.sh options
+    - Installer flags
+description: Every option the FOG installer accepts, what it changes, and which ones are remembered in .fogsettings
 context_id: command-line-options
 tags:
-    - in-progress
-    - updating-content
     - installation
     - fog-server
+    - configuration
+    - certificates
+    - secure-boot
 ---
-
 
 # Fog installer command line options
 
-The FOG installer has quite a few command line options. See the output
-below. You might want force FOG to setup the web interface via HTTPS,
-change the web root directory, or install to a non-default location.
+The FOG installer takes a lot of options. Most installs need none of them —
+the defaults are chosen for the common case, and anything you do pass is
+recorded in [[install-fogsettings|the .fogsettings file]] so an upgrade keeps
+it without you passing it again.
 
-    ./installfog.sh --help
-    Usage: ./installfog.sh [-h?odEUHSCKYyXTFl] [-f <filename>] [-N <databasename>]
-            [-D </directory/to/document/root/>] [-c <ssl-path>]
-            [-W <webroot/to/fog/after/docroot/>] [-B </backup/path/>]
-            [-s <192.168.1.10>] [-e <192.168.1.254>]
-        -h -? --help            Display this info
-        -o    --oldcopy         Copy back old data
-        -d    --no-defaults     Don't guess defaults
-        -U    --no-upgrade      Don't attempt to upgrade
-        -H    --no-htmldoc      No htmldoc, means no PDFs
-        -S    --force-https     Force HTTPS for all comunication
-        -C    --recreate-CA     Recreate the CA Keys
-        -K    --recreate-keys   Recreate the SSL Keys
-              --external-ca     Sign FOG's server certificate with an
-                                existing external/intermediate CA instead
-                                of generating a self-signed CA
-              --ca-cert         Path to the intermediate CA certificate (PEM)
-              --ca-key          Path to the intermediate CA private key (PEM)
-              --ca-root         Path to the root CA certificate (PEM)
-              --web-ca-cert     Bring your own CA for the WEB zone: the
-                                intermediate that signs this server's
-                                vhost certificate
-              --web-ca-key      Private key matching --web-ca-cert
-              --web-ca-root     Root certificate --web-ca-cert chains to
-                                (all three are required together)
-        -Y -y --autoaccept      Auto accept defaults and install
-        -f    --file            Use different update file
-        -c    --ssl-path        Specify the ssl path
-                                defaults to /opt/fog/snapins/ssl
-        -D    --docroot         Specify the Apache Docroot for fog
-                                defaults to OS DocumentRoot
-        -W    --webroot         Specify the web root url want fog to use
-                                (E.G. http://127.0.0.1/fog,
-                                      http://127.0.0.1/)
-                                Defaults to /fog/
-              --fogprogramdir   Specify the FOG base directory
-                                defaults to /opt/fog
-                                remembered in /etc/fog/fog.conf, so it
-                                only needs giving on a first install
-        -N    --mysqldbname     Specify the FOG database name
-                                defaults to fog
-        -B    --backuppath      Specify the backup path
-              --uninstall       Uninstall FOG. Removes FOG's own files,
-                                services and config, and restores the
-                                files FOG replaced. Your database,
-                                images, snapins, SSL CA and the fog
-                                account are KEPT unless purged below.
-                                Packages are never removed.
-              --dry-run         With --uninstall, list what would be
-                                removed and exit without changing anything
-              --force           With --uninstall, skip the typed
-                                confirmation (-Y does NOT skip it)
-              --purge-db        Also drop the FOG database
-              --purge-images    Also delete the image storage
-              --purge-snapins   Also delete the snapins
-              --purge-ssl       Also delete the SSL CA. This permanently
-                                breaks every deployed fog-client
-              --purge-user      Also delete the fog Linux account
-              --purge-all       All of the --purge-* options above
-        -s    --startrange      DHCP Start range
-        -e    --endrange        DHCP End range
-        -E    --no-exportbuild  Skip building nfs file
-        -X    --exitFail        Do not exit if item fails
-        -T    --no-tftpbuild    Do not rebuild the tftpd config file
-        -F    --no-vhost        Do not overwrite vhost file
-        -l    --list-packages   List of the basic packages FOG needs for install or is currently installed for FOG
-              --secure-boot-key   Private key used to re-sign the FOS
-                                  kernels for UEFI Secure Boot
-              --secure-boot-cert  Certificate matching --secure-boot-key
-                                  (both are required together)
-              --no-secure-boot    Do not generate a Secure Boot signing
-                                  key, and leave the FOS kernels unsigned
-              --no-ca-trust       Do not add this server's CA to this
-                                  server's own system trust store
+>[!note] Options beat the stored value
+>The installer reads `.fogsettings` first and applies your command line after,
+>so you never have to clear a setting before overriding it. The exception is
+>`--install-mode`, which is a preset: it is applied *before* the individual
+>options, so those still win over it.
+
+## The four install modes
+
+`--install-mode` sets four settings at once, and is the easiest way to pick a
+combination that works. Full reasoning in
+[[netboot-transport-and-pki|Netboot Transport and PKI]].
+
+| Mode | `WEB_url_proto` | `BOOT_url_proto` | `PKI_web_cert_publicly_trusted` | `BOOT_rebuild_ipxe_with_my_ca` |
+|---|---|---|---|---|
+| `standard` *(default)* | https | http | no | no |
+| `http-only` | http | http | no | no |
+| `public-cert` | https | **https** | **yes** | no |
+| `embed-ca` | https | **https** | no | **yes** |
+
+An attended install offers these as a numbered prompt. Under `-y` it does not
+ask and you get `standard` unless you passed something else.
+
+>[!warning] `--install-mode` does not touch the HTTP→HTTPS redirect
+>No mode sets or clears `WEB_https_redirect`. A server upgraded from a `-S`
+>install keeps its redirect whichever mode you pick, because that setting is
+>seeded once from the old `httpproto=https` and is then yours for good. Use
+>`--no-https-redirect` to turn it off.
+
+>[!warning] `http-only` does not persist
+>`WEB_url_proto` is set back to `https` at the start of every run — 443 listens
+>on every install either way — so `--install-mode http-only` applies only to the
+>run you pass it on. Pass it again on each upgrade, or it silently reverts.
+
+## Transport options
+
+These are the individual settings the modes above are shorthand for. Any of
+them can be given on its own.
+
+| Option | What it does |
+| --- | --- |
+| `--netboot-proto http\|https` | The protocol iPXE uses to fetch `boot.php`. Otherwise derived every run: `https` when the certificate is public or iPXE was rebuilt with your CA. Passing it explicitly is **remembered as explicit**, so later runs stop re-deriving it |
+| `--public-web-cert` | States that the web certificate chains to a **public** root, so iPXE can validate it with no rebuild. Needs an FQDN, not an IP. Also stops FOG re-issuing the leaf |
+| `--rebuild-ipxe-with-my-ca` | Recompiles iPXE with the configured CA embedded, for HTTPS netboot behind a **private** CA. The build takes 10–25 minutes but is stamped against the pinned iPXE version and the CA, so it re-runs only when one of those changes |
+| `-S`, `--force-https`, `--https-redirect` | Redirect HTTP to HTTPS, **and send HSTS**. All three spellings are the same option |
+| `--no-force-https`, `--no-https-redirect` | Serve both HTTP and HTTPS without redirecting. This is the default |
+| `--boot-delay <0-120>` | Seconds a client waits before its first DHCP attempt, for switches slow to come out of STP or port power-save. `0` writes no delay. Any non-zero value gives BIOS clients exactly ten seconds, because that is the only pre-built BIOS binary |
+| `--no-public-web-cert`, `--no-rebuild-ipxe-with-my-ca` | Undo the corresponding option |
+
+>[!important] `-S` no longer means what it used to
+>Before 1.6 `-S`/`--force-https` decided three unrelated things at once: the
+>protocol FOG used for its own URLs, the redirect, and whether iPXE was
+>recompiled. It now means **only** the redirect, which is what its help text
+>always said. The other two are `--install-mode` and
+>`--rebuild-ipxe-with-my-ca`.
+
+>[!warning] HTTPS netboot needs `FOG_WEB_HOST` set to the certificate's name
+>The boot script the installer writes uses the server's hostname, but FOG
+>rebuilds every later boot URL from the `FOG_WEB_HOST` setting in the web
+>interface — which holds the server's **IP address** unless you change it. On
+>`public-cert` or `embed-ca`, set it to the same FQDN the certificate is issued
+>to, or every fetch after the first fails iPXE's name check.
+
+## The full option list
+
+```
+Usage: ./installfog.sh [-h?odEUHSCKYyXTFl] [-f <filename>] [-N <databasename>]
+                [-D </directory/to/document/root/>] [-c <ssl-path>]
+                [-W <webroot/to/fog/after/docroot/>] [-B </backup/path/>]
+                [-s <192.168.1.10>] [-e <192.168.1.254>]
+        -h -? --help                    Display this info
+        -o    --oldcopy                 Copy back old data
+        -d    --no-defaults             Don't guess defaults
+        -U    --no-upgrade              Don't attempt to upgrade
+        -H    --no-htmldoc              No htmldoc, means no PDFs
+              --install-mode            Preset for the four settings below.
+                                                standard (default): HTTPS web UI, HTTP
+                                                  netboot, no redirect, no rebuild
+                                                http-only: plain HTTP everywhere
+                                                public-cert: a publicly-trusted cert, so
+                                                  netboot can use HTTPS with no rebuild
+                                                embed-ca: rebuild iPXE with your CA
+                                                  (adds 10-25 min and a Secure Boot step)
+        -S    --force-https             Force the HTTP->HTTPS redirect
+              --https-redirect            (same thing, clearer name)
+              --no-force-https          Undo --force-https: serve both HTTP and
+              --no-https-redirect                       HTTPS without redirecting
+              --public-web-cert         The web certificate chains to a PUBLIC
+                                                root, so iPXE can validate it without
+                                                a rebuild. Needs an FQDN, not an IP
+              --no-public-web-cert      Undo --public-web-cert
+              --rebuild-ipxe-with-my-ca Rebuild iPXE embedding the
+                                                configured CA. Slow, and the
+                                                result is not upstream's signed
+                                                binary, so its MOK must be
+                                                enrolled before a client netboots
+              --no-rebuild-ipxe-with-my-ca      Undo the above
+              --netboot-proto           http or https: the protocol iPXE uses to
+              --boot-delay              seconds to sleep before the first DHCP
+                                        attempt, for switches slow out of STP or
+                                        powersave. 0 (default) writes no sleep.
+                                                fetch boot.php. Defaults to http, and
+                                                to https when the certificate is public
+                                                or iPXE was rebuilt with your CA
+        -C    --recreate-CA             Recreate the CA Keys
+                                                Implies --recreate-keys below, and
+                                                re-anchors what fog-client pins
+        -K    --recreate-keys           Recreate the SSL Keys
+                                                Replaces the client communication
+                                                keypair. EVERY registered fog-client
+                                                must then be reinstalled or re-pinned
+              --external-ca             Sign FOG's server certificate with an
+                                                existing external/intermediate CA instead
+                                                of generating a self-signed CA
+              --ca-cert                 Path to the intermediate CA certificate (PEM)
+              --ca-key                  Path to the intermediate CA private key (PEM)
+              --ca-root                 Path to the root CA certificate (PEM)
+        -Y -y --autoaccept              Auto accept defaults and install
+        -f    --file                    Use different update file
+        -c    --ssl-path                Specify the ssl path
+                                                defaults to /opt/fog/snapins/ssl
+        -D    --docroot                 Specify the Apache Docroot for fog
+                                                defaults to OS DocumentRoot
+        -W    --webroot                 Specify the web root url want fog to use
+                                                (E.G. http://127.0.0.1/fog,
+                                                      http://127.0.0.1/)
+                                                Defaults to /fog/
+              --fogprogramdir           Specify the FOG base directory
+                                                defaults to /opt/fog
+                                                remembered in /etc/fog/fog.conf, so it
+                                                only needs giving on a first install
+              --hostname                Override the vhost/cert hostname
+                                        defaults to `hostname -f`, remembered in .fogsettings
+              --extra-server-name       Add an extra vhost/cert name (repeatable)
+                                        alongside the primary hostname and detected IPs
+              --internal-domain         Permit this domain in the Web and Secure Boot
+                                                CAs' name constraints (repeatable). The server's
+                                                own domain is always permitted
+              --internal-subnet         Restrict those CAs to this subnet, e.g.
+                                                10.20.30.0/24 (repeatable). REPLACES the default
+                                                of all RFC1918 ranges
+              --web-ca-cert/-key/-root  Bring your own CA for the WEB zone only
+                                                (equivalent to --external-ca --ca-*)
+              --secureboot-ca-cert      Your own SECURE BOOT intermediate: the
+                                                certificate enrolled in firmware. Pair it with
+                                                --secure-boot-key/--secure-boot-cert, which name
+                                                the code-signing leaf issued from it. Rotate the
+                                                leaf freely; the enrolled CA never changes
+              --kernel-backup-count     How many prior kernel/init generations to
+                                        keep (default 3). Restore one with
+                                        bin/restorekernel.sh. See
+                                        docs/SUPPORTED_CUSTOMIZATIONS.md
+              --restore-kernel-backup   Also restore the previous kernel/init set
+                                        this run. Used by updatefog.sh when reverting;
+                                        not normally passed by hand
+        -N    --mysqldbname             Specify the FOG database name
+                                                defaults to fog
+        -B    --backuppath              Specify the backup path
+              --uninstall               Uninstall FOG. Removes FOG's own files,
+                                                services and config, and restores the
+                                                files FOG replaced. Your database,
+                                                images, snapins, SSL CA and the fog
+                                                account are KEPT unless purged below.
+                                                Packages are never removed.
+              --dry-run                 With --uninstall, list what would be
+                                                removed and exit without changing anything
+              --force                   With --uninstall, skip the typed
+                                                confirmation (-Y does NOT skip it)
+              --purge-db                Also drop the FOG database
+              --purge-images            Also delete the image storage
+              --purge-snapins           Also delete the snapins
+              --purge-ssl               Also delete the SSL CA. This permanently
+                                                breaks every deployed fog-client
+              --purge-user              Also delete the fog Linux account
+              --purge-all               All of the --purge-* options above
+        -s    --startrange              DHCP Start range
+        -e    --endrange                DHCP End range
+        -E    --no-exportbuild          Skip building nfs file
+        -X    --exitFail                Do not exit if item fails
+        -T    --no-tftpbuild            Do not rebuild the tftpd config file
+        -F    --no-vhost                Do not touch the vhost file at all. FOG
+                                                normally rewrites only the region between its
+                                                MANAGED BLOCK markers and leaves your own
+                                                additions alone, so skipping also skips its
+                                                security fixes to the parts it owns.
+                                                See docs/SUPPORTED_CUSTOMIZATIONS.md
+        -l    --list-packages           List of the basic packages FOG needs for install or is currently installed for FOG
+              --secure-boot-key         Private key used to re-sign the FOS
+                                                kernels for UEFI Secure Boot
+              --secure-boot-cert        Certificate matching --secure-boot-key
+                                                        (both are required together)
+              --no-secure-boot          Do not publish Secure Boot ENROLMENT
+                                                material: no MOK.der, no PK/KEK/db.auth,
+                                                and no 'Enroll Secure Boot Key' menu
+                                                entry. Binaries are still signed -- a
+                                                signature is inert with Secure Boot off
+```
 
 The `--uninstall`, `--dry-run`, `--force` and `--purge-*` options are
-covered in detail in [Uninstalling the Fog server](uninstall-fog-server.md).
+covered in detail in [[uninstall-fog-server|Uninstalling the Fog server]].
+
+>[!note] Two flags were removed in 1.6
+>`--no-ca-trust` and `--no-sb-name-constraints` are gone, along with the
+>settings behind them. Both were opt-outs that put the safe answer behind a flag
+>nobody passes until something has already broken — see
+>[[command-line-options#Certificate options|Certificate options]] and
+>[[command-line-options#Name constraints|Name constraints]]. Passing either is
+>now an unrecognized option.
 
 ## Certificate options
 
 FOG generates its own Certificate Authority at install time and uses it to sign
 this server's HTTPS certificate. These options change **which** CA does that
-signing, and whether this server trusts the result locally.
+signing.
 
 | Option | Use it when |
 | --- | --- |
 | *(none)* | The default. FOG generates a CA and a Web CA beneath it, and signs the vhost certificate from that. |
 | `--web-ca-cert` + `--web-ca-key` + `--web-ca-root` | You want this server's HTTPS certificate signed by a CA **you** supply — your enterprise PKI, an internal ACME CA, or one issued by another FOG server. All three are required together. |
 | `--external-ca` with `--ca-cert`/`--ca-key`/`--ca-root` | The older spelling of the same thing. It targets the same zone, which is what it has always effectively meant. |
-| `--no-ca-trust` | You do **not** want the installer adding this server's CA to this server's own system trust store. |
 
 Passing any one of `--web-ca-*` implies `--external-ca`, so you do not need
 both. You supply the files **once** — they are imported and later upgrades
@@ -118,23 +250,58 @@ certificate, the certificate must be a CA (`basicConstraints CA:TRUE`), and it
 must verify against the root you supply. Any failure stops the install rather
 than producing a server signed by the wrong thing.
 
+>[!note] Both spellings now write one run-scoped input
+>Before 1.6 these were six persisted settings holding three values — three from
+>the prompt and three from the flags — resolved one against the other. That is
+>what silently discarded anything typed at the prompt whenever the flags were
+>also given, and made the flags appear to work *only* under `-y`. There is one
+>set of import paths now, written by either spelling and by the prompt, and the
+>canonical `PKI_web_ca_*` slots are set once the import validates.
+
 >[!info] This does not affect fog-client
 >`--web-ca-*` replaces the CA that signs the **web** certificate and nothing
 >else. The root that fog-client pinned at registration is untouched, which is
 >what makes this safe to do on a running fleet without re-registering a single
 >machine.
 
-### `--no-ca-trust` and the local trust store
+### Name constraints
 
-By default the installer adds this server's own CA to this server's system
-trust store, so `curl`, `wget` and PHP's stream wrapper on the FOG server can
-verify the FOG server without being handed a CA file each time. The store is
-detected from the host — `/etc/pki/ca-trust/source/anchors` on the RHEL family,
+FOG restricts the Web CA to a set of permitted names, so a compromised CA
+cannot issue for the whole internet.
+
+| Option | What it does |
+| --- | --- |
+| `--internal-domain <domain>` | Permit this domain in the Web CA's constraints, and add it to the certificate and the vhost `ServerAlias`. Repeatable. The server's own domain is always permitted |
+| `--internal-subnet <cidr>` | Restrict the Web CA to this subnet. Repeatable, and it **replaces** the default of all private ranges rather than adding to it |
+
+>[!important] Constraints are fixed when a CA is first created
+>FOG never re-mints an existing authority, so changing these on a server that
+>already has one does nothing until you remove the intermediate as well.
+
+>[!warning] A CA you supply must constrain only by DNS name or IP address
+>iPXE enforces name constraints, and only understands `dNSName` and
+>`iPAddress` permitted subtrees. A CA carrying any other subtree type — or any
+>`minimum`/`maximum` — **fails to parse**, and the whole chain with it. Leave
+>your intermediate unconstrained or constrain it with those two only. This
+>matters only when netboot is on HTTPS.
+
+>[!note] The Secure Boot zone gets no constraints at all
+>`--no-sb-name-constraints` is gone because there is nothing left to turn off.
+>See [[command-line-options#Secure Boot options|Secure Boot options]].
+
+### The local trust store
+
+The installer adds this server's own CA to this server's system trust store, so
+`curl`, `wget` and PHP's stream wrapper on the FOG server can verify the FOG
+server without being handed a CA file each time. The store is detected from the
+host — `/etc/pki/ca-trust/source/anchors` on the RHEL family,
 `/usr/local/share/ca-certificates` on Debian/Ubuntu/Alpine,
 `/etc/ca-certificates/trust-source/anchors` on Arch.
 
-`--no-ca-trust` skips it, and is remembered in `.fogsettings` so an upgrade
-does not quietly reverse the decision.
+This is unconditional since 1.6. `--no-ca-trust` used to skip it, and was
+removed with the setting behind it: declining it left a server that could not
+verify its own certificate, with the failures surfacing far from the flag that
+caused them.
 
 >[!warning] This does not make your browser stop warning
 >Firefox keeps its own certificate store and Chrome reads a per-user one, so
@@ -147,31 +314,66 @@ For the per-zone mechanism in full see
 at a single CA so one import covers all of them, see
 [[unify-certificates-across-fog-servers|Unifying certificates across several FOG servers]].
 
+### Recreating certificates
+
+| Option | What it does |
+| --- | --- |
+| `-C`, `--recreate-CA` | Recreate the CA keys. Implies `--recreate-keys`, and re-anchors what fog-client pins |
+| `-K`, `--recreate-keys` | Recreate the SSL keys. Replaces the client communication keypair, so **every registered fog-client must then be reinstalled or re-pinned** |
+
+Neither touches Secure Boot material — see below for why.
+
 ## Secure Boot options
 
-Since FOG 1.6.0 the installer **generates a Secure Boot signing key by
+Since FOG 1.6.0 the installer **generates Secure Boot signing material by
 default** and signs the FOS kernels with it, so a stock server always has a
-certificate fingerprint to check and an enrollment kit to hand out. The three
-options above only matter if you want to change that:
+certificate fingerprint to check and an enrollment kit to hand out.
+
+FOG creates a Secure Boot **certificate authority** and enrols that, then
+issues a separate **signing certificate** beneath it. Because firmware trusts
+the issuer, the signing material can be rotated without a second trip to every
+machine.
 
 | Option | Use it when |
 | --- | --- |
-| *(none)* | The default. A key is generated at `/opt/fog/secureboot/` on first install and **reused, never regenerated**, on every later upgrade. |
+| *(none)* | The default. The material is generated on first install and **reused, never regenerated**, on every later upgrade. |
 | `--secure-boot-key` + `--secure-boot-cert` | You already have a signing key you want FOG to use. Both are required together; the certificate may be PEM or DER. Your key is never overwritten. |
-| `--no-secure-boot` | You do not want a signing key or the root-only signing helper on this server. The FOS kernels are left unsigned. |
+| `--secureboot-ca-cert` | You are supplying your own Secure Boot **intermediate** — the certificate enrolled in firmware. Pair it with the two above, which then name the code-signing certificate issued from it. |
+| `--no-secure-boot` | You do not want enrollment material published: no `MOK.der`, no `PK`/`KEK`/`db.auth`, and no "Enroll Secure Boot Key" menu entry. |
+
+>[!note] `--no-secure-boot` declines enrollment, not signing
+>Binaries are still signed. A signature is inert on a machine with Secure Boot
+>off, so signing costs nothing; what the option turns off is publishing the
+>material a client would enrol.
 
 `--no-secure-boot` is remembered in `.fogsettings`, so an upgrade will not
 hand back a key and a `sudoers` rule you deliberately declined.
 
->[!warning] The generated key is never regenerated, and that is deliberate
+>[!warning] The signing key is never regenerated, and that is deliberate
 >A new signing key silently invalidates enrollment on **every machine that
 >already trusted the old one**, and nothing reports that until a client fails
 >to boot — long after the install that caused it. `--recreate-keys` and
 >`--recreate-CA` deliberately do not touch it. To rotate deliberately, remove
->`/opt/fog/secureboot/` and re-run the installer, then re-enroll every client.
+>the directory and re-run the installer, then re-enroll every client.
 
-The private key lives at `/opt/fog/secureboot/MOK.key`, `0600` inside a `0700`
-directory owned by root. It is never copied into the web root and the web
-server cannot read it — see
+The material lives under `/opt/fog/pki/secureboot/`: the enrolled authority in
+`ca/` and the signing certificate in `leaf/sign.{key,pem}`, private keys `0600`
+inside a directory owned by root. Nothing there is copied into the web root and
+the web server cannot read it — see
 [[secure-boot-signing|Secure Boot: signing FOS with your own key]] for the
-full procedure and for what to do on each client.
+full procedure and for what to do on each client, and
+[[pki-zones|FOG PKI Infrastructure]] for the layout.
+
+## Kernel backups
+
+| Option | What it does |
+| --- | --- |
+| `--kernel-backup-count <n>` | How many prior kernel and init generations to keep. Default 3. Restore one with `bin/restorekernel.sh` |
+| `--restore-kernel-backup` | Also restore the previous kernel and init set on this run. Used by `updatefog.sh` when reverting; not normally passed by hand |
+
+## See also
+
+- [[netboot-transport-and-pki|Netboot Transport and PKI]] — what the install modes mean
+- [[install-fogsettings|The .fogsettings file]] — where these options are remembered
+- [[install-fog-server|Installing the FOG server]]
+- [[dhcp-server-settings|DHCP server settings]] — where `--boot-delay` shows up on the client

--- a/docs/installation/server/migrating-fog-server.md
+++ b/docs/installation/server/migrating-fog-server.md
@@ -275,9 +275,9 @@ your organization's PKI — supply it at install time with
 `--web-ca-cert`/`--web-ca-key`/`--web-ca-root` instead of using FOG's
 generated one; see [[bringing-your-own-ca|Bringing your own CA]]. That
 replaces the **web** certificate only and deliberately leaves fog-client's
-pinned CA alone, which is what makes it safe to do on a live fleet. On
-working-1.6, `--external-ca` with `--ca-cert`/`--ca-key`/`--ca-root` is an
-older spelling of the same three options. If the goal is to stop importing one
+pinned CA alone, which is what makes it safe to do on a live fleet.
+`--external-ca` with `--ca-cert`/`--ca-key`/`--ca-root` is an older spelling of
+the same three options, and still works. If the goal is to stop importing one
 CA per server across several FOG servers,
 [[unify-certificates-across-fog-servers|Unifying certificates across several FOG servers]]
 covers that case specifically.
@@ -334,8 +334,8 @@ re-enrolling.
 `--secure-boot-key`/`--secure-boot-cert`): make those same files available to
 the new server — copied to the same path, or anywhere else — and pass the same
 flags when installing it. Post-PKI those two flags name the code-signing
-**leaf**, and `--secureboot-ca-cert` (working-1.6) names the intermediate that
-is actually enrolled in firmware:
+**leaf**, and `--secureboot-ca-cert` names the intermediate that is actually
+enrolled in firmware:
 
 ```bash
 cd /path/to/fogproject/bin

--- a/docs/kb/how-tos/index.md
+++ b/docs/kb/how-tos/index.md
@@ -27,6 +27,7 @@ More advanced/situational guides:
 - [[add-extend-a-2nd-virtual-hdd|Add & Extend a 2nd Virtual HDD]]
 - [[post-download-scripts|Post Download Scripts]]
 - [[unify-certificates-across-fog-servers|Unify Certificates Across FOG Servers]]
+- [[lets-encrypt-setup|Set up Let's Encrypt on a FOG server]]
 - [[firewall|Firewall Ports]]
 
 Secure Boot and booting without PXE:

--- a/docs/kb/how-tos/lets-encrypt-setup.md
+++ b/docs/kb/how-tos/lets-encrypt-setup.md
@@ -1,0 +1,246 @@
+---
+title: Set up Let's Encrypt on a FOG server
+aliases:
+    - Set up Let's Encrypt on a FOG server
+    - Let's Encrypt walkthrough
+    - ACME setup
+    - Public certificate setup
+description: End-to-end walkthrough for putting a publicly-issued certificate on a FOG server, including HTTPS netboot and automatic renewal
+context_id: lets-encrypt-setup
+tags:
+    - how-to
+    - certificates
+    - pki
+    - acme
+    - lets-encrypt
+    - netboot
+---
+
+# Set up Let's Encrypt on a FOG server
+
+A certificate from a public certificate authority buys a FOG server two things
+FOG's own authority cannot: browsers trust it with no import, and **iPXE can
+validate it during netboot with no rebuilt binary**. This walks through it end
+to end.
+
+>[!note] Terms used on this page
+>**ACME** is the protocol Let's Encrypt uses to issue and renew certificates
+>automatically. **DNS-01** is one of its challenge types: you prove you control
+>a domain by putting a record in its DNS, rather than by serving a file over
+>port 80. **FQDN** is the server's full DNS name, like `fog.example.com`.
+>**Leaf** is the server's own certificate, as opposed to the authority that
+>signed it.
+
+## What this gets you, and what it does not
+
+| | With a public certificate |
+|---|---|
+| Browsers and the API | Trusted with no CA import |
+| iPXE netboot over HTTPS | Works with **no** iPXE rebuild |
+| Secure Boot | Unaffected — staged and signed either way |
+| fog-client | **Read the caveat at the end before rolling this out** |
+
+## Before you start
+
+**You need an FQDN, and the booting clients need to resolve it.** A certificate
+is issued to a name; no public authority will issue one for a private IP, and
+iPXE fails the TLS handshake on a name mismatch even after the chain itself
+validates. The DNS servers your DHCP hands out have to answer for that name.
+
+**The server does not need to be reachable from the internet.** Use a **DNS-01**
+challenge and the only thing that has to be public is the DNS record, not the
+FOG server. That is the normal shape for an imaging server on a private network.
+
+You will need an ACME client — `acme.sh` and `certbot` are both fine — and API
+credentials for whoever hosts your DNS.
+
+## Step 1 — issue the certificate
+
+Get a certificate for the FQDN using a DNS-01 challenge. With `acme.sh` and a
+generic DNS provider:
+
+```bash
+acme.sh --issue --dns dns_yourprovider -d fog.example.com
+```
+
+Or with `certbot`:
+
+```bash
+certbot certonly --preferred-challenges dns \
+    --manual -d fog.example.com
+```
+
+Install the result somewhere stable that your renewal process will keep
+updating — `/etc/letsencrypt/live/fog.example.com/` for certbot, or wherever
+`acme.sh --install-cert` puts it. **Do not** copy the files into FOG's own PKI
+tree; the point of the next step is to tell FOG they live elsewhere and are not
+FOG's to manage.
+
+>[!note] Cloudflare DNS-01 recipe — to be filled in
+>@darksidemilk has a working Cloudflare DNS-challenge recipe to contribute
+>here. Until then, use your provider's DNS-01 plugin as above; nothing on the
+>rest of this page depends on which provider you use.
+
+## Step 2 — tell FOG the certificate is not its to manage
+
+There are two separate things to say, and FOG learns them in two different
+ways.
+
+**"Something other than FOG renews this leaf" is not a setting.** FOG works it
+out from the filesystem. It always refers to the vhost certificate by a
+*canonical* path, and asks where that path resolves: if the answer is outside
+its own web zone directory, the leaf belongs to something else. So you point
+the canonical paths at your ACME files and FOG reads the target and leaves it
+alone:
+
+```bash
+ln -sf /etc/letsencrypt/live/fog.example.com/fullchain.pem \
+       /opt/fog/pki/web/leaf/.webLeaf.pem
+ln -sf /etc/letsencrypt/live/fog.example.com/privkey.pem \
+       /opt/fog/pki/web/leaf/.webLeaf.key
+```
+
+That is what stops the installer regenerating the certificate from its original
+signing request while your ACME client owns the key — a certificate/key
+mismatch that stops the web server — and what stops FOG locking the private key
+to `root:root 0600`, which would break a renewal hook running as anyone else.
+
+>[!important] Point the path at your file; do not write your file at the path
+>Editing the path in `.fogsettings` moves nothing: FOG recomputes canonical
+>paths on every run. And having your ACME client write a *real file* to
+>`/opt/fog/pki/web/leaf/.webLeaf.pem` is worse than doing nothing — that file
+>is inside FOG's own web zone, so FOG concludes the leaf is its and re-issues
+>it. A symlink out of the zone cannot be misread that way.
+>
+>This replaces FOG 1.5's `acmeLeaf='yes'`, which had to be typed in by hand and
+>failed in exactly this manner when it was forgotten — silently, under `-y`.
+
+**"This certificate chains to a public root" is a setting**, because nothing on
+disk can tell FOG that. Edit [[install-fogsettings|/opt/fog/.fogsettings]]:
+
+```bash
+PKI_web_cert_publicly_trusted='yes'
+```
+
+This is what moves netboot to HTTPS, because it tells FOG that iPXE will be
+able to validate the chain on its own. FOG never measures it: it anchors its
+own CA in this server's trust store, so probing that store would report FOG's
+own leaf as trusted — exactly the case that *does* need an iPXE rebuild.
+
+The two answers are independent, and all four combinations are real. An
+**internal** ACME server such as step-ca is a symlinked leaf with
+`PKI_web_cert_publicly_trusted='no'`.
+
+## Step 3 — make FOG address itself by name
+
+Two places have to agree with the name on the certificate.
+
+**The installer's idea of the hostname**, if `hostname -f` does not already
+return the FQDN:
+
+```bash
+./installfog.sh --hostname fog.example.com
+```
+
+**`FOG_WEB_HOST`**, in the web interface under
+FOG Configuration → FOG Settings → Web Server. This one is easy to miss and
+breaks netboot in a way that looks like a certificate problem:
+
+>[!warning] Set FOG_WEB_HOST or HTTPS netboot fails after the first hop
+>The boot script the installer writes chains to the server by hostname, so the
+>first request succeeds. But `boot.php` then rebuilds every later URL — the
+>kernel, the init, `MOK.der`, the background image — from `FOG_WEB_HOST`, which
+>holds the server's **IP address** on a fresh install and is not updated by
+>upgrades. Every one of those fetches then fails iPXE's name check.
+>
+>Set it to the same FQDN the certificate is issued to. Nothing in the installer
+>does this for you.
+
+## Step 4 — run the installer
+
+```bash
+cd /path/to/fogproject/bin
+./installfog.sh --install-mode public-cert
+```
+
+`public-cert` sets `WEB_url_proto=https`, `BOOT_url_proto=https` and
+`PKI_web_cert_publicly_trusted=yes`, and leaves
+`BOOT_rebuild_ipxe_with_my_ca=no` — which is the whole point, since a public
+certificate needs no rebuild. See
+[[netboot-transport-and-pki|Netboot Transport and PKI]].
+
+The installer will not re-issue your leaf, will not touch its key permissions,
+and will refuse to write a boot script that chains to an IP over HTTPS rather
+than completing and leaving you unable to boot.
+
+## Step 5 — verify
+
+**The served chain**, from another machine:
+
+```bash
+openssl s_client -connect fog.example.com:443 -servername fog.example.com </dev/null 2>/dev/null \
+    | openssl x509 -noout -subject -issuer -dates
+```
+
+The issuer should be your public CA, and the subject should be the FQDN.
+
+**The boot script** actually names the FQDN:
+
+```bash
+grep chain /tftpboot/default.ipxe
+```
+
+It should read `https://fog.example.com/fog/service/ipxe/boot.php`, not an IP.
+
+**A real client.** Netboot one machine and watch it get past `boot.php` to the
+menu. Getting to the menu and then failing on a later fetch is the
+`FOG_WEB_HOST` symptom from step 3.
+
+## Renewal
+
+Renewal is your ACME client's job, not FOG's. FOG follows the symlinks to
+whatever is there now, so a renewal that writes to the same paths needs nothing
+from FOG — only a web server reload:
+
+```bash
+systemctl reload nginx     # or: systemctl reload httpd / apache2
+```
+
+Wire that into your client's post-renewal hook.
+
+>[!note] Nothing re-runs the installer for you
+>A renewed **leaf** needs no installer run. A changed **issuing intermediate**
+>is different, and Let's Encrypt does rotate intermediates — see the caveat
+>below and [[external-ca-lets-encrypt#renewal-and-rotation|Renewal and rotation]].
+
+## The fog-client caveat — check this before a fleet rollout
+
+The certificate zones were separated in 1.6: the **Web TLS** certificate this
+page swaps out, and the **Client Communication** certificate fog-client uses,
+are no longer the same material.
+[[pki-zones|FOG PKI Infrastructure]] records the cost of changing the Web TLS
+zone as *"None. Browsers just need the issuer trusted."*
+
+But [[external-ca-lets-encrypt|External CA & Let's Encrypt Certificates]] also
+documents fog-client as pinning `ca.cert.der` and requiring that exact
+certificate in the served chain — which a Let's Encrypt chain does not contain,
+and which LE's intermediate rotation would break even if it did. That passage
+predates the zone split and has not been re-verified against it.
+
+**The two pages disagree, and this one is not going to guess.** Before rolling a
+public certificate out to a fleet running fog-client, swap it on the server and
+confirm that **one** already-registered client still checks in. If it does, the
+zone split has done its job. If it does not, the pinning caveat still applies
+and an internal ACME CA is the better fit — see
+[[external-ca-lets-encrypt#recommended-internal-acme-ca-step-ca|the step-ca recommendation]],
+which gives you ACME automation with a stable pinned CA.
+
+Netboot and browser trust are unaffected either way.
+
+## See also
+
+- [[netboot-transport-and-pki|Netboot Transport and PKI]] — why a public certificate needs no iPXE rebuild
+- [[external-ca-lets-encrypt|External CA & Let's Encrypt Certificates]] — the reference behind this walkthrough
+- [[pki-zones|FOG PKI Infrastructure]] — the three certificate zones
+- [[install-fogsettings|The .fogsettings file]] — `PKI_web_cert_publicly_trusted` and the canonical certificate paths
+- [[command-line-options|Fog installer command line options]] — `--install-mode`, `--hostname`

--- a/docs/kb/how-tos/secure-boot-setup-mode-enrollment.md
+++ b/docs/kb/how-tos/secure-boot-setup-mode-enrollment.md
@@ -144,10 +144,11 @@ same Secure Boot CA, not alternatives that conflict. Confirmed on real UEFI
 hardware: machines boot FOG's leaf-signed kernels while trusting only the
 intermediate, whether that intermediate was enrolled as `MOK.der` through
 MokManager or written into `db` through this path. That verification
-predates the name-constraints extension now carried on the Secure Boot
-CA — re-confirm on hardware before relying on it, and use
-`--no-sb-name-constraints` (see
-[[pki-zones#name-constraints|Name constraints]]) if a fleet rejects the chain.
+predates a name-constraints extension that the Secure Boot CA briefly carried
+and no longer does: FOG 1.6 took constraints off this zone entirely, precisely
+because a critical extension firmware mishandles costs a trip to every machine.
+There is no flag to re-enable them — `--no-sb-name-constraints` was removed with
+the setting behind it. See [[pki-zones#name-constraints|Name constraints]].
 
 >[!note] Validation status
 >Route C has been validated end to end in VirtualBox: Setup Mode → task

--- a/docs/kb/how-tos/secure-boot-signing.md
+++ b/docs/kb/how-tos/secure-boot-signing.md
@@ -79,19 +79,25 @@ iPXE** boots under Secure Boot with nothing for you to sign.
 The catch is specific to FOG, and it is worth being precise about, because it
 is the whole reason this guide exists:
 
-**FOG does not ship stock iPXE binaries.** FOG builds its own, with the boot
-script compiled in (`EMBED=ipxescript`) and — on HTTPS installs using FOG's
-own internal CA — the server's CA baked in (`TRUST=`). Those are by
-definition custom binaries, they carry no signature, and iPXE's signed shim
-will refuse them, exactly as it should. A shim that loaded any binary calling
-itself iPXE would be worthless.
+**FOG does not ship stock iPXE binaries.** FOG builds its own — the BIOS
+targets with the boot script compiled in (`EMBED=ipxescript`), and, when you
+ask for it with `--rebuild-ipxe-with-my-ca`, with your CA baked in (`TRUST=`).
+Those are by definition custom binaries, so upstream's signed shim will not
+accept them on the strength of iPXE's vendor certificate alone, exactly as it
+should. A shim that loaded any binary calling itself iPXE would be worthless.
 
-FOG could not fix this by signing its own builds either. The shim only trusts
-iPXE's vendor certificate, so a FOG-signed binary would need every machine to
-enroll FOG's key first — the same physical visit this guide already asks for,
-while making one key compromise everyone's problem at once. There is no
-mechanism, on any FOG release, for signing a custom-rebuilt iPXE binary with
-FOG's own Secure Boot certificate so that shim would accept it.
+What FOG *does* do is sign them itself. Every `.efi` in FOG's TFTP tree is
+signed with this server's own Secure Boot key, and shim will load one once that
+key has been enrolled as a MOK on the machine — which is the physical visit
+this guide is about. So the choice is not "signed shim or custom binary"; it is
+whether you need a custom binary badly enough to enrol a key before the machine
+can netboot. Most sites do not, which is why the section below matters.
+
+>[!note] Only your own tree is signed
+>`secureboot/` is left strictly alone — that is upstream's Microsoft-signed
+>shim, its loaders and MokManager, and adding a second signature to them buys
+>nothing. Binaries you build and copy into `/tftpboot` by hand are not signed
+>either; re-run the installer so it signs them.
 
 The way out is to stop needing a custom binary. FOG's embedded boot script is
 entirely generic, and iPXE 2.0 can fetch that script from the TFTP server
@@ -272,13 +278,13 @@ Nothing is served from this directory unless you point DHCP at it, so its
 presence changes nothing for your existing clients.
 
 >[!info] If the directory is missing
->Two reasons it would not be there. **HTTPS-netboot installs using FOG's own
->CA skip it** — these are upstream's generic binaries, so they cannot carry
->your server's CA, and a signed binary cannot be rebuilt without voiding the
->signature. See [[pki-zones#https-and-netboot|HTTPS and netboot]] for the way
->round that, and note that a public CA on the vhost avoids the tradeoff
->entirely. Otherwise the download failed — it is deliberately not fatal —
->and the installer will have said so. Re-run it.
+>There is one reason now: the download failed. It is deliberately not fatal, so
+>the install completed and said so in its output — re-run it.
+>
+>Earlier releases also skipped this directory on any HTTPS install, on the
+>reasoning that Secure Boot and HTTPS could not coexist. They can, and FOG 1.6
+>stages it in **every** install mode. See
+>[[netboot-transport-and-pki|Netboot Transport and PKI]].
 
 You can confirm you have a signed binary — a signed one has a non-empty
 certificate table, an unsigned one does not:
@@ -504,19 +510,20 @@ would put a root password; see [The signing key](#the-signing-key).
   together than you'd expect.** A web certificate from a **public CA** (e.g.
   Let's Encrypt) on an FQDN gets you HTTPS netboot with no rebuild and no
   loss of the signed Secure Boot shim — see
-  [[pki-zones#https-and-netboot|HTTPS and netboot]] for why. It's only
-  FOG's own or your internal (non-publicly-trusted) CA that forces a choice
-  between a `TRUST=`-rebuilt iPXE (HTTPS netboot, no signed shim) and the
-  signed shim (Secure Boot, netboot stays HTTP) — unless you use
-  [[secure-boot-setup-mode-enrollment|Setup Mode enrollment]] to skip shim's
-  involvement entirely.
+  [[netboot-transport-and-pki|Netboot Transport and PKI]] for why. With FOG's
+  own or your internal CA, a `TRUST=`-rebuilt iPXE is needed, and that binary
+  is signed by this server rather than by iPXE — so it costs you a MOK
+  enrolment *before* the machine can netboot, not the signed shim itself.
+  [[secure-boot-setup-mode-enrollment|Setup Mode enrollment]] skips shim's
+  involvement entirely if you would rather.
 - **A Secure Boot USB stick does not work the same way.** The filename trick
   the shim uses to find its second stage — `automatic_next_path()` — is called
   only from shim's network and HTTP boot paths. There is no local-filesystem
   equivalent, so a shim booted from a USB stick or an ESP ignores the `-shim`
   rename entirely and falls back to its compiled-in default, `ipxe.efi`. If you
   build a Secure Boot USB from these instructions, name the second stage
-  `ipxe.efi` or it will not be found.
+  `ipxe.efi` or it will not be found. FOG's ready-made ESP archives sidestep
+  this by shipping both loaders — see [[local-esp-boot|Local ESP Boot]].
 
 >[!warning] Turning Secure Boot on can break existing Windows Hello for Business sign-in
 >If a machine already has users signed in with Windows Hello for Business

--- a/docs/kb/how-tos/unify-certificates-across-fog-servers.md
+++ b/docs/kb/how-tos/unify-certificates-across-fog-servers.md
@@ -254,7 +254,7 @@ You want `OK`.
 >
 >```bash
 >sudo openssl x509 -noout -issuer \
->  -in "$(grep -oP "(?<=^sslpubcert=').*(?=')" /opt/fog/.fogsettings)"
+>  -in "$(grep -oP "(?<=^PKI_web_vhost_cert=').*(?=')" /opt/fog/.fogsettings)"
 >```
 >
 >`CN = FOG Web CA - <hostname>` here means the install worked and the problem is
@@ -262,7 +262,7 @@ You want `OK`.
 >sends the old one"* under [Troubleshooting](#troubleshooting). Anything else
 >means the install itself did not take.
 >
->Note the path comes from `sslpubcert`. `/opt/fog/snapins/ssl/.srvpublic.crt` is
+>Note the path comes from `PKI_web_vhost_cert`. `/opt/fog/snapins/ssl/.srvpublic.crt` is
 >the **client communication** certificate, a different zone, and it is *supposed*
 >to stay signed by the server's own CA — reading that one instead will convince
 >you a working setup is broken.

--- a/docs/kb/integrations/external-ca-lets-encrypt.md
+++ b/docs/kb/integrations/external-ca-lets-encrypt.md
@@ -146,7 +146,7 @@ page.
 >A real Let's Encrypt certificate on the vhost does validate for iPXE
 >netboot with no FOG-side change, as this section claims. Getting there in
 >practice took two settings beyond just dropping the cert in place:
->`httpproto` in `.fogsettings` set to `https`, and `FOG_WEB_HOST` (in the
+>`WEB_url_proto` in `.fogsettings` set to `https`, and `FOG_WEB_HOST` (in the
 >FOG web UI's Settings page) set to the server's FQDN, not its IP address.
 
 ---
@@ -234,24 +234,28 @@ would mean owning its failure modes, its renewal scheduling, and its
 credential handling without adding anything those tools don't already do
 better.
 
-Point your ACME client's install/renew hook at the two paths FOG's vhost
-reads — `sslpubcert` and `sslprivkey` from `/opt/fog/.fogsettings` — and
-reload the web server afterward:
+Let your ACME client own its own directory, and then make FOG's canonical
+paths **resolve** there. That second step is what tells FOG the leaf is not
+its own:
 
 ```bash
 acme.sh --issue --server https://step-ca.internal/acme/acme/directory \
     -d fog.example.com --webroot /var/www/html
 acme.sh --install-cert -d fog.example.com \
-    --key-file       /opt/fog/pki/web/leaf/.webLeaf.key \
-    --cert-file      /opt/fog/pki/web/leaf/.webLeaf.pem \
-    --ca-file        /opt/fog/pki/web/ca/.fogWebCAchain.pem \
+    --key-file       /etc/ssl/fog-acme/fog.example.com.key \
+    --cert-file      /etc/ssl/fog-acme/fog.example.com.pem \
+    --ca-file        /etc/ssl/fog-acme/chain.pem \
     --reloadcmd      "systemctl reload httpd"     # apache2 on Ubuntu
 ```
 
-`--cert-file` (leaf only) maps to `sslpubcert`; `--ca-file` (intermediate
-only) maps to `sslcachain` — matching Apache's
-`SSLCertificateFile`/`SSLCertificateChainFile` split. Don't use
-`--fullchain-file` for `sslpubcert`, or the vhost ends up listing the
+```bash
+ln -sf /etc/ssl/fog-acme/fog.example.com.pem /opt/fog/pki/web/leaf/.webLeaf.pem
+ln -sf /etc/ssl/fog-acme/fog.example.com.key /opt/fog/pki/web/leaf/.webLeaf.key
+```
+
+`--cert-file` is the leaf only and `--ca-file` the intermediate only,
+matching Apache's `SSLCertificateFile`/`SSLCertificateChainFile` split.
+Don't point the leaf at `--fullchain-file`, or the vhost ends up listing the
 intermediate twice.
 
 Use a DNS-01 plugin instead of `--webroot` if you do not want to expose port
@@ -259,22 +263,22 @@ Use a DNS-01 plugin instead of `--webroot` if you do not want to expose port
 practical option for public Let's Encrypt on a server that is not publicly
 reachable.
 
-**Tell the installer to stop managing the leaf.** Add this to
-`/opt/fog/.fogsettings`:
+>[!important] Do not have your ACME client write straight to the canonical paths
+>It looks simpler and it silently reintroduces the exact failure this section
+>exists to prevent. FOG decides whether a leaf is its own by asking where the
+>canonical path *resolves*: a real file sitting at
+>`/opt/fog/pki/web/leaf/.webLeaf.pem` is inside FOG's own web zone, so FOG
+>concludes the leaf is its and re-issues it from the stored request — while your
+>ACME private key sits beside it. That is a mismatched pair and a web server
+>that will not start, and under `-y` there is nobody to notice.
+>
+>A symlink pointing out of the zone directory cannot be misread that way. This
+>replaces FOG 1.5's `acmeLeaf=yes`, which had to be typed in by hand and had
+>exactly this failure mode when it was forgotten. There is nothing to set now.
 
-```
-acmeLeaf=yes
-sslprivkey=/opt/fog/pki/web/leaf/.webLeaf.key
-sslpubcert=/opt/fog/pki/web/leaf/.webLeaf.pem
-sslcachain=/opt/fog/pki/web/ca/.fogWebCAchain.pem
-```
-
-Without it, the next `installfog.sh` run regenerates the leaf from a stale
-public key while the private key on disk is the one your ACME client
-installed — a certificate and key that don't match, and a web server that
-refuses to start. `--recreate-keys` and `--recreate-CA` deliberately
-override this marker, since both regenerate the keypair anyway and a
-self-signed pair is the correct fallback at that point.
+`--recreate-keys` and `--recreate-CA` deliberately override the symlinks,
+since both regenerate the keypair anyway and a self-signed pair is the
+correct fallback at that point.
 
 >[!note] This used to be a much sharper trap
 >Before FOG's certificate zones were separated, the web server's private

--- a/docs/kb/reference/netboot-transport-and-pki.md
+++ b/docs/kb/reference/netboot-transport-and-pki.md
@@ -49,7 +49,9 @@ vocabulary, see [[pki-glossary|PKI Glossary]].
 >Everything on this page is 1.6. In 1.5.x a single `httpproto` setting decided
 >the web protocol, the HTTP→HTTPS redirect and whether iPXE was recompiled, all
 >at once. Those are now separate settings, and the old behaviour of inferring one
->from another is gone.
+>from another is gone. Every setting on this page was also renamed in 1.6 — an
+>existing `.fogsettings` migrates itself on the first run. See
+>[[install-fogsettings#The 1.6 rename|The 1.6 rename]].
 
 ## The four install modes
 
@@ -80,32 +82,47 @@ no setting silently changes another:
 
 | Setting | Default | What it means |
 |---|---|---|
-| `httpproto` | `https` | The protocol FOG uses for its own **non-netboot** URLs |
-| `netbootproto` | `http` | The protocol iPXE uses to fetch `boot.php` |
-| `publicWebCert` | `no` | The web certificate chains to a **public** root |
-| `rebuildIpxeWithMyCA` | `no` | Recompile iPXE with your CA embedded in it |
-| `httpsRedirect` | `no` | Redirect HTTP to HTTPS, and send HSTS |
-| `acmeLeaf` | `no` | The leaf certificate is managed outside FOG |
+| `WEB_url_proto` | `https` | The protocol FOG uses for its own **non-netboot** URLs |
+| `BOOT_url_proto` | `http` | The protocol iPXE uses to fetch `boot.php` |
+| `PKI_web_cert_publicly_trusted` | `no` | The web certificate chains to a **public** root |
+| `BOOT_rebuild_ipxe_with_my_ca` | `no` | Recompile iPXE with your CA embedded in it |
+| `WEB_https_redirect` | `no` | Redirect HTTP to HTTPS, and send HSTS |
 
-Two of them are statements of fact about your certificate rather than
-instructions: `publicWebCert` says **what the certificate chains to**, and
-`acmeLeaf` says **who renews it**. They are different questions and all four
-combinations are real — an internal ACME server such as step-ca is
-`acmeLeaf=yes` with `publicWebCert=no`. Either one tells FOG the certificate was
-issued somewhere else, so FOG will neither re-issue it nor lock its private key
-away from whatever renews it.
+The `WEB_` and `BOOT_` prefixes are the point of the naming: they are separate
+namespaces precisely because "the web UI uses HTTPS" says nothing about how
+clients netboot, and parallel names in different categories make that
+independence visible in the file you edit.
+
+`PKI_web_cert_publicly_trusted` is a statement of fact about your certificate
+rather than an instruction — it says **what the certificate chains to**. It is
+never measured: FOG anchors its own CA in this server's trust store, so probing
+that store would report FOG's own leaf as trusted, which is exactly the case
+that does need the rebuild.
+
+**Who renews the certificate is a separate question, and it has no setting.**
+FOG asks the filesystem: when the canonical path `PKI_web_vhost_cert` resolves
+outside FOG's own web zone directory, the leaf belongs to something else, so FOG
+neither re-issues it nor locks its private key away from whatever renews it.
+Both answers are independent — an internal ACME server such as step-ca is an
+externally-renewed leaf with `PKI_web_cert_publicly_trusted='no'`. See
+[[install-fogsettings#Certificates FOG did not issue|Certificates FOG did not issue]].
 
 ### How the netboot protocol is decided
 
-1. If you passed `--netboot-proto`, that wins — and it is **remembered**, so a
-   later run without the option does not undo it.
-2. Otherwise it becomes `https` if **either** `publicWebCert=yes` **or**
-   `rebuildIpxeWithMyCA=yes`.
+1. If you passed `--netboot-proto`, that wins — and the fact that you forced it
+   is **remembered separately**, in `BOOT_url_proto_forced`, so a later run
+   without the option does not undo it.
+2. Otherwise it becomes `https` if **either**
+   `PKI_web_cert_publicly_trusted='yes'` **or**
+   `BOOT_rebuild_ipxe_with_my_ca='yes'`.
 3. Otherwise it is `http`.
 
 A value that FOG derived for you is re-derived on every run. That is deliberate:
 if you later turn off the thing that put netboot on HTTPS, netboot goes back to
-HTTP instead of outliving the reason it was there.
+HTTP instead of outliving the reason it was there. It is also why the forced flag
+is its own setting — when the derived answer and a deliberate override share one
+key, a value FOG worked out once becomes indistinguishable from one you chose,
+and goes on overriding the settings it was derived from.
 
 You may force `--netboot-proto https` with neither trigger set. It is allowed,
 and the installer warns you, because iPXE cannot be told to trust a private CA
@@ -218,7 +235,7 @@ or constrain it with `dNSName`/`iPAddress` subtrees only. See
 
 ## Why the HTTPS redirect is off by default
 
-`httpsRedirect` is not part of any mode, and no mode turns it on.
+`WEB_https_redirect` is not part of any mode, and no mode turns it on.
 
 Trust in FOG's own certificate authority reaches a client machine when
 **fog-client installs it into that machine's trusted root store**. On a fresh

--- a/docs/kb/reference/pki-glossary.md
+++ b/docs/kb/reference/pki-glossary.md
@@ -102,8 +102,10 @@ at.
 ### ACME leaf
 
 The web leaf when it's sourced from an external ACME client (e.g.
-`acme.sh`) instead of FOG's own Web CA, flagged via `acmeLeaf=yes` in
-`.fogsettings`. See
+`acme.sh`) instead of FOG's own Web CA. FOG detects this rather than being
+told: the canonical path `PKI_web_vhost_cert` resolving outside the web zone
+directory *is* the signal, so there is nothing to set. FOG 1.5's `acmeLeaf=yes`
+flag is retired. See
 [[external-ca-lets-encrypt|External CA & Let's Encrypt]].
 
 ### Pinning (fog-client)

--- a/docs/kb/reference/pki-zones.md
+++ b/docs/kb/reference/pki-zones.md
@@ -106,8 +106,8 @@ that CA issues day to day):
 | Path | What it is |
 |---|---|
 | `root/ca/.fogCA.{key,pem}` | The anchor. Key never regenerated, `0400 root:root`. |
-| `root/leaf/.srvprivate.key` | Symlink → `$sslpath/.srvprivate.key` |
-| `root/leaf/.srvpublic.crt` | Symlink → `$sslpath/.srvpublic.crt` |
+| `root/leaf/.srvprivate.key` | Symlink → `$PKI_client_cert_dir/.srvprivate.key` |
+| `root/leaf/.srvpublic.crt` | Symlink → `$PKI_client_cert_dir/.srvpublic.crt` |
 | `web/ca/.fogWebCA.{key,pem}` | Signs the vhost's certificate |
 | `web/ca/.fogWebCAchain.pem` | CA + web intermediate |
 | `web/leaf/.webLeaf.{key,pem}` | What the web server actually serves |
@@ -196,8 +196,8 @@ for the fleet-wide implications of that.
 
 Either invocation refuses, and tells you the exact path to restore, if the
 signing CA's private key isn't on this server. The web leaf invocation also
-refuses on an ACME-managed leaf (`acmeLeaf=yes`) — renew that one through
-your ACME client instead; see
+refuses on a leaf managed outside FOG — one whose canonical path resolves
+outside this zone directory. Renew that one through your ACME client instead; see
 [[external-ca-lets-encrypt|External CA & Let's Encrypt certificates]].
 
 Nothing here runs on a timer — wire it into your own cron if you want
@@ -229,12 +229,19 @@ Extend or narrow with:
 >installer verifies the leaf against its issuer after signing and names the
 >`rm -rf` that lets the CA be re-created with the new constraints.
 
-**On the Secure Boot CA the constraints are opt-out**, via
-`--no-sb-name-constraints`. They don't constrain anything that matters for
-code signing — a code-signing leaf carries no names anyone resolves — and
-they sit in the one certificate UEFI and shim actually parse. The flag
-exists so a fleet that rejects the chain is a re-issue of one intermediate,
-not a re-enrollment of every machine.
+**The Secure Boot CA carries no name constraints at all**, and since FOG 1.6
+there is deliberately no setting or flag to add them. They don't constrain
+anything that matters for code signing — a code-signing certificate carries no
+names anyone resolves — and they sit in the one certificate UEFI and shim
+actually parse, where a critical extension the firmware mishandles costs a
+physical trip to every machine.
+
+`--no-sb-name-constraints` used to make them opt-out, and was removed with the
+setting behind it: an opt-out put the safe answer behind a flag nobody passes
+until a fleet has already failed to boot. Existing servers keep whatever their
+Secure Boot intermediate already carries, since an intermediate is never
+re-minted. Constraints stay on the **Web** CA, where iPXE is a verifier FOG can
+patch and firmware is not.
 
 >[!note] A related trap, measured rather than assumed
 >OpenSSL applies DNS constraints to the subject **CN** when a certificate
@@ -297,11 +304,15 @@ reference fixed canonical paths. Those paths may be symlinks, so the real
 files can live wherever you keep certificates:
 
 ```bash
-sed -i "s|^sslprivkey=.*|sslprivkey='/etc/pki/fog/server.key'|" /opt/fog/.fogsettings
-./installfog.sh -Y
+ln -sf /etc/pki/fog/server.key /opt/fog/pki/web/leaf/.webLeaf.key
+ln -sf /etc/pki/fog/server.pem /opt/fog/pki/web/leaf/.webLeaf.pem
 ```
 
-Relocating a certificate then never means editing the vhost.
+Relocating a certificate then never means editing the vhost — or
+`.fogsettings`. The canonical path is what FOG recomputes and refers to every
+run, so pointing the *path* somewhere else does nothing; make the path
+**resolve** to your file instead. FOG reads the target, sees it is outside this
+zone, and leaves it alone.
 
 >[!note]
 >SELinux labels follow the symlink **target**, so a certificate outside the
@@ -348,7 +359,8 @@ an alternative that bypasses shim entirely, not the only route.
 
 Netboot stays on HTTP unless something asks otherwise, on fresh installs and
 existing servers alike. It moves to HTTPS when the web certificate is declared
-public (`publicWebCert`) or the rebuild is requested (`rebuildIpxeWithMyCA`).
+public (`PKI_web_cert_publicly_trusted`) or the rebuild is requested
+(`BOOT_rebuild_ipxe_with_my_ca`).
 A value FOG derived is re-derived on every run, so turning the trigger back off
 returns netboot to HTTP. Override either way with `--netboot-proto http|https`,
 which is remembered.
@@ -361,7 +373,7 @@ which is remembered.
 >certificate.
 
 >[!info] FOG 1.6
->The web/API-vs-netboot protocol split described above (`netbootproto`,
+>The web/API-vs-netboot protocol split described above (`BOOT_url_proto`,
 >`--netboot-proto`) is a FOG 1.6 addition, and its Nginx support is
 >unverified — see [Still unverified](#still-unverified).
 
@@ -394,7 +406,7 @@ unattended).
 ## Still unverified
 
 - **Nginx.** Vhost changes for this redesign (the managed-block splice, the
-  `netbootproto` redirect exclusion) have been exercised on Apache only.
+  `BOOT_url_proto` redirect exclusion) have been exercised on Apache only.
 - **Secure Boot with name constraints, on hardware.**
 - **Node certificate issuance against a real second machine.** The endpoint
   and the signing helper are each verified in isolation; the two halves

--- a/docs/management/server/install-fogsettings.md
+++ b/docs/management/server/install-fogsettings.md
@@ -37,9 +37,67 @@ work instead of asking eighty questions again.
 >[!warning] Do not paste this file into a forum post or a bug report
 >It contains your `fogproject` account password (which is also the FTP account
 >used for image replication, so it is fleet-wide) and your database password.
->Redact `password` and `snmysqlpass` first.
+>Redact `SVC_password` and `DB_password` first.
+
+## Key names tell you who owns the setting
+
+Every setting the installer manages is named `CATEGORY_lower_snake_case`. The
+first `_` is the category boundary, and there are nine categories:
+
+| Prefix | Owns |
+|---|---|
+| `FOG_` | Install shape, OS records, update channel, install location |
+| `NET_` | This server's own network identity |
+| `DHCP_` | FOG acting *as* a DHCP server |
+| `DB_` | The database connection and its dump path |
+| `WEB_` | The web server and the web-UI URL surface |
+| `PKI_` | Certificate authorities and trust, with a zone token in the name |
+| `BOOT_` | The client netboot path: iPXE, TFTP, FOS kernels |
+| `STORAGE_` | Image storage and its NFS export |
+| `SVC_` | FOG's own system account and host services |
+
+**The category is the subsystem that *owns* the value, not every subsystem that
+reads it.** That is what settles the settings that could plausibly sit in two
+places: the storage-node database password is `DB_password`, not a `STORAGE_`
+key, because it is a database credential — that a node also uses it is carried
+by `FOG_install_type='S'` instead.
+
+>[!note] `WEB_` and `BOOT_` look like one category and are not
+>"The web UI uses HTTPS" says nothing about how clients netboot. `WEB_url_proto`
+>and `BOOT_url_proto` are deliberately parallel names in separate namespaces, so
+>that independence is visible in the file you edit. See
+>[[netboot-transport-and-pki|Netboot Transport and PKI]].
+
+If you are upgrading from FOG 1.5, every name in this file changed — see
+[[install-fogsettings#The 1.6 rename|The 1.6 rename]]. You do not have to do
+anything about it.
+
+## The four kinds of setting
+
+Confusing these is the source of most surprises in this file, so it is worth
+knowing which kind you are looking at before you edit anything. Every table in
+the reference below marks each setting with its kind.
+
+| Kind | Meaning | Editing it by hand |
+|---|---|---|
+| **Preference** | Your decision. Persisted so it survives an upgrade, and nothing may silently reverse it | **Works.** This is the intended way to change some of them |
+| **Record** | Written so you can read it back. The installer recomputes the real value every run and ignores what is stored | **Does nothing.** Use the installer option instead |
+| **Hand-set** | Nothing in the installer ever writes it. It survives only because the merge preserves lines it does not manage | **The only way to set it** |
+| **Inferred preference** | A preference the installer may write *once* from what it observed, and then treats as yours | **Works**, and your value is then final |
+
+>[!important] A preference and a record can never be the same setting
+>`BOOT_url_proto` used to be both, and it caused a real bug: a value one run
+>*derived* was indistinguishable from one an admin *forced*, so it went on
+>overriding the very settings it had been derived from. On a live server, an
+>install resolved `http` and wrote it down; the admin then set
+>`PKI_web_cert_publicly_trusted='yes'` and watched it be read and ignored.
+>
+>The pair is split now. `BOOT_url_proto` is a record, re-derived every run;
+>`BOOT_url_proto_forced` is the preference that says you chose it.
 
 ## Example
+
+A freshly written file, with the category blocks the installer emits:
 
 ```bash
 ## Start of FOG Settings
@@ -48,53 +106,103 @@ work instead of asking eighty questions again.
 ##     https://wiki.fogproject.org/wiki/index.php?title=.fogsettings
 ## Version: 1.6.0
 ## Install time: Mon 17 Aug 2026 05:13:02 PM CDT
-ipaddress='10.0.0.39'
-copybackold='0'
-interface='ens3'
-submask='255.255.255.0'
-hostname='fog.example.lan'
-routeraddress='10.0.0.1'
-plainrouter='10.0.0.1'
-dnsaddress='208.67.222.222'
-username='fogproject'
-password='<redacted>'
-osid='1'
-osname='Redhat'
-dodhcp='N'
-bldhcp='0'
-dhcpd='dhcpd'
-blexports='1'
-installtype='N'
-snmysqluser='fogmaster'
-snmysqlpass='<redacted>'
-snmysqlhost='localhost'
-mysqldbname='fog'
-installlang='0'
-storageLocation='/images'
-fogupdateloaded=1
-docroot='/var/www/html/'
-webroot='/fog/'
-caCreated='yes'
-httpproto='http'
-sslpath='/opt/fog/snapins/ssl'
-backupPath='/home/'
-php_ver='8.3'
-sslprivkey='/opt/fog/pki/web/leaf/.webLeaf.key'
-sslcapem='/opt/fog/pki/web/ca/.fogWebCA.pem'
-rootCAPem='/opt/fog/snapins/ssl/CA/.fogCA.pem'
-secureboot='1'
-secureBootKey='/opt/fog/pki/secureboot/leaf/sign.key'
-fwconfigure='configure'
-netbootproto='http'
-webserver='nginx'
-sendreports='Y'
+
+## FOG -- install shape, OS records, update channel, install location
+FOG_install_type='N'
+FOG_os_id='1'
+FOG_os_name='Redhat'
+FOG_install_lang='0'
+FOG_send_reports='Y'
+FOG_copy_back_old='0'
+FOG_installed=1
+FOG_packages='...'
+FOG_git_path='/root/fogproject'
+FOG_update_channel='stable'
+FOG_program_dir='/opt/fog'
+
+## NET -- this server own network identity
+NET_interface='ens3'
+NET_fog_server_ip='10.0.0.39'
+NET_subnet_mask='255.255.255.0'
+NET_hostname='fog.example.lan'
+
+## DHCP -- FOG acting AS a DHCP server
+DHCP_enabled='0'
+DHCP_engine='isc'
+DHCP_service_name='dhcpd'
+DHCP_router='10.0.0.1'
+DHCP_dns_server_ip='208.67.222.222'
+DHCP_range_start=''
+DHCP_range_end=''
+
+## DB -- the database connection and its dump path
+DB_name='fog'
+DB_host='localhost'
+DB_user='fogmaster'
+DB_password='<redacted>'
+DB_external=''
+DB_backup_path='/home/'
+
+## WEB -- the web server and the web-UI URL surface
+WEB_server_engine='nginx'
+WEB_docroot='/var/www/html/'
+WEB_root='/fog/'
+WEB_php_version='8.3'
+WEB_url_proto='https'
+WEB_https_redirect='no'
+
+## BOOT -- the client netboot path: iPXE, TFTP, FOS kernels
+BOOT_url_proto='http'
+BOOT_url_proto_forced=''
+BOOT_rebuild_ipxe_with_my_ca='no'
+BOOT_external_tftp_server=''
+BOOT_tftp_options=''
+BOOT_dhcp_delay_seconds='0'
+BOOT_kernel_backups_kept='3'
+
+## STORAGE -- image storage and its NFS export
+STORAGE_image_share_path='/images'
+STORAGE_rebuild_nfs_exports='1'
+
+## SVC -- FOG own system account and host services
+SVC_user='fogproject'
+SVC_password='<redacted>'
+SVC_firewall_control='configure'
+
+## PKI -- certificate authorities and trust
+PKI_sb_enabled='1'
+PKI_web_cert_publicly_trusted='no'
+PKI_allowed_domain_names=''
+PKI_internal_subnets=''
+PKI_san_ip_addresses='10.0.0.39'
+PKI_san_dns_names=''
+PKI_client_cert_dir='/opt/fog/snapins/ssl'
+
+## Derived -- do not edit
+## Canonical certificate paths. The installer recomputes these every
+## run, so editing a path here moves nothing. To use a certificate FOG
+## did not issue, leave the path alone and make it resolve to your file
+## (a symlink is enough) -- FOG then reads the target and leaves it be.
+PKI_root_ca_cert='/opt/fog/snapins/ssl/CA/.fogCA.pem'
+PKI_root_ca_key='/opt/fog/snapins/ssl/CA/.fogCA.key'
+PKI_web_ca_cert='/opt/fog/pki/web/ca/.fogWebCA.pem'
+PKI_web_ca_key='/opt/fog/pki/web/ca/.fogWebCA.key'
+PKI_web_external_root_cert=''
+PKI_web_trust_chain='/opt/fog/pki/web/ca/.fogWebCAchain.pem'
+PKI_web_vhost_cert='/opt/fog/pki/web/leaf/.webLeaf.pem'
+PKI_web_vhost_key='/opt/fog/pki/web/leaf/.webLeaf.key'
+PKI_client_encrypt_cert='/opt/fog/snapins/ssl/.srvpublic.crt'
+PKI_client_encrypt_key='/opt/fog/snapins/ssl/.srvprivate.key'
+PKI_sb_ca_cert='/opt/fog/pki/secureboot/ca/.fogSBCA.pem'
+PKI_sb_codesign_cert='/opt/fog/pki/secureboot/leaf/sign.pem'
+PKI_sb_codesign_key='/opt/fog/pki/secureboot/leaf/sign.key'
 ## End of FOG Settings
 ```
 
->[!note] Your file will have keys after the `## End of FOG Settings` line
->That marker is cosmetic. When an upgrade introduces a new setting the installer
->appends it to the end of the file, so on any server that has been upgraded a few
->times there are live settings below the marker. See
+>[!note] Your file may have keys after the `## End of FOG Settings` line
+>That marker is cosmetic — the file is sourced in full. When an upgrade
+>introduces a new setting the installer appends it, so on a server that has been
+>upgraded a few times there are live settings below the marker. See
 >[[install-fogsettings#How the file is rewritten|How the file is rewritten]].
 
 ## Where each value comes from
@@ -117,6 +225,11 @@ Two consequences worth knowing:
   `--internal-domain` and `--internal-subnet` each replace the stored list, so
   re-running with a shorter list genuinely shortens it.
 
+`--install-mode` sits slightly outside this order: it is a *preset* that writes
+four settings at once, and it is applied **before** the individual options, so
+`--install-mode public-cert --no-rebuild-ipxe-with-my-ca` means what it reads
+like. Each individual option overrides its own field and nothing else.
+
 ### Where the install lives
 
 `.fogsettings` cannot record its own location, because it lives *inside* it. The
@@ -126,9 +239,16 @@ installer keeps a one-line pointer at `/etc/fog/fog.conf` instead:
 fogprogramdir='/opt/fog'
 ```
 
-`fogprogramdir` also appears in `.fogsettings`, but only as a record — the
-installer recomputes it. To move an install, re-run with `--fogprogramdir`; do
-not edit either file. `fog_git_path` is a record in the same sense.
+`FOG_program_dir` also appears in `.fogsettings`, but only as a record — the
+installer recomputes it, and re-asserts the value it actually resolved after
+sourcing this file, so a stale line cannot relocate an install half way through
+a run. To move an install, re-run with `--fogprogramdir`; do not edit either
+file. `FOG_git_path` is a record in the same sense.
+
+>[!note] `fog.conf` keeps the old spelling on purpose
+>`/etc/fog/fog.conf` still says `fogprogramdir=`, not `FOG_program_dir=`. Every
+>existing server already carries that spelling, and it is the one file that
+>cannot be found by reading `.fogsettings`. Renaming it is a separate decision.
 
 ## How the file is rewritten
 
@@ -143,8 +263,15 @@ If the file already exists and looks valid, it is **merged in place**:
 - Managed settings that were not already present are **appended at the end**,
   which is why upgraded servers have live settings after the footer.
 
-If there is no file, or it has no recognizable header, it is written fresh in the
-canonical order.
+A file that still carries only pre-1.6 names is a special case: it gets a
+**one-time canonical rewrite** into the category blocks shown above, with
+everything the installer does not manage carried through into a trailing
+section. The in-place merge cannot do that run — with every old name retired and
+every new one absent, it would strip all 79 old lines and append 66 new ones
+after the footer, leaving the category headers describing nothing.
+
+If there is no file at all, or it has no recognizable header, it is written fresh
+in canonical order.
 
 Two steps then finish the run:
 
@@ -153,133 +280,275 @@ Two steps then finish the run:
    facts the `/api/whoami` endpoint publishes. See
    [[install-fogsettings#Security|Security]].
 
+### The 1.6 rename
+
+FOG 1.6 renamed all 79 managed keys into the nine categories above: 79 became
+**66** — six retired, nine absorbed into settings that already existed, and two
+promoted from internal variables.
+
+>[!important] You do not need to do anything
+>The first 1.6 installer run copies each old value onto its new name and deletes
+>the old line, so an existing `.fogsettings` migrates itself in one pass. Your
+>hand-set keys and your own comments are carried through.
+>
+>**No aliases are kept.** A file carrying two spellings of one setting, with
+>nothing to say which is live, is worse than a rename — and because this file is
+>*sourced*, a stale line keeps having effects. If you have scripts that read
+>`.fogsettings` directly, they need the new names.
+
+A few renames are worth knowing because the setting also changed category:
+
+| Was | Is now | Note |
+|---|---|---|
+| `snmysqlpass`, `snmysqluser`, `snmysqlhost` | `DB_password`, `DB_user`, `DB_host` | The `sn` prefix read as "storage node", but these are used on a full server too |
+| `password` | `SVC_password` | Two different secrets were in this file and the generic name held the fleet-wide one |
+| `sslpath` | `PKI_client_cert_dir` | It stopped holding FOG's authorities two restructurings ago |
+| `ipaddresses` | `PKI_san_ip_addresses` | It reaches past certificates: it also writes the nginx maintenance allow list |
+| `extraServerNames` | `PKI_san_dns_names` | Mirrored into `FOG_EXTRA_SERVER_NAMES` in the web UI |
+| `noTftpBuild` | `BOOT_external_tftp_server` | Same polarity, so the value carries across untouched — it now names the *reason* rather than the mechanic |
+| `secureBootMokCert` | `PKI_sb_ca_cert` | The certificate enrolled in firmware is an authority, not a leaf |
+| `secureBootKey`, `secureBootCert` | `PKI_sb_codesign_key`, `PKI_sb_codesign_cert` | `codesign`, not `leaf`: nothing in this zone authenticates a server |
+
+>[!note] Two lookalikes are not affected
+>Neither is a key in this file: the storage-node `sslpath` field used by the API
+>and by CSV import/export, and PHP's own `httpproto`.
+
 ### Settings the installer removes
 
-These were written by older versions and are stripped on upgrade. If a guide
-tells you to set one of them, that guide predates FOG 1.6:
+These are written by older versions and stripped on upgrade. If a guide tells you
+to set one of them, that guide predates FOG 1.6:
 
 | Removed | Why |
 |---|---|
+| Every pre-1.6 spelling of a setting that still exists | Renamed as above. Your value is copied onto the new name once, then the old line goes |
+| `caCreated` | Stood in for "the CA exists". Both of its readers already paired it with an existence check on the very file it named |
+| `acmeLeaf` | Now derived — see [[install-fogsettings#Certificates FOG did not issue|Certificates FOG did not issue]] |
+| `webCertFile`, `webKeyFile` | Folded into `PKI_web_vhost_cert`/`PKI_web_vhost_key`, which are now canonical paths |
+| `sslcsr` | Could only ever hold one path, and was re-derived to it every run |
+| `externalca` | Derivable from "is an import path set", and now scoped to the run rather than persisted |
+| `catrust` | FOG's CA is now always anchored in this server's own trust store |
+| `sbNameConstraints` | Name constraints come off the Secure Boot zone entirely — see [[install-fogsettings#Secure Boot|Secure Boot]] |
+| `extcacert`, `extcakey`, `extcaroot`, `webExtCACert`, `webExtCAKey`, `webExtCARoot` | Six keys that only ever held three values, reached two ways. Both spellings of the flag still work; they are run-scoped inputs now |
 | `bootfilename`, `notpxedefaultfile` | Replaced by per-architecture boot file selection |
 | `storageftpuser`, `storageftppass` | Storage node FTP credentials moved into the database |
 | `php_verAdds` | Folded into the distribution package lists |
 | `pkiMode`, `fogClientCACN` | Belonged to the retired four-tier certificate layout |
-| `dnsbootimage`, `donate` | Long dead; FOS gets DNS from DHCP, and telemetry is `sendreports` |
+
+>[!note] Four of these were retired for the same reason
+>`acmeLeaf`, `caCreated`, `externalca` and `sslcsr` each stood in for something
+>already knowable from the filesystem, and each had failed in the same way: a
+>persisted flag and the thing it described could disagree, and did. FOG asks the
+>filesystem now.
+>
+>`catrust` and `sbNameConstraints` went for a different reason — both were
+>opt-outs that put the safe answer behind a flag nobody passes until something
+>has already broken.
 
 ## Settings reference
 
-### Network and host identity
+### `FOG_` — install shape and location
 
-| Setting | Meaning |
-|---|---|
-| `interface` | The NIC FOG binds services to and takes its address from |
-| `ipaddress` | The server's **primary** address. Everything that needs "the FOG server" uses this |
-| `ipaddresses` | **Every** address on that interface. Used for certificate names, `server_name`/`ServerAlias`, and the maintenance allow list |
-| `submask` | Netmask, used when FOG runs DHCP |
-| `hostname` | The name put in the web certificate and vhost. **This does not set your system hostname.** Change it with `--hostname` |
-| `extraServerNames` | Additional names this server answers to. Set with `--extra-server-name` |
+| Setting | Kind | Meaning |
+|---|---|---|
+| `FOG_install_type` | Preference | `N` for a full server, `S` for a storage node |
+| `FOG_os_id` | Record | `1` Redhat, `2` Debian, `3` Alpine (experimental), `4` Arch |
+| `FOG_os_name` | Record | The detected distribution family |
+| `FOG_install_lang` | Preference | Whether the extra language packs were installed |
+| `FOG_send_reports` | Preference | `Y`/`N` — send OS name, OS version and FOG version to the project. This is anonymous version telemetry and nothing else |
+| `FOG_copy_back_old` | Preference | Copy the old web directory aside before replacing it (`-o`) |
+| `FOG_installed` | Record | `1` once a first install has completed; lets later runs skip the full question set. Deliberately unquoted and numeric, to match the historical format |
+| `FOG_packages` | Record | What was installed on this box. Re-derived every run from the distribution package lists |
+| `FOG_git_path` | Record | Where the checkout is. Re-asserted from what the run actually resolved, so a moved or re-cloned tree cannot point `updatefog.sh` at a directory that is gone |
+| `FOG_update_channel` | Preference | Which channel this server tracks: `stable`, `staging` or `dev` |
+| `FOG_program_dir` | Record | Where this install lives, so `grep FOG_program_dir .fogsettings` answers the question. Not a control — see [[install-fogsettings#Where the install lives|Where the install lives]] |
 
-### DHCP
-
-| Setting | Meaning |
-|---|---|
-| `dodhcp` / `bldhcp` | Whether FOG runs DHCP — the same answer as `Y`/`N` and as `1`/`0` |
-| `dhcpengine` | `isc` or `kea`. Leave blank to let FOG detect; it prefers Kea only where ISC is unavailable and never switches an existing install |
-| `dhcpd` | The DHCP service name on your distribution |
-| `routeraddress` / `dnsaddress` | Handed to DHCP clients. When DHCP is off these hold a literal comment string, because the value is written straight into a config file |
-| `plainrouter` | The router address without that comment fallback |
-| `startrange` / `endrange` | The DHCP pool, set with `-s` and `-e` |
-
-### Install shape
-
-| Setting | Meaning |
-|---|---|
-| `installtype` | `N` for a full server, `S` for a storage node |
-| `osid` / `osname` | `1` Redhat, `2` Debian, `3` Alpine (experimental), `4` Arch |
-| `packages` | What was installed on this box, as a record |
-| `php_ver` | The PHP version found, e.g. `8.3` |
-| `webserver` | `apache`, `httpd` or `nginx` |
-| `installlang` | Whether the extra language packs were installed |
-| `sendreports` | `Y`/`N` — send OS name, OS version and FOG version to the project. This is anonymous version telemetry and nothing else |
-| `fogupdateloaded` | `1` once a first install has completed; lets later runs skip the full question set |
-| `copybackold` | Copy the old web directory aside before replacing it (`-o`) |
-| `fog_update_channel` | Which channel this server tracks: `stable`, `staging` or `dev` |
-| `fogprogramdir`, `fog_git_path` | Records of where things are. The installer recomputes both |
-
->[!warning] `osid` changed meaning between 1.5 and 1.6
+>[!warning] `FOG_os_id` changed meaning between 1.5 and 1.6
 >In FOG 1.5, Arch was `3`. In 1.6, `3` is Alpine and Arch is `4`. An Arch server
 >upgrading from 1.5 carries the old value; the installer corrects it, but do not
->set `osid='3'` by hand expecting Arch.
+>set `FOG_os_id='3'` by hand expecting Arch.
 
-### Paths
+### `NET_` — this server's network identity
+
+| Setting | Kind | Meaning |
+|---|---|---|
+| `NET_interface` | Preference | The NIC FOG binds services to and takes its address from |
+| `NET_fog_server_ip` | Record | The server's **primary** address. Everything that needs "the FOG server" uses this |
+| `NET_subnet_mask` | Record | Netmask, used when FOG runs DHCP |
+| `NET_hostname` | Preference | The name put in the web certificate and the vhost. **This does not set your system hostname.** Change it with `--hostname` |
+
+Every *other* address on that interface is `PKI_san_ip_addresses`, and extra
+names this server answers to are `PKI_san_dns_names` — both under `PKI_` because
+they reach past certificates into the vhost and the maintenance allow list.
+
+### `DHCP_` — FOG acting as a DHCP server
+
+| Setting | Kind | Meaning |
+|---|---|---|
+| `DHCP_enabled` | Preference | `1`/`0` — whether FOG runs DHCP. Replaces `dodhcp` and `bldhcp`, which were one answer in two encodings |
+| `DHCP_engine` | Preference | `isc` or `kea`. Leave blank to let FOG detect; it prefers Kea only where ISC is unavailable, and never switches an existing install |
+| `DHCP_service_name` | Record | The DHCP service name on your distribution |
+| `DHCP_router` | Preference | The router handed to DHCP clients, or empty. Holds the clean value only — the config writers emit the "no router" comment themselves |
+| `DHCP_dns_server_ip` | Preference | The DNS server handed to DHCP clients, same treatment |
+| `DHCP_range_start`, `DHCP_range_end` | Preference | The DHCP pool, set with `-s` and `-e`. Passing either also turns `DHCP_enabled` on |
+
+### `DB_` — the database
+
+| Setting | Kind | Meaning |
+|---|---|---|
+| `DB_name` | Preference | The database name, normally `fog` |
+| `DB_host` | Preference | Where the database is. On a storage node, this is the main server |
+| `DB_user` | Record | `fogmaster` on a server, `fogstorage` on a node |
+| `DB_password` | Record | That user's password, generated on first install. **Cleartext** |
+| `DB_external` | Preference | Set to `1` when the database is on a host FOG does not administer. The installer then only verifies the connection, and skips the backup, the user management and the grants |
+| `DB_backup_path` | Preference | Where the database is dumped before a schema change |
+
+### `WEB_` — the web server and the web UI
+
+| Setting | Kind | Meaning |
+|---|---|---|
+| `WEB_server_engine` | Record | `apache`, `httpd` or `nginx` |
+| `WEB_docroot` | Preference | The web server's document root |
+| `WEB_root` | Preference | The URL path FOG is served under — `/fog/`, or `/` to serve at the site root |
+| `WEB_php_version` | Record | The PHP version found, e.g. `8.3` |
+| `WEB_url_proto` | Record | The protocol FOG uses for its **own non-netboot** URLs. The installer sets it to `https` on every run, because 443 listens on every install. `--install-mode http-only` lowers it for that run only |
+| `WEB_https_redirect` | Inferred preference | Redirect HTTP to HTTPS, **and send HSTS**. Seeded once from a pre-existing `httpproto=https`, then yours for good |
+
+>[!warning] `--install-mode http-only` does not persist
+>`WEB_url_proto` is set back to `https` at the start of every run — 443 listens
+>either way — so pass `--install-mode http-only` on each upgrade or it silently
+>reverts.
+
+>[!note] No install mode turns the redirect on
+>A redirect only helps machines that already trust the certificate, and FOG
+>cannot know how you got that trust there. fog-client installing FOG's root is
+>the common route, but your own deployment tooling or a public CA work too. Turn
+>`WEB_https_redirect` on once one of them is true.
+
+### `BOOT_` — the client netboot path
+
+| Setting | Kind | Meaning |
+|---|---|---|
+| `BOOT_url_proto` | Record | The protocol iPXE uses to reach `boot.php`. Re-derived every run: `https` when either `PKI_web_cert_publicly_trusted` or `BOOT_rebuild_ipxe_with_my_ca` is `yes`, otherwise `http` |
+| `BOOT_url_proto_forced` | Inferred preference | `yes` once `--netboot-proto` has been passed explicitly. This is the only thing that distinguishes "the admin chose this" from "a previous run worked this out" |
+| `BOOT_rebuild_ipxe_with_my_ca` | Preference | Recompile iPXE with the configured CA embedded, so netboot can use HTTPS behind a **private** CA. The build takes 10–25 minutes, but is stamped against the pinned iPXE version and the CA, so it re-runs only when one of those changes |
+| `BOOT_external_tftp_server` | Preference | Your TFTP server is elsewhere, so leave the TFTP configuration alone. Also keeps `69/udp` closed in the firewall |
+| `BOOT_tftp_options` | Hand-set | Extra options for `in.tftpd` |
+| `BOOT_dhcp_delay_seconds` | Preference | Seconds (0–120) a client waits before its first DHCP attempt, for switches slow to come out of STP or port power-save. `0` writes no delay. See [[dhcp-server-settings|DHCP server settings]] |
+| `BOOT_kernel_backups_kept` | Preference | How many previous kernel and init sets to keep. Default 3 |
+
+### `STORAGE_` — image storage
+
+| Setting | Kind | Meaning |
+|---|---|---|
+| `STORAGE_image_share_path` | Preference | Where images are kept, normally `/images` |
+| `STORAGE_rebuild_nfs_exports` | Preference | Whether to rebuild `/etc/exports` for NFS |
+
+### `SVC_` — FOG's system account and host services
+
+| Setting | Kind | Meaning |
+|---|---|---|
+| `SVC_user` | Record | FOG's system account, `fogproject`. Also the FTP account used for replication |
+| `SVC_password` | Record | That account's password, generated on first install. **Cleartext, and fleet-wide** |
+| `SVC_firewall_control` | Preference | `configure`, `disable` or `skip` for the local firewall. Remembered so an upgrade cannot quietly reverse your choice |
+
+### `PKI_` — certificates and trust
+
+The zone token in each name (`root`, `web`, `client`, `sb`) says which authority
+it belongs to; [[pki-zones|FOG PKI Infrastructure]] explains the split.
+
+**Policy and inputs** — these are yours to set:
+
+| Setting | Kind | Meaning |
+|---|---|---|
+| `PKI_web_cert_publicly_trusted` | Preference | A **statement** that the web certificate chains to a public root. Steers netboot to HTTPS with no iPXE rebuild, and stops FOG re-issuing the leaf. Never measured: FOG anchors its own CA in the host trust store, so probing the store would answer "trusted" for FOG's own leaf — exactly the case that does need the rebuild |
+| `PKI_allowed_domain_names` | Preference | Domains the Web CA may issue for, and names added to the certificate and the vhost `ServerAlias`. Set with `--internal-domain`. The server's own domain is always permitted |
+| `PKI_internal_subnets` | Preference | Restricts the Web CA to these subnets. Set with `--internal-subnet`, and it **replaces** the default of all private ranges rather than adding to it |
+| `PKI_san_ip_addresses` | Preference | Every address this server answers on. Used for certificate names, `server_name`/`ServerAlias`, and the nginx maintenance allow list |
+| `PKI_san_dns_names` | Preference | Extra names this server answers to, set with `--extra-server-name`. Mirrored into `FOG_EXTRA_SERVER_NAMES` in the web UI |
+| `PKI_client_cert_dir` | Preference | Holds uploaded snapin SSL material and the client communication certificate. **Not** where FOG's own authorities live any more |
+| `PKI_sb_enabled` | Preference | `1`/`0`. On by default. See [[install-fogsettings#Secure Boot|Secure Boot]] |
+
+**Canonical paths** — these are records, under the `## Derived — do not edit`
+marker in the file:
 
 | Setting | Meaning |
 |---|---|
-| `docroot` | The web server's document root |
-| `webroot` | The URL path FOG is served under — `/fog/`, or `/` to serve at the site root |
-| `storageLocation` | Where images are kept, normally `/images` |
-| `backupPath` | Where the database is dumped before a schema change |
-| `sslpath` | Holds uploaded snapin SSL material and the client communication certificate. **Not** where FOG's own certificate authorities live any more |
+| `PKI_root_ca_cert`, `PKI_root_ca_key` | The trust anchor — what `ca.cert.der` publishes and what fog-client pins. Recorded in its own right rather than inferred from the Web CA, which would mistake the intermediate for the root on the next run |
+| `PKI_web_ca_cert`, `PKI_web_ca_key` | The CA that signs the vhost certificate — and all that an external CA replaces |
+| `PKI_web_external_root_cert` | A root you imported that FOG does not already have. Empty on an ordinary install, and kept deliberately separate from `PKI_root_ca_cert`: an external web CA's root feeds the chain file only, and is not what fog-client pins |
+| `PKI_web_trust_chain` | The web zone's **trust path** — intermediate plus the root anchoring it. Not what the vhost serves; those files are rebuilt every run and never persisted |
+| `PKI_web_vhost_cert`, `PKI_web_vhost_key` | The certificate and key the web server actually serves |
+| `PKI_client_encrypt_cert`, `PKI_client_encrypt_key` | The client-communication keypair that every registered client pins |
+| `PKI_sb_ca_cert` | The Secure Boot certificate **enrolled in firmware** |
+| `PKI_sb_codesign_cert`, `PKI_sb_codesign_key` | The Secure Boot material that **signs** the FOS kernels |
 
-### Database
+>[!note] The client-encryption keys are new, and their names are not free
+>These were internal variables until 1.6, which made the client zone the only one
+>you could not point elsewhere — an odd exception in a model whose whole premise
+>is "say where the certificate is". But `FOGBase` builds `.srvprivate.key` with
+>the filename hardcoded, taking the directory from the storage-node record. So
+>these name a canonical path whose *target* may move while the name may not.
 
-| Setting | Meaning |
-|---|---|
-| `mysqldbname` | The database name, normally `fog` |
-| `snmysqlhost` | Where the database is. On a storage node, this is the main server |
-| `snmysqluser` | `fogmaster` on a server, `fogstorage` on a node |
-| `snmysqlpass` | That user's password, generated on first install |
-| `snmysqlexternal` | Set to `1` when the database is on a host FOG does not administer. The installer then only verifies the connection, and skips the backup, the user management and the grants |
+#### Certificates FOG did not issue
 
-### Web and certificates
+This is the inverse of how it worked before 1.6, and it is worth reading before
+you touch a certificate path.
 
-| Setting | Meaning |
-|---|---|
-| `httpproto` | `http` or `https` for the web interface |
-| `netbootproto` | The protocol iPXE uses to reach `boot.php`. On a new HTTPS install using FOG's own CA this stays `http`, because HTTPS netboot needs an iPXE rebuilt to trust that CA. Override with `--netboot-proto` |
-| `caCreated` | Set once FOG's certificate authority exists |
-| `catrust` | Whether FOG adds its own CA to *this server's* trust store. On by default; without it FOG's HTTPS calls to itself fail to verify |
-| `externalca`, `extcacert`, `extcakey`, `extcaroot` | Your own certificate authority. See [[external-ca-lets-encrypt\|External CA & Let's Encrypt Certificates]] |
-| `webExtCACert`, `webExtCAKey`, `webExtCARoot` | The same, for the web certificates only |
-| `rootCAPem`, `rootCAKey` | The trust anchor — what `ca.cert.der` publishes and what the fog-client pins |
-| `sslcapem`, `sslcakey`, `sslcachain` | The web certificate authority |
-| `sslprivkey`, `sslpubcert`, `sslcsr` | The web server's own certificate and key |
-| `internalDomains`, `internalSubnets` | Which names FOG's authorities may issue for. Anything you list in `internalSubnets` **replaces** the default of all private ranges rather than adding to it |
-| `acmeLeaf` | Set to `yes` **by hand** when your web certificate is managed by certbot, acme.sh or a corporate process |
+**A `PKI_*` path is canonical.** FOG always refers to the vhost certificate as
+`PKI_web_vhost_cert`, and recomputes that path every run — so editing it moves
+nothing. To use a certificate FOG did not issue, leave the path alone and make it
+**resolve** to your file. A symlink is enough:
 
->[!important] `acmeLeaf` is not optional if you use ACME
->Nothing sets it for you. Without it the installer regenerates the web
->certificate from the original request while your ACME client owns the key,
->producing a certificate/key mismatch that stops the web server. See
->[[external-ca-lets-encrypt|External CA & Let's Encrypt Certificates]].
+```bash
+ln -sf /etc/letsencrypt/live/fog.example.com/fullchain.pem \
+       /opt/fog/pki/web/leaf/.webLeaf.pem
+ln -sf /etc/letsencrypt/live/fog.example.com/privkey.pem \
+       /opt/fog/pki/web/leaf/.webLeaf.key
+```
+
+FOG then reads the target and leaves it alone. That is the whole mechanism: when
+the canonical path resolves *outside* FOG's own web zone directory, the leaf is
+somebody else's, so FOG will neither re-issue it nor lock its private key away
+from whatever renews it.
+
+>[!important] This replaces `acmeLeaf`, and you no longer set anything by hand
+>`acmeLeaf` had to be typed in, and forgetting it was expensive: FOG re-issued
+>the web certificate from the original request while an ACME private key sat
+>beside it, producing a mismatched pair and a web server that would not start —
+>silently, under `-y`.
+>
+>A symlink cannot disagree with itself, where a persisted flag and two recorded
+>paths could each disagree with the vhost. That is why the flag is gone.
+
+If your certificate chains to a **public** root, also set
+`PKI_web_cert_publicly_trusted='yes'` (or install with `--install-mode
+public-cert`) — that is a separate question from who renews it, and it is what
+lets netboot use HTTPS with no iPXE rebuild. An internal ACME server such as
+step-ca is a symlinked leaf with `PKI_web_cert_publicly_trusted='no'`.
+
+Full walkthrough: [[external-ca-lets-encrypt|External CA & Let's Encrypt Certificates]].
 
 >[!note] Name constraints are fixed when a CA is first created
->`internalDomains` and `internalSubnets` only take effect when the authority is
->issued, and FOG never re-issues one. Changing them on an existing server does
->nothing until the intermediate is removed as well — which is why the installer
->stops asking once `caCreated='yes'`.
+>`PKI_allowed_domain_names` and `PKI_internal_subnets` only take effect when the
+>authority is issued, and FOG never re-mints one. Changing them on an existing
+>server does nothing until the intermediate is removed as well.
 
-### Services
+### Settings only you can set
 
-| Setting | Meaning |
+A few values the installer *reads* but never writes. They have no option and no
+prompt, so the only way to set one is to add the line to `.fogsettings`
+yourself. They survive because the merge preserves what it does not manage.
+
+| Setting | What it does |
 |---|---|
-| `username` | FOG's system account, `fogproject`. Also the FTP account used for replication |
-| `password` | That account's password, generated on first install |
-| `blexports` | Whether to rebuild `/etc/exports` for NFS |
-| `noTftpBuild` | Set to leave the TFTP configuration alone |
-| `tftpAdvOpts` | Extra options for `in.tftpd` |
-| `fwconfigure` | `configure`, `disable` or `skip` for the local firewall. Remembered so an upgrade cannot quietly reverse your choice |
-| `kernelBackupGenerations` | How many previous kernel sets to keep. Default 3 |
+| `snapinLocation` | Where snapins live, if not under the default. `FOGBackup.sh` reads it and will tell you to add it by hand when it needs it |
+| `storageLocationCapture` | Where captured images land, if you want them off `STORAGE_image_share_path` |
 | `inetConnectTimeout`, `inetMaxTime` | Bounds on the installer's downloads — 5s to connect, 15s total. Raise them only for a genuinely slow link |
+| `ftppasvmin`, `ftppasvmax` | The FTP passive port range |
+| `mcastportmin`, `mcastportmax` | The multicast port range |
 
-### Secure Boot
-
-| Setting | Meaning |
-|---|---|
-| `secureboot` | `1`/`0`. On by default |
-| `secureBootKey`, `secureBootCert` | The key and certificate that **sign** the FOS kernels |
-| `secureBootMokCert` | The certificate **enrolled in firmware** — not always the same file |
-| `sbNameConstraints` | Set to `no` to issue the Secure Boot CA without name constraints, if your firmware rejects the chain |
+These work because `.fogsettings` is sourced *before* the installer applies its
+own defaults, and each of those defaults is guarded on the value being empty.
 
 ## Secure Boot
 
@@ -287,19 +556,25 @@ This is the part of `.fogsettings` most worth understanding, because getting it
 wrong produces machines that will not boot, and the failure shows up at the
 *client* as a Security Policy Violation with nothing on the server to explain it.
 
-### Signing and enrollment are different keys
+### Signing and enrolment are different keys
 
 | Setting | Role | Cost of changing it |
 |---|---|---|
-| `secureBootKey` + `secureBootCert` | The **signing key**. What actually signs kernels | None. Re-sign and carry on |
-| `secureBootMokCert` | The **enrolled certificate**. What firmware trusts | A physical trip to **every machine** |
+| `PKI_sb_codesign_key` + `PKI_sb_codesign_cert` | The **signing** material. What actually signs kernels | None. Re-sign and carry on |
+| `PKI_sb_ca_cert` | The **enrolled** certificate. What firmware trusts | A physical trip to **every machine** |
 
-FOG creates a Secure Boot certificate authority and enrolls *that*, then issues a
-separate signing key beneath it. Because firmware trusts the issuer, the signing
-key can be rotated — or issued per storage node — and your fleet keeps booting.
+FOG creates a Secure Boot certificate authority and enrols *that*, then issues a
+separate signing certificate beneath it. Because firmware trusts the issuer, the
+signing material can be rotated — or issued per storage node — and your fleet
+keeps booting.
 
->[!warning] Servers upgrading from the older layout must re-enroll once
->FOG used to enroll the signing certificate itself, which made the thing you must
+The names say which is which: the Secure Boot zone carries
+`extendedKeyUsage = codeSigning` on both the authority and the certificate it
+issues, where the web zone carries `serverAuth`. Nothing here authenticates a
+server, so nothing here is called a leaf.
+
+>[!warning] Servers upgrading from the older layout must re-enrol once
+>FOG used to enrol the signing certificate itself, which made the thing you must
 >never change and the thing you want to rotate the same object. Upgrading moves
 >you onto the certificate authority, so **every machine that enrolled the old key
 >must enroll once more**. The installer prints a notice when this happens. After
@@ -310,18 +585,35 @@ key can be rotated — or issued per storage node — and your fleet keeps booti
 
 An upgrade that quietly replaced signed kernels with unsigned ones is the main
 way this breaks, so the settings persist and every later upgrade re-signs without
-you passing anything. `secureboot='0'` persists for the mirror reason: opting out
-must not be undone by the next upgrade.
+you passing anything. `PKI_sb_enabled='0'` persists for the mirror reason: opting
+out must not be undone by the next upgrade.
 
 >[!important] The signing key is never regenerated once it exists
->A new key silently invalidates enrollment everywhere, and you would not find out
+>A new key silently invalidates enrolment everywhere, and you would not find out
 >until a client failed to boot. Even `--recreate-keys` deliberately leaves Secure
 >Boot material alone. To force a new one, remove the directory — the installer
 >then reports the recorded key as missing and generates a fresh one.
 
+### No name constraints in this zone
+
+The Secure Boot authority carries **no name constraints**, and there is
+deliberately no setting or flag to add them. FOG 1.6 retired both
+`sbNameConstraints` and `--no-sb-name-constraints`.
+
+They constrained nothing that matters for code signing — a code-signing
+certificate carries no names anyone resolves — while this is the one certificate
+UEFI and shim actually parse, and a critical extension they mishandle costs a
+firmware trip to every machine. An opt-out was the wrong shape for that risk: it
+put the safe answer behind a flag nobody passes until a fleet has already failed
+to boot.
+
+The Web CA still gets constraints, because iPXE is a verifier FOG can patch and
+firmware is not. Existing servers keep whatever their Secure Boot authority
+already carries — an intermediate is never re-minted.
+
 ### Bringing your own key
 
-Both forms work. Supplying only the signing pair enrolls that certificate, as it
+Both forms work. Supplying only the signing pair enrols that certificate, as it
 always did:
 
 ```bash
@@ -351,8 +643,8 @@ Full walkthrough: [[secure-boot-signing|Secure Boot - signing FOS with your own 
 ## Security
 
 `.fogsettings` is `0600 root:root`, because it holds two cleartext passwords:
-`password` (the `fogproject` account, which is also the replication FTP account)
-and `snmysqlpass` (the database).
+`SVC_password` (the `fogproject` account, which is also the replication FTP
+account) and `DB_password` (the database).
 
 It used to be world-readable, so any local account on the server could read both.
 That was not simple carelessness — FOG's `/api/whoami` endpoint read the file
@@ -361,7 +653,7 @@ directly and needed it readable. The two jobs are now separate:
 | File | Permissions | Contents |
 |---|---|---|
 | `/opt/fog/.fogsettings` | `0600 root:root` | Everything, including the passwords |
-| `/opt/fog/.fogsettings.pub` | `0644 root:root` | Only `ipaddress`, `hostname`, `osid`, `osname`, `installtype` |
+| `/opt/fog/.fogsettings.pub` | `0644 root:root` | Only `NET_fog_server_ip`, `NET_hostname`, `FOG_os_id`, `FOG_os_name`, `FOG_install_type` |
 
 Re-running the installer is the whole migration — it corrects the permissions and
 writes the public file, on servers and storage nodes alike.
@@ -369,6 +661,12 @@ writes the public file, on servers and storage nodes alike.
 >[!tip] Which file to read from a script
 >If you only need to know *which server this is*, read `.fogsettings.pub` and
 >stay unprivileged. Reading `.fogsettings` needs root.
+
+>[!warning] `/api/whoami` renamed its response keys too
+>The five fields it publishes are the ones above, and they are renamed rather
+>than mapped back to their old spellings. A client reading `osid` or `hostname`
+>from that route needs updating. On a server whose web tree is newer than its
+>last installer run, the route answers empty strings until the installer runs.
 
 Two habits worth keeping:
 
@@ -380,36 +678,40 @@ Two habits worth keeping:
 
 ## Editing it by hand
 
-Some settings exist only for you to set — nothing in the installer writes them:
+Which settings respond to a hand edit follows straight from
+[[install-fogsettings#The four kinds of setting|the four kinds]]: **preferences**
+and **hand-set** values do, **records** do not. Some common ones:
 
 | Setting | When you would |
 |---|---|
-| `acmeLeaf='yes'` | Your web certificate is managed by certbot or acme.sh |
-| `snmysqlexternal='1'` | Your database is on a host FOG does not administer |
-| `dhcpengine='kea'` or `'isc'` | Force a DHCP engine instead of letting FOG detect one |
-| `tftpAdvOpts` | Extra `in.tftpd` options |
-| `fwconfigure` | Change your mind about the firewall without being asked again |
+| `PKI_web_cert_publicly_trusted='yes'` | Your web certificate chains to a public root |
+| `DB_external='1'` | Your database is on a host FOG does not administer |
+| `DHCP_engine='kea'` or `'isc'` | Force a DHCP engine instead of letting FOG detect one |
+| `BOOT_tftp_options` | Extra `in.tftpd` options |
+| `SVC_firewall_control` | Change your mind about the firewall without being asked again |
 | `inetConnectTimeout`, `inetMaxTime` | Your link is genuinely slower than 5s/15s |
-
-This works because FOG reads `.fogsettings` before applying its own defaults, and
-the in-place merge never touches a line it does not manage.
 
 Before you edit:
 
 1. **You need root**, and you should leave the permissions at `0600`.
 2. **Keep the `key='value'` form.** An unbalanced quote breaks the next install.
-3. **Managed settings are overwritten on the next run.** Editing `ipaddress` or
-   `hostname` here changes nothing — use the installer option instead. To change
-   the server's address properly, follow [[change-fog-server-ip-address|Change FOG Server IP Address]].
-4. **Take a copy first.** The installer rewrites the file with no backup.
-5. **Do not edit `.fogsettings.pub`** — it is regenerated from `.fogsettings`
+3. **Records are recomputed on the next run.** Editing `NET_fog_server_ip` here
+   changes nothing — use the installer option instead. To change the server's
+   address properly, follow [[change-fog-server-ip-address|Change FOG Server IP Address]].
+4. **Certificate paths are canonical.** Do not repoint one at your own file;
+   make the path *resolve* there instead. See
+   [[install-fogsettings#Certificates FOG did not issue|Certificates FOG did not issue]].
+5. **Take a copy first.** The installer rewrites the file with no backup.
+6. **Do not edit `.fogsettings.pub`** — it is regenerated from `.fogsettings`
    every run.
 
 ## Related
 
 - [[command-line-options|Fog installer command line options]] — every option that writes a setting here
+- [[netboot-transport-and-pki|Netboot Transport and PKI]] — why `WEB_` and `BOOT_` are separate
 - [[install-fog-server|Install FOG Server]] — the install itself
 - [[install-script-architecture|Install Script Architecture]] — how the installer is put together
+- [[pki-zones|FOG PKI Infrastructure]] — what each `PKI_` zone is for
 - [[secure-boot-signing|Secure Boot - signing FOS with your own key]]
 - [[external-ca-lets-encrypt|External CA & Let's Encrypt Certificates]]
 - [[unify-certificates-across-fog-servers|Unifying certificates across several FOG servers]]

--- a/docs/management/server/install-fogsettings.md
+++ b/docs/management/server/install-fogsettings.md
@@ -322,12 +322,12 @@ to set one of them, that guide predates FOG 1.6:
 |---|---|
 | Every pre-1.6 spelling of a setting that still exists | Renamed as above. Your value is copied onto the new name once, then the old line goes |
 | `caCreated` | Stood in for "the CA exists". Both of its readers already paired it with an existence check on the very file it named |
-| `acmeLeaf` | Now derived — see [[install-fogsettings#Certificates FOG did not issue|Certificates FOG did not issue]] |
+| `acmeLeaf` | Now derived — see [[install-fogsettings#Certificates FOG did not issue\|Certificates FOG did not issue]] |
 | `webCertFile`, `webKeyFile` | Folded into `PKI_web_vhost_cert`/`PKI_web_vhost_key`, which are now canonical paths |
 | `sslcsr` | Could only ever hold one path, and was re-derived to it every run |
 | `externalca` | Derivable from "is an import path set", and now scoped to the run rather than persisted |
 | `catrust` | FOG's CA is now always anchored in this server's own trust store |
-| `sbNameConstraints` | Name constraints come off the Secure Boot zone entirely — see [[install-fogsettings#Secure Boot|Secure Boot]] |
+| `sbNameConstraints` | Name constraints come off the Secure Boot zone entirely — see [[install-fogsettings#Secure Boot\|Secure Boot]] |
 | `extcacert`, `extcakey`, `extcaroot`, `webExtCACert`, `webExtCAKey`, `webExtCARoot` | Six keys that only ever held three values, reached two ways. Both spellings of the flag still work; they are run-scoped inputs now |
 | `bootfilename`, `notpxedefaultfile` | Replaced by per-architecture boot file selection |
 | `storageftpuser`, `storageftppass` | Storage node FTP credentials moved into the database |
@@ -360,7 +360,7 @@ to set one of them, that guide predates FOG 1.6:
 | `FOG_packages` | Record | What was installed on this box. Re-derived every run from the distribution package lists |
 | `FOG_git_path` | Record | Where the checkout is. Re-asserted from what the run actually resolved, so a moved or re-cloned tree cannot point `updatefog.sh` at a directory that is gone |
 | `FOG_update_channel` | Preference | Which channel this server tracks: `stable`, `staging` or `dev` |
-| `FOG_program_dir` | Record | Where this install lives, so `grep FOG_program_dir .fogsettings` answers the question. Not a control — see [[install-fogsettings#Where the install lives|Where the install lives]] |
+| `FOG_program_dir` | Record | Where this install lives, so `grep FOG_program_dir .fogsettings` answers the question. Not a control — see [[install-fogsettings#Where the install lives\|Where the install lives]] |
 
 >[!warning] `FOG_os_id` changed meaning between 1.5 and 1.6
 >In FOG 1.5, Arch was `3`. In 1.6, `3` is Alpine and Arch is `4`. An Arch server
@@ -433,7 +433,7 @@ they reach past certificates into the vhost and the maintenance allow list.
 | `BOOT_rebuild_ipxe_with_my_ca` | Preference | Recompile iPXE with the configured CA embedded, so netboot can use HTTPS behind a **private** CA. The build takes 10–25 minutes, but is stamped against the pinned iPXE version and the CA, so it re-runs only when one of those changes |
 | `BOOT_external_tftp_server` | Preference | Your TFTP server is elsewhere, so leave the TFTP configuration alone. Also keeps `69/udp` closed in the firewall |
 | `BOOT_tftp_options` | Hand-set | Extra options for `in.tftpd` |
-| `BOOT_dhcp_delay_seconds` | Preference | Seconds (0–120) a client waits before its first DHCP attempt, for switches slow to come out of STP or port power-save. `0` writes no delay. See [[dhcp-server-settings|DHCP server settings]] |
+| `BOOT_dhcp_delay_seconds` | Preference | Seconds (0–120) a client waits before its first DHCP attempt, for switches slow to come out of STP or port power-save. `0` writes no delay. See [[dhcp-server-settings\|DHCP server settings]] |
 | `BOOT_kernel_backups_kept` | Preference | How many previous kernel and init sets to keep. Default 3 |
 
 ### `STORAGE_` — image storage
@@ -466,7 +466,7 @@ it belongs to; [[pki-zones|FOG PKI Infrastructure]] explains the split.
 | `PKI_san_ip_addresses` | Preference | Every address this server answers on. Used for certificate names, `server_name`/`ServerAlias`, and the nginx maintenance allow list |
 | `PKI_san_dns_names` | Preference | Extra names this server answers to, set with `--extra-server-name`. Mirrored into `FOG_EXTRA_SERVER_NAMES` in the web UI |
 | `PKI_client_cert_dir` | Preference | Holds uploaded snapin SSL material and the client communication certificate. **Not** where FOG's own authorities live any more |
-| `PKI_sb_enabled` | Preference | `1`/`0`. On by default. See [[install-fogsettings#Secure Boot|Secure Boot]] |
+| `PKI_sb_enabled` | Preference | `1`/`0`. On by default. See [[install-fogsettings#Secure Boot\|Secure Boot]] |
 
 **Canonical paths** — these are records, under the `## Derived — do not edit`
 marker in the file:


### PR DESCRIPTION
FOG 1.6 (GH-1120) renamed all 79 managed `.fogsettings` keys to `CATEGORY_lower_snake_case`, leaving **66** — six retired, nine absorbed, two promoted. That change deliberately left the admin-facing docs alone ("The admin-facing fog-docs pages, and the still-stale `command-line-options.md`, remain a separate change"). This is that change.

Key names, flag list and behaviour all come from the shipped `working-1.6` code — `managedKeys`/`deprecatedKeys` in `lib/common/functions.sh`, the option handlers in `bin/installfog.sh` — not from the plan. The plan's own Outcome section records where the two diverged.

## The two pages that were asked for

**`docs/management/server/install-fogsettings.md`** — rewritten to the nine-category model. All 66 keys documented by category, each tagged **preference / record / hand-set / inferred preference**. That taxonomy was previously implicit; it is now explicit and stated once up front, because it is the thing that tells a reader whether a hand edit survives the next installer run. Includes why a preference and a record can never share one key, using the `BOOT_url_proto` bug as the worked example.

**`docs/installation/server/command-line-options.md`** — regenerated; it was still showing the pre-1.6 option list. `--install-mode` (with the four presets), `--netboot-proto`, `--public-web-cert` and `--rebuild-ipxe-with-my-ca` are all covered.

The full option block is now **rendered from the installer's own `--help` output** rather than transcribed by hand. That is what caught `--no-ca-trust` and `--no-sb-name-constraints`, both removed in 1.6 with the settings behind them, and picked up help text the page predated: `-C` implying `--recreate-keys`, `-K`'s warning that every registered fog-client must be re-pinned, and `--no-secure-boot` now declining *enrolment* rather than signing.

## Two corrections that are not renames

Some pages did not merely *name* retired settings — they told readers to set them, and following them now breaks a server.

**The ACME instructions inverted.** `external-ca-lets-encrypt.md` had the ACME client install certificates straight to FOG's canonical leaf paths and then set `acmeLeaf=yes`. Under 1.6 that produces the exact failure it was written to prevent: `_externallyManagedLeaf()` decides ownership by asking whether `PKI_web_vhost_cert` resolves *outside* `_pkiZoneDir web`, so a real file at that path reads as FOG's own and gets re-issued from the stored CSR while the ACME private key sits beside it — a mismatched pair and a web server that will not start, silently, under `-y`. The client now owns its own directory and the canonical paths are symlinked at it.

**Relocating a certificate by editing the path.** `pki-zones.md` did this with `sed` on `.fogsettings`. Canonical paths are recomputed every run, so that edit moves nothing.

## PR backlog

Five PRs predated the rename and overlapped it.

- **#130** — merged separately. It was clean and fixed an inaccuracy already live on `master`; `master` is merged back into this branch.
- **#125** closed, salvage carried here: the correction that FOG **does** sign its own iPXE binaries (so the tradeoff is whether a custom binary is worth enrolling a key *before* netboot, not "signed shim or custom binary"), plus the `migrating-fog-server.md` tidy. Its `local-esp-boot.md` was superseded by merged #129.
- **#128** closed, walkthrough carried here with step 2 rewritten to the canonical-symlink model. Its step 1 ("do not copy the files into FOG's own PKI tree") was already correct and is unchanged.
- **#126** and **#127** closed as superseded — they document the intermediate camelCase step (`httpProto`, `sslPath`) and, in #127's case, the two removed flags. Their surviving substance is folded in.
- **#131** untouched — not ours, and verified read-only to name no retired setting.

Neither #125's nor #128's `kb/how-tos/index.md` was usable: both branched before #129 and would have deleted the Secure Boot section it added. The one new entry is added by hand instead.

Each closed PR carries a comment explaining what moved and why.

## Verification

- `cd quartz && npm i && npm run docs:build` — clean, no warnings (110 files, 954 emitted).
- All **66/66** managed keys present, with no invented names (cross-checked against `managedKeys`).
- Every internal wikilink and in-page anchor on the changed pages resolves; the deep anchors into `external-ca-lets-encrypt` still land.
- Literal `[[` in the built HTML held at **12**, all pre-existing and unrelated — 9 are shell `[[ -z $var ]]` inside code blocks, 3 are old MediaWiki links in pages not touched here.
- Retired-key sweep: every remaining hit is either a deliberate "this was renamed/removed" table row, a labelled FOG 1.5 mention, or the storage-node `sslpath` CSV field that ADR 0024 explicitly excludes (it is that endpoint's own field name mapping to a `storageNode` column).

### One trap worth knowing

**A wikilink inside a table cell needs its pipe escaped** — `[[target\|Text]]`. Unescaped, the `|` is read as a column separator and the link renders literally as `[[page`, and **the build does not warn**. This bit the change once before being caught in the built HTML. The check is `grep -rnE '^\|.*\[\[[^]]*[^\\]\|' docs --include=*.md`, and it may be worth adding to `CLAUDE.md` alongside the existing newline-wrapped-wikilink warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gj9EW4NNDT8JHHghG3pZDt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gj9EW4NNDT8JHHghG3pZDt)_