### PR TITLE
One channel vocabulary: document stable/patches/beta

### DIFF
--- a/docs/development/version-sync-automation.md
+++ b/docs/development/version-sync-automation.md
@@ -44,13 +44,36 @@ when the third line says `true`. This split exists so:
 
 The formula per branch prefix:
 
-| Branch prefix | Channel | Version scheme |
+| Branch prefix | Channel written | Channel computed | Version scheme |
+|---|---|---|---|
+| `dev` (`dev-branch`) | *(none)* | Patches | `{tag base}.{commits since master}` |
+| `stable` | *(none)* | Stable | Same as `dev`, but counted from `dev-branch` instead of `HEAD` |
+| `working` (`working-1.6`) | Beta | Beta | `{branch suffix}.0-beta.{commits since master}` |
+| `feature` (`feature-*`) | Feature | Feature | `{branch suffix}.0-feature.{commits since master}` |
+| `rc` (`rc-*`) | Release Candidate | Release Candidate | `{branch suffix}.0-RC-{n}`, where `n` increments by 1 from whatever's currently committed |
+
+The two channel columns differ only for `dev` and `stable`, which compute a
+label that is never written — see the note below. The *computed* label matters
+anyway: it is what the sync commit message and the CI job summary say.
+
+**One vocabulary, shared with `FOG_update_channel`.** Since
+[fogproject#1279](https://github.com/FOGProject/fogproject/issues/1279) the
+channel label is the title-case form of the update channel a server tracks, so
+the value you configure and the value you read back are the same word:
+
+| Branch | `FOG_update_channel` | `FOG_CHANNEL` |
 |---|---|---|
-| `dev` (`dev-branch`) | *(none)* | `{tag base}.{commits since master}` |
-| `stable` | *(none)* | Same as `dev`, but counted from `dev-branch` instead of `HEAD` |
-| `working` (`working-1.6`) | Beta | `{branch suffix}.0-beta.{commits since master}` |
-| `feature` (`feature-*`) | Feature | `{branch suffix}.0-feature.{commits since master}` |
-| `rc` (`rc-*`) | Release Candidate | `{branch suffix}.0-RC-{n}`, where `n` increments by 1 from whatever's currently committed |
+| `stable` | `stable` | Stable |
+| `dev-branch` | `patches` | Patches |
+| `working-1.6` | `beta` | Beta |
+| `rc-*` / `feature-*` | *(none — not a track anyone follows)* | Release Candidate / Feature |
+
+`lib/common/functions.sh` owns the update-track half and `fog-version.sh` owns
+the label half; nothing else connects the two files, which is how they drifted
+apart in the first place. `tests/update-channel-vocabulary.test.sh` parses the
+`case` arms out of both and fails if they disagree. The retired spellings
+`staging` and `dev` still resolve, so existing servers keep updating — see
+[[install-fogsettings]].
 
 `dev-branch` and `stable` deliberately carry **no `FOG_CHANNEL` line at all**
 — a clean version string with no channel text, by design. This isn't an

--- a/docs/management/server/install-fogsettings.md
+++ b/docs/management/server/install-fogsettings.md
@@ -359,7 +359,7 @@ to set one of them, that guide predates FOG 1.6:
 | `FOG_installed` | Record | `1` once a first install has completed; lets later runs skip the full question set. Deliberately unquoted and numeric, to match the historical format |
 | `FOG_packages` | Record | What was installed on this box. Re-derived every run from the distribution package lists |
 | `FOG_git_path` | Record | Where the checkout is. Re-asserted from what the run actually resolved, so a moved or re-cloned tree cannot point `updatefog.sh` at a directory that is gone |
-| `FOG_update_channel` | Preference | Which channel this server tracks: `stable`, `staging` or `dev` |
+| `FOG_update_channel` | Preference | Which channel this server tracks: `stable`, `patches` or `beta`. The same word as the `FOG_CHANNEL` the server reports, in lowercase. The earlier spellings `staging` and `dev` mean `patches` and `beta`, and are still accepted so existing servers keep updating |
 | `FOG_program_dir` | Record | Where this install lives, so `grep FOG_program_dir .fogsettings` answers the question. Not a control — see [[install-fogsettings#Where the install lives\|Where the install lives]] |
 
 >[!warning] `FOG_os_id` changed meaning between 1.5 and 1.6


### PR DESCRIPTION
Docs half of [fogproject#1402](https://github.com/FOGProject/fogproject/pull/1402), which fixes [fogproject#1279](https://github.com/FOGProject/fogproject/issues/1279).

## Why

FOG had two things called a channel, sharing the word and nothing else:

| | Values |
|---|---|
| `fog_update_channel` | `stable` / `staging` / `dev` |
| `FOG_CHANNEL` | `Patches` / `Beta` / `Release Candidate` / `Feature` |

**These two docs are where that contradiction actually lived.** `install-fogsettings` described the first and `version-sync-automation` described the second, so they disagreed about the same branch — both correct about different variables, which is exactly how an admin reading one while configuring the other got it wrong, silently.

They are now one word: the stored value is lowercase, the label is its title-case form.

| Branch | `FOG_update_channel` | `FOG_CHANNEL` |
|---|---|---|
| `stable` | `stable` | Stable |
| `dev-branch` | `patches` | Patches |
| `working-1.6` | `beta` | Beta |
| `rc-*` / `feature-*` | *(none)* | Release Candidate / Feature |

`dev` in particular pointed at `working-1.6`, **not** at `dev-branch` — it read as a typo and was not one.

## Changes

**`install-fogsettings.md`** — names `stable`/`patches`/`beta`, says it is the same word as the `FOG_CHANNEL` the server reports, and records that `staging` and `dev` still resolve so existing servers keep updating. The `FOG_update_channel='stable'` example is unchanged; that value did not move.

**`version-sync-automation.md`** — gains the shared-vocabulary table, and its channel column splits in two. That distinction was already implicit in the page and is worth stating outright: `dev` and `stable` **compute** a label that is never **written**, because neither branch carries a `FOG_CHANNEL` line for `apply-fog-version.sh`'s `sed` to match. The computed value still matters — it is what the sync commit message and the CI job summary say — which is why `stable`'s moved from `Patches` to `Stable` even though nothing released changes.

The existing "`dev-branch` and `stable` deliberately carry no `FOG_CHANNEL` line — don't add one" note is untouched and still correct.

## Ordering

Merge after fogproject#1402, or together with it. On its own this documents behavior that is not in a release yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)