### PR TITLE
Cross-link the netboot transport page, and document System → Export

### DIFF
--- a/docs/kb/reference/bringing-your-own-ca.md
+++ b/docs/kb/reference/bringing-your-own-ca.md
@@ -207,3 +207,4 @@ Boot on its self-signed key. Nothing is silently broken.
 - [[external-ca-lets-encrypt|External CA & Let's Encrypt certificates]]
 - [[secure-boot-signing|Secure Boot signing]]
 - [[unify-certificates-across-fog-servers|Unifying certificates across several FOG servers]] — applying the Web zone options across a fleet
+- [[netboot-transport-and-pki|Netboot transport and PKI]] — which zone each install mode uses, and why replacing the CA changes what iPXE must trust

--- a/docs/kb/reference/netboot-transport-and-pki.md
+++ b/docs/kb/reference/netboot-transport-and-pki.md
@@ -292,3 +292,4 @@ not the transport. See [[fog-security|FOG Security]].
 - [[command-line-options|Fog installer command line options]] — every option named here
 - [[install-fogsettings|The .fogsettings file]] — where these settings persist
 - [[compile_ipxe_binaries|Compile iPXE binaries]] — building iPXE by hand
+- [[local-esp-boot|Booting FOG from the local ESP]] — the same transport choices when iPXE is started from disk rather than PXE

--- a/docs/kb/reference/secure-boot-technical-details.md
+++ b/docs/kb/reference/secure-boot-technical-details.md
@@ -224,3 +224,4 @@ is not being accepted. In order of likelihood:
 - [[secure-boot-mok-enrollment|MOK enrollment]]
 - [[secure-boot-setup-mode-enrollment|Setup Mode enrollment]]
 - [[pki-zones|FOG's Certificate Zones]]
+- [[netboot-transport-and-pki|Netboot transport and PKI]] — how Secure Boot and an HTTPS netboot transport combine

--- a/docs/management/web/roles.md
+++ b/docs/management/web/roles.md
@@ -38,7 +38,7 @@ Each permission is an **area** plus an **action**:
 
 - **Areas** are the sections of FOG: Hosts, Groups, Images, Snapins,
   Printers, Tasks, Users, Roles, Storage Nodes, Storage Groups, Client
-  Settings, FOG Settings, Reports, Plugins, and so on.
+  Settings, FOG Settings, Reports, Plugins, System, and so on.
 - **Actions** are what can be done there: **View**, **Create**,
   **Edit**, **Delete**, and **Task** (starting imaging/snapin tasks).
 
@@ -53,6 +53,25 @@ They are separate on purpose. Switching on code an administrator already chose
 to put on the server, and adding new code to it, are different authorities —
 so a role that manages plugins does not thereby get to add one. See
 [[management/web/plugins#Installing a plugin from an archive|Plugins]].
+
+**System** works the same way. Its only action is **Export**, and it controls
+the whole-database dump on **FOG Configuration → Configuration Save**. That is
+every host, every user, every stored credential and every setting in one
+file, so it is a far larger authority than editing a setting is — and it
+is held separately from **FOG Settings → Edit** for exactly that reason.
+Without it the Export button is not rendered, the page refuses the request,
+and `GET /api/system/export` answers 403.
+
+>[!warning] This changed during the 1.6 beta
+>
+>Earlier 1.6 builds gated the database export on **FOG Settings → Edit**.
+>It is now its own permission, **System → Export**, and nothing grants it
+>automatically — including the upgrade, which seeds no default for it.
+>
+>A role that holds **FOG Settings → Edit** therefore **loses the export**
+>until you tick **System → Export** on it as well. Full-access roles are
+>unaffected. Deny-by-default is deliberate: a new permission that quietly
+>arrives already granted is not a permission.
 
 For example, a help-desk role might have full Host and Printer access
 plus the ability to view Images and start imaging tasks, but no access
@@ -98,20 +117,20 @@ along with a suggestion to ask an administrator to assign one. They keep
 the handful of pages that belong to any signed-in user regardless —
 their dashboard, the client-facing pages, and log out.
 
-!!! warning "This changed during the 1.6 beta"
-
-    Early 1.6 builds did the opposite: a role-less account was treated
-    as a full administrator, so that adopting roles could not lock an
-    existing server out before anyone had been assigned one.
-
-    That was a trap. It made removing a user's last role a **promotion**
-    rather than a restriction, and it meant any account created by an
-    authentication plugin arrived with unlimited access simply by virtue
-    of arriving without a role.
-
-    The upgrade converts every account that was relying on the old
-    behavior into an explicit role, so nobody's access changes silently
-    — see [What the upgrade does to existing users](#what-the-upgrade-does-to-existing-users).
+>[!warning] This changed during the 1.6 beta
+>
+>Early 1.6 builds did the opposite: a role-less account was treated
+>as a full administrator, so that adopting roles could not lock an
+>existing server out before anyone had been assigned one.
+>
+>That was a trap. It made removing a user's last role a **promotion**
+>rather than a restriction, and it meant any account created by an
+>authentication plugin arrived with unlimited access simply by virtue
+>of arriving without a role.
+>
+>The upgrade converts every account that was relying on the old
+>behavior into an explicit role, so nobody's access changes silently
+>— see [What the upgrade does to existing users](#what-the-upgrade-does-to-existing-users).
 
 ## What restricted users see
 
@@ -179,12 +198,16 @@ plugin every time they log in, so the upgrade has nothing useful to say
 about them, and copying their old account type across would hand every
 directory account the administrator role.
 
-!!! tip "After upgrading"
-
-    Review **Roles → Administrator → Users**. Any account that was an
-    administrator only because nobody had ever restricted it is now an
-    administrator explicitly, and this is a good moment to move it to
-    something narrower.
+>[!tip] After upgrading
+>
+>Review **Roles → Administrator → Users**. Any account that was an
+>administrator only because nobody had ever restricted it is now an
+>administrator explicitly, and this is a good moment to move it to
+>something narrower.
+>
+>Then review **System → Export** on any role that is meant to be able to
+>take a database backup — see the note under
+>[How permissions work](#how-permissions-work).
 
 ## Upgrading from the Access Control plugin
 


### PR DESCRIPTION
Closes FOGProject/fogproject#1120.

## Netboot transport / PKI (#1120)

The reference page `kb/reference/netboot-transport-and-pki.md` already landed and eleven pages already link to it. What was missing was the two pages that most need to point *at* it, and one link out of it:

| Page | Change |
|---|---|
| `bringing-your-own-ca.md` | See also → netboot page. Replacing the CA is exactly the decision that changes what iPXE has to trust. |
| `secure-boot-technical-details.md` | See also → netboot page. This is the pair readers most often believe are mutually exclusive; both pages already correct that in prose, this makes the second reachable from the first. |
| `netboot-transport-and-pki.md` | See also → `local-esp-boot`. Same transport choices, iPXE started from disk rather than PXE. |

### One bullet in #1120 is stale — deliberately not written

#1120 asks the page to state plainly that the ESP `autoexec.ipxe` fallback is a `chain X || goto Y` ladder. It no longer is. GH-1195 removed the ladder outright: a chained EFI image resolves `autoexec.ipxe` by *flat name* through `efi_image_exec()`'s synthetic filesystem, so a root-level ladder recursed and exhausted firmware pool memory. Every copy is now identical, emitted from `_espAutoexecScript()`.

`kb/how-tos/local-esp-boot.md:69` already documents the shipped reality — "there is no fallback chain to wait for, by design" — so writing the issue's version would have put two pages in contradiction.

## System → Export (`roles.md`)

Owed from FOGProject/fogproject#1440, which split the whole-database dump out of `settings.edit` into its own `system.export` permission.

- New **System** area documented alongside the existing **Plugins** exemplar of an area with its own action.
- Beta-to-beta behavior change called out: a role holding **FOG Settings → Edit** **loses the export** until **System → Export** is ticked. Nothing seeds it — no schema step, exactly as `activity` and `audit.manage` were introduced. Full-access (`*`) roles are unaffected.
- Cross-referenced from the existing "After upgrading" note.

Verified against the shipped code rather than from memory: the route is `GET /api/system/export` (`Route.php:1358`), the UI is **FOG Configuration → Configuration Save** (`$foglang['ConfigSave']`, `text.php:152`), the button is suppressed by `Authorization::can('system.export')` (`fogconfigurationpage.page.php:3826`), and `'*'` short-circuits at `Authorization.php:672`.

## Drive-by

The two MkDocs `!!!` admonitions in `roles.md` are converted to Obsidian callouts. `README.md:72` mandates Obsidian syntax; the `!!!` form does not render and was reaching the built page as plain text.

## Validation

`npm run docs:build` from `quartz/` — 113 files, clean, no warnings. Confirmed in the emitted HTML that all three new wikilinks resolve (`href="../../netboot-transport-and-pki"` etc., matching the shape existing links use), that no page carries `class="internal broken"`, and that `roles.html` now renders `data-callout="warning"` ×2 and `data-callout="tip"` ×1 with no literal `!!!` left.