### PR TITLE
Record the OrganizationAdmin bypass on the working-1.6 ruleset

### DIFF
--- a/docs/development/version-sync-automation.md
+++ b/docs/development/version-sync-automation.md
@@ -194,7 +194,8 @@ gh api --method POST /repos/FOGProject/fogproject/rulesets \
   "enforcement": "active",
   "conditions": { "ref_name": { "include": ["refs/heads/working-1.6"], "exclude": [] } },
   "bypass_actors": [
-    { "actor_id": 971767, "actor_type": "Integration", "bypass_mode": "always" }
+    { "actor_id": 971767, "actor_type": "Integration", "bypass_mode": "always" },
+    { "actor_id": 1, "actor_type": "OrganizationAdmin", "bypass_mode": "always" }
   ],
   "rules": [
     { "type": "pull_request", "parameters": {
@@ -229,6 +230,15 @@ Four things that will bite if they are skipped:
   that looks correct and bypasses nobody. For `fog-workflows` it is `971767`,
   as written above; read it back from
   `gh api orgs/FOGProject/installations --jq '.installations[]|"\(.app_id) \(.app_slug)"'`.
+- **The `OrganizationAdmin` bypass is a deliberate trade, not an oversight.** A
+  `pull_request` rule blocks direct pushes from *everyone*, maintainers
+  included -- rulesets do not exempt admins by default. Without this entry a
+  maintainer cannot push to `working-1.6` at all. With it, a maintainer can
+  also squash, rebase or push directly, any of which breaks the commit-count
+  prediction; that is precisely the "an admin bypassed the ruleset" case the
+  merge-time sync is retained to cover, so the failure mode stays churn rather
+  than a wrong version reaching a release. GitHub normalises this entry's
+  `actor_id` to `null` on read-back, which is expected.
 - **Confirm the seven check names against a real run before enabling.** They
   are `<caller job name> / <called job name>`, and a mistyped required check
   blocks every pull request permanently while looking like a workflow that


### PR DESCRIPTION
Follow-up to #137/#144. The live ruleset changed, so the documented JSON had drifted.

`allowed_merge_methods` only exists inside a `pull_request` rule, and that rule blocks direct pushes from **everyone** — rulesets do not exempt admins by default. As first applied, ruleset `21585641` left maintainers unable to push to `working-1.6` at all. It now carries an `OrganizationAdmin` bypass.

This records that entry in the JSON and adds a bullet saying what it costs, so the next reader does not remove it as an apparent mistake: an admin can now squash, rebase or push directly, any of which breaks the commit-count prediction. That is exactly the "admin bypassed the ruleset" case the merge-time sync is deliberately retained to cover, so the failure mode remains churn rather than a wrong version reaching a release.

Read-back of the live ruleset:

```
bypass_actors:
  id=null type=OrganizationAdmin mode=always
  id=971767 type=Integration mode=always
merge methods: merge
strict (branches up to date): true
required checks: 7
```

GitHub normalises the OrganizationAdmin entry's `actor_id` to `null` on read-back — noted in the doc so it does not read as a failed write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)