### PR TITLE
docs(api): document Authorization: Bearer authentication

### DIFF
--- a/docs/kb/integrations/api-expansion-and-pagination.md
+++ b/docs/kb/integrations/api-expansion-and-pagination.md
@@ -30,9 +30,11 @@ in the main [API](api.md) article:
     before. Scalar foreign keys (for example `imageID`) are always preserved —
     expansion **adds** an object alongside the key, it never replaces the key.
 
-All examples assume the API is enabled and you are sending the
-`fog-api-token` and `fog-user-token` headers (see
-[Authentication](api.md#authentication)).
+All examples assume the API is enabled and the request is authenticated. They
+show the `fog-api-token` + `fog-user-token` pair, which works on every version;
+on FOG 1.6 and newer you can send a single `Authorization: Bearer <user token>`
+header instead and drop the other two. See
+[Authentication](api.md#authentication).
 
 ---
 

--- a/docs/kb/integrations/api.md
+++ b/docs/kb/integrations/api.md
@@ -37,19 +37,80 @@ web UI (FOG Configuration → FOG Settings
 
 ## Authentication
 
-### Tokens
+There are three ways to authenticate. Pick one &mdash; you do not combine them.
+
+| Method | What you send | Also needs `fog-api-token`? |
+| --- | --- | --- |
+| **Bearer token** (recommended) | `Authorization: Bearer <user token>` | **no** |
+| Token pair | `fog-api-token` + `fog-user-token` headers | yes |
+| HTTP Basic | `Authorization: Basic <base64 user:password>` | yes |
+
+Every method carries the same permissions: the acting user's roles are applied
+either way, so a user without `user.view` gets `403 Forbidden` from `/fog/user`
+however they signed in.
+
+### Bearer token (recommended)
+
+Send the **user** API token in the standard `Authorization` header and nothing
+else is required:
+
+```bash
+curl -H 'Authorization: Bearer yourusertoken' \
+     -X GET http://fogserver/fog/host
+```
+
+A user API token is a 512-bit random secret, so it stands on its own and does
+**not** need the server-wide `fog-api-token` beside it. This is the form most
+HTTP clients, API tools and generated SDKs expect, so it is the one to reach for
+in new integrations.
+
+Where to find the token: Users → List All Users
+→ *your username* → **API**. The
+**User API Token** field on that tab holds the value; tick **User API Enable**
+on the same tab or the token is rejected even when sent, and use **Reset Token**
+to roll it.
+
+!!! note "Copy the token value exactly as the UI shows it"
+    The **User API Token** field is already **base64-encoded**, and that is what
+    the server expects. Copy it verbatim.
+
+    Do not decode it first, and do not read the raw value out of the database.
+    A FOG token is hexadecimal, and hexadecimal is *itself* valid base64 &mdash;
+    so a raw token decodes "successfully" into something meaningless rather than
+    failing loudly. The request just comes back `401 Unauthorized` with no hint
+    as to why.
+
+!!! tip "`Bearer` with nothing after it"
+    If you build the header from a config value that turns out to be unset, you
+    send a bare `Authorization: Bearer`. FOG answers `401 Unauthorized` for that
+    specifically, rather than falling through to another method &mdash; so a 401
+    on a request you believe is authenticated is worth checking for an empty
+    token variable.
+
+!!! info "Availability"
+    Bearer authentication is available from FOG 1.6.0. On older servers, and on
+    1.5.x, use the token pair below. Both older methods keep working on 1.6 and
+    are not deprecated &mdash; nothing you have already built needs to change.
+
+### Token pair
+
+The original scheme, and the one to use on 1.5.x. **Both** headers are required
+together.
 
 **API global token** &mdash; a header named `fog-api-token`. You can find yours
 via FOG Configuration → FOG Settings
  → API System.
 
-**API user token** (*highly recommended*) &mdash; a header named
-`fog-user-token`. You can find yours via Users → List
-All Users → *your username* →
-API. The user's **User API Enable** checkbox on that tab must be ticked, or the
-token is rejected even when sent.
+**API user token** &mdash; a header named `fog-user-token`. You can find yours
+via Users → List All Users →
+*your username* → API. The user's **User API
+Enable** checkbox on that tab must be ticked, or the token is rejected even when
+sent.
 
-!!! note "Copy the token value as shown"
+The user token here is the same value the Bearer method uses; only the header it
+travels in differs.
+
+!!! note "Copy the token values as shown"
     The web UI already displays both tokens **base64-encoded**, which is exactly
     the form the server expects in the header. Copy the displayed value verbatim
     &mdash; the server base64-decodes the header before comparing it. A raw,
@@ -80,19 +141,28 @@ from an external directory (LDAP) can authenticate this way too, provided
 **Allow API** is enabled on the LDAP server.
 
 !!! warning "Upgrading an existing server: re-run the installer"
-    Basic auth depends on the `Authorization` header reaching PHP, and under
-    FastCGI it does not arrive on its own &mdash; nginx forwards only a fixed
-    parameter list, and Apache strips it before `proxy_fcgi`. The FOG installer
-    emits the necessary web server configuration, but a server installed before
-    this was fixed still has the old configuration on disk. If basic auth
-    returns `401 Unauthorized` with credentials you know are correct, re-run the
-    installer to refresh the web server configuration. Token authentication is
-    unaffected and needs no reinstall.
+    Basic auth **and Bearer** both depend on the `Authorization` header reaching
+    PHP, and under FastCGI it does not arrive on its own &mdash; nginx forwards
+    only a fixed parameter list, and Apache strips it before `proxy_fcgi`. The
+    FOG installer emits the necessary web server configuration, but a server
+    installed before this was fixed still has the old configuration on disk. If
+    either method returns `401 Unauthorized` with credentials you know are
+    correct, re-run the installer to refresh the web server configuration. The
+    `fog-api-token` / `fog-user-token` pair travels in its own headers, is
+    unaffected, and needs no reinstall &mdash; so it is also the quickest way to
+    tell this problem apart from a genuinely bad credential.
 
 ### Example
 
 While many different tools can be used to make API calls, `curl` is one of the
 most basic ones if you are on Linux and want to give it a try:
+
+```bash
+curl -H 'Authorization: Bearer yourusertoken' \
+     -X GET http://fogserver/fog/system/info
+```
+
+The same call using the token pair:
 
 ```bash
 curl -H 'fog-api-token: yourapitoken' \

--- a/docs/management/web/config.md
+++ b/docs/management/web/config.md
@@ -253,8 +253,9 @@ the worker that handled your click.
 ### Automating with the API
 
 The same actions are available through the FOG API for scripting. Like any FOG
-API call, they require a valid `fog-api-token` and an API-enabled
-`fog-user-token`:
+API call, they need an authenticated request &mdash; an `Authorization: Bearer`
+user token, or the `fog-api-token` + `fog-user-token` pair. See
+[[api#Authentication]]:
 
 | Method | Endpoint | Purpose |
 | --- | --- | --- |


### PR DESCRIPTION
## Problem

[FOGProject/fogproject#1324](https://github.com/FOGProject/fogproject/pull/1324)
added `Authorization: Bearer` as a standalone API credential on 1.6 — the
per-user API token in the standard header, with no `fog-api-token` beside it.
The API page still documented only the two-header pair and basic auth, and did
not say where in the UI the token lives.

## Fix

Rewrites **Authentication** in `docs/kb/integrations/api.md` to lead with a
three-way comparison table, then documents Bearer first as the recommended
method, with the token pair and basic auth kept below it.

| Method | What you send | Also needs `fog-api-token`? |
| --- | --- | --- |
| **Bearer token** (recommended) | `Authorization: Bearer <user token>` | **no** |
| Token pair | `fog-api-token` + `fog-user-token` headers | yes |
| HTTP Basic | `Authorization: Basic <base64 user:password>` | yes |

Answers "where do I get the token": Users → List All Users → *your username* →
**API**, the **User API Token** field, with **User API Enable** ticked and
**Reset Token** to roll it. It is the same value the `fog-user-token` header
carries — only the header differs.

Two traps get their own callouts, because both surface as a bare 401 with
nothing to go on:

- **Copy the value the UI shows.** Don't decode it, and don't read it out of the
  database. A FOG token is hexadecimal, and hexadecimal is *itself* valid
  base64 — so a raw token decodes "successfully" into something meaningless
  rather than failing loudly.
- **A bare `Authorization: Bearer`** — what a client built from an unset config
  value sends — answers 401 specifically rather than falling through to another
  method.

The FastCGI reinstall warning now covers Bearer too: it rides the same
`Authorization` header basic auth does, so the same missing web server
configuration breaks it. The token pair travels in its own headers and is
unaffected, which also makes it the quickest way to tell that problem apart from
a genuinely bad credential.

Two framing sentences elsewhere said an API call requires the header pair, which
is no longer the only way, so they now point at the authentication section:
`api-expansion-and-pagination.md` and `management/web/config.md`. Their examples
still show the pair — it works on every version and needed no churn.

## Done when

A reader who wants to call the 1.6 API can find the recommended method, get the
token out of the UI, and make a working call without hitting either 401 trap.

## Verification

Both documented `curl` invocations run verbatim against a 1.6 server carrying
#1324: `200`. Both trap callouts reproduce: bare `Bearer` → `401`, raw decoded
token → `401`.

## Notes

- **Nothing is deprecated.** Both older methods keep working on 1.6, and the page
  says so — no existing integration needs to change.
- **1.5.x is unaffected**; the page marks Bearer as 1.6.0 and up, and keeps the
  token pair as the method to use there.
- **French translations untouched** — `.github/workflows/translate.yml`
  regenerates those.