### PR TITLE
Document the hostname requirement and that the install mode is remembered

### DIFF
--- a/docs/installation/server/command-line-options.md
+++ b/docs/installation/server/command-line-options.md
@@ -40,8 +40,10 @@ combination that works. Full reasoning in
 | `public-cert` | https | **https** | **yes** | no |
 | `embed-ca` | https | **https** | no | **yes** |
 
-An attended install offers these as a numbered prompt. Under `-y` it does not
-ask and you get `standard` unless you passed something else.
+An attended install offers these as a numbered prompt on a machine that has not
+had FOG on it before. Under `-y`, on a re-install, or with any of the transport
+options below, it does not ask: you get `standard` on a first install unless you
+passed something else, and on an upgrade you keep what you already had.
 
 >[!warning] `--install-mode` does not touch the HTTP→HTTPS redirect
 >No mode sets or clears `WEB_https_redirect`. A server upgraded from a `-S`
@@ -49,10 +51,21 @@ ask and you get `standard` unless you passed something else.
 >seeded once from the old `httpproto=https` and is then yours for good. Use
 >`--no-https-redirect` to turn it off.
 
->[!warning] `http-only` does not persist
->`WEB_url_proto` is set back to `https` at the start of every run — 443 listens
->on every install either way — so `--install-mode http-only` applies only to the
->run you pass it on. Pass it again on each upgrade, or it silently reverts.
+>[!note] The mode is asked once and remembered
+>Your choice is stored as `FOG_install_mode` in
+>[[install-fogsettings|.fogsettings]], so `--install-mode` only needs giving to
+>*change* it — an upgrade keeps the mode you picked, and the four-mode menu is
+>not shown again.
+>
+>This is also what makes `http-only` stick. `WEB_url_proto` is set back to
+>`https` early in every run (443 listens on every install either way), and the
+>preset is applied *after* that line — so the mode survives where it previously
+>had to be passed again on every upgrade or it silently reverted.
+>
+>Any of the individual transport options below **clears** the remembered mode,
+>because the result is no longer one of the four named shapes. That is
+>deliberate: a mode name left in place would have the next upgrade re-apply the
+>preset over the very setting you changed.
 
 ## Transport options
 

--- a/docs/management/server/install-fogsettings.md
+++ b/docs/management/server/install-fogsettings.md
@@ -351,6 +351,7 @@ to set one of them, that guide predates FOG 1.6:
 | Setting | Kind | Meaning |
 |---|---|---|
 | `FOG_install_type` | Preference | `N` for a full server, `S` for a storage node |
+| `FOG_install_mode` | Preference | Which of the four `--install-mode` presets was chosen — `standard`, `http-only`, `public-cert` or `embed-ca` — or empty for a shape built from the individual transport options. Asked once and remembered, so the four-mode menu is not shown again on an upgrade. Any individual transport option clears it; see [[command-line-options#The four install modes\|The four install modes]] |
 | `FOG_os_id` | Record | `1` Redhat, `2` Debian, `3` Alpine (experimental), `4` Arch |
 | `FOG_os_name` | Record | The detected distribution family |
 | `FOG_install_lang` | Preference | Whether the extra language packs were installed |
@@ -374,11 +375,36 @@ to set one of them, that guide predates FOG 1.6:
 | `NET_interface` | Preference | The NIC FOG binds services to and takes its address from |
 | `NET_fog_server_ip` | Record | The server's **primary** address. Everything that needs "the FOG server" uses this |
 | `NET_subnet_mask` | Record | Netmask, used when FOG runs DHCP |
-| `NET_hostname` | Preference | The name put in the web certificate and the vhost. **This does not set your system hostname.** Change it with `--hostname` |
+| `NET_hostname` | Preference | The name put in the web certificate and the vhost. Change it with `--hostname`. **FOG will not rename a server that already has a hostname** — but if the machine has *none*, FOG sets this as its system hostname and adds it to `/etc/hosts`, because nothing can be issued a certificate without a name. See [[#No hostname set]] |
 
 Every *other* address on that interface is `PKI_san_ip_addresses`, and extra
 names this server answers to are `PKI_san_dns_names` — both under `PKI_` because
 they reach past certificates into the vhost and the maintenance allow list.
+
+#### No hostname set
+
+FOG 1.6 cannot install without a hostname. Every certificate it issues is issued
+*to a name*, so a machine that reports no hostname — or the kernel's literal
+default `(none)`, which is not the same thing as blank — has nothing to put in
+one. Earlier 1.6 builds failed late and unhelpfully here: the installer stopped
+the web server, aborted while generating certificates, and never restarted it,
+with nothing in the output mentioning a hostname.
+
+The installer now checks this before it starts, and rejects anything that cannot
+serve as a certificate name: blank, `(none)`, `localhost`, and IP addresses.
+
+- **Attended**, with no usable hostname: you are asked for one, and told why.
+- **Unattended** (`-y`, or piped), with no usable hostname and no `--hostname`:
+  it warns and uses `fogserver`, which every FOG certificate already covers.
+- **A bad value already in `.fogsettings`** is not carried forward silently —
+  you are asked again.
+
+In the no-hostname case *only*, FOG then sets that name as the machine's system
+hostname and adds it to `/etc/hosts`, because the installer verifies its own web
+tier by name and cannot do that if nothing resolves. A server that already has a
+hostname is never renamed, whatever names its certificate carries. If the
+hostname cannot be set — an unprivileged container, for instance — the install
+continues and tells you what to fix.
 
 ### `DHCP_` — FOG acting as a DHCP server
 


### PR DESCRIPTION
Companion to FOGProject/fogproject#1359, which fixes two installer defects: a server with no hostname could not be installed at all, and the four install modes were asked on every run rather than once.

## `.fogsettings` (`docs/management/server/install-fogsettings.md`)

- New **No hostname set** section under `NET_`: what counts as unusable (blank, the kernel's `(none)`, `localhost`, an IP address), what happens attended vs unattended, and the one case where FOG now sets the machine's own hostname — when it has none, because the installer verifies its own web tier by name and cannot do that if nothing resolves.
- The `NET_hostname` row said flatly that FOG **does not set your system hostname**. Narrowed to what it actually promises: a server that *already has* a name is never renamed. That was the right statement for the case it was written for, and wrong for a machine with no name at all.
- New `FOG_install_mode` row in the `FOG_` reference table.

## Command-line options (`docs/installation/server/command-line-options.md`)

- Replaced the "`http-only` does not persist" warning, which is no longer true. In its place: the mode is stored as `FOG_install_mode` and only needs giving to *change* it, why `http-only` sticks now (the preset is applied after the line that forces `WEB_url_proto=https`), and why any individual transport option clears the remembered mode.
- Corrected the description of when the numbered prompt appears — first install only, not every attended run.

## Verification

`npm run docs:build` completes clean (111 files, 960 emitted). Checked the built HTML for both changed pages: no unrendered `[[…]]`, the new `#no-hostname-set` anchor exists, and every cross-link resolves — `install-fogsettings` ↔ `command-line-options#the-four-install-modes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvP4cqggYooEDFRqHZQzdd

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvP4cqggYooEDFRqHZQzdd)_