### PR TITLE
Document the API page's request snippet tabs

### DIFF
--- a/docs/kb/integrations/api-openapi-reference.md
+++ b/docs/kb/integrations/api-openapi-reference.md
@@ -40,6 +40,30 @@ Paste both exactly as the UI shows them. See [[api|API]] for the detail on why.
 
 The reference follows the light/dark toggle in the header along with the rest of the UI.
 
+## Code snippets for the call you just made
+
+Run a call with **Try it out** → **Execute** and a **Snippets** panel appears with the same request
+written four ways:
+
+| Tab | What it uses |
+|---|---|
+| cURL | `curl`, the form the rest of these pages quote |
+| PowerShell | `Invoke-RestMethod`, with the headers in a hashtable and the body in a here-string |
+| Python | the [`requests`](https://requests.readthedocs.io/) library |
+| JavaScript | `fetch` |
+
+Each is the *actual* request — your server's address, the path with your parameters filled in, your
+headers, and the body you typed — so it can be pasted into a shell or a script and run as-is.
+
+The PowerShell tab is a real PowerShell command rather than a `curl.exe` command line with
+PowerShell quoting, which is what Swagger UI offers out of the box. It is a starting point for a
+one-off script; for anything larger, [FogApi](https://fogapi.readthedocs.io/en/latest/) is a
+PowerShell module built around this API and worth reaching for first.
+
+> [!warning] The snippet contains your token
+> Whatever you entered under **Authorize** is in the snippet, because it was in the request. Strip
+> it before pasting a snippet into a ticket, a chat, or a repository.
+
 ## The raw document
 
 Two paths serve the same document:

--- a/docs/kb/integrations/api-openapi-reference.md
+++ b/docs/kb/integrations/api-openapi-reference.md
@@ -43,22 +43,33 @@ The reference follows the light/dark toggle in the header along with the rest of
 ## Code snippets for the call you just made
 
 Run a call with **Try it out** → **Execute** and a **Snippets** panel appears with the same request
-written four ways:
+written several ways:
 
 | Tab | What it uses |
 |---|---|
 | cURL | `curl`, the form the rest of these pages quote |
-| PowerShell | `Invoke-RestMethod`, with the headers in a hashtable and the body in a here-string |
+| cURL (PowerShell) | `curl.exe`, with PowerShell quoting and backtick continuations |
+| cURL (CMD) | `curl`, with Windows `cmd` quoting and caret continuations |
+| PowerShell | `Invoke-RestMethod`, headers in a hashtable and the body in a here-string |
 | Python | the [`requests`](https://requests.readthedocs.io/) library |
 | JavaScript | `fetch` |
+| Ruby | `net/http` from the standard library, so nothing needs installing |
+| PHP | the [cURL extension](https://www.php.net/manual/en/book.curl.php) |
 
 Each is the *actual* request — your server's address, the path with your parameters filled in, your
 headers, and the body you typed — so it can be pasted into a shell or a script and run as-is.
 
-The PowerShell tab is a real PowerShell command rather than a `curl.exe` command line with
-PowerShell quoting, which is what Swagger UI offers out of the box. It is a starting point for a
-one-off script; for anything larger, [FogApi](https://fogapi.readthedocs.io/en/latest/) is a
-PowerShell module built around this API and worth reaching for first.
+> [!note] This list is likely to get shorter
+> Every generator that exists is on for now, so the set can be judged in use rather than in the
+> abstract. Expect some tabs to go — **cURL (PowerShell)** and **PowerShell** in particular answer
+> the same question in two different ways on purpose, so it is easy to see which one is worth
+> keeping.
+
+**cURL (PowerShell)** is Swagger UI's own, and despite the name it is a `curl.exe` command line
+rather than PowerShell. **PowerShell** is the one that uses the cmdlets. Either runs; the second is
+the one to build a script on — and for anything past a one-off,
+[FogApi](https://fogapi.readthedocs.io/en/latest/) is a PowerShell module built around this API and
+worth reaching for first.
 
 > [!warning] The snippet contains your token
 > Whatever you entered under **Authorize** is in the snippet, because it was in the request. Strip


### PR DESCRIPTION
Documents the request-snippet panel added to the API Documentation page in FOGProject/fogproject#1356.

Adds one section to `docs/kb/integrations/api-openapi-reference.md`, between the Authorize instructions and the raw-document section, covering:

- the eight tabs and what each one uses
- that the list is provisional — everything is on so the set can be judged in use, and some tabs are expected to go
- the thing the tab names themselves do not say: **cURL (PowerShell)** is Swagger UI's own and is a `curl.exe` command line despite the name, while **PowerShell** is the one that uses the cmdlets
- a pointer to [FogApi](https://fogapi.readthedocs.io/en/latest/) for anything past a one-off script
- a warning that the snippet carries whatever token was entered under **Authorize**, because it is the actual request — a snippet pasted into a ticket takes the credential with it

No new wikilinks, no new `context_id`, no front-matter changes; menu arrows use the literal `→` per the repo convention.

This is a docs-only change and merges independently of the code PR, but it describes behaviour that does not exist until that one lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8SYdjTE1d7xjVKwcR89FL)_