### PR TITLE
Document the per-column Filter on every list

### DIFF
--- a/docs/management/web/filtering-lists.md
+++ b/docs/management/web/filtering-lists.md
@@ -1,0 +1,108 @@
+---
+title: Filtering Lists
+aliases:
+    - Filtering Lists
+    - Column Filters
+description: how to filter any list in the FOG web interface by individual columns, including date ranges
+context_id: filtering-lists
+tags:
+    - management
+    - web-management
+    - web-ui
+---
+
+# Filtering Lists
+
+Every list in FOG — hosts, images, snapins, tasks, reports, the association
+tabs inside an edit page, and the lists a plugin adds — carries two ways to
+narrow what it shows.
+
+The **search box** above the list is a quick free-text match: type anything and
+FOG returns rows where *any* column contains it. It is the fastest way to find
+one thing you can already name.
+
+The **Filter** button, next to Select All and Refresh, is for everything else.
+It builds a filter one rule at a time, and each rule names a single column.
+
+## Building a filter
+
+Click **Filter**, then **Add condition**. A rule has three parts:
+
+1. the **column** to look at,
+2. the **condition** to apply,
+3. the **value** to compare against.
+
+Add more rules to narrow further. The **And / Or** control to the left of the
+rules decides how they combine: *And* keeps only the rows matching every rule,
+*Or* keeps the rows matching any of them. **Add group** nests a set of rules
+inside brackets, so you can express things like *"deployed this month, and
+called either lab-a or lab-b"*.
+
+The button counts the rules you have added, so `Filter (2)` means two are
+active. **Clear All** removes them.
+
+>[!note]
+>The filter and the search box work together — with both in use, a row has to
+>satisfy the search *and* the filter. If a list looks emptier than you expect,
+>check both.
+
+## The conditions you get depend on the column
+
+FOG knows what each column really holds, and offers only the conditions that
+make sense for it.
+
+| Kind of column | Examples | Conditions offered |
+| --- | --- | --- |
+| Text | Host name, image name, description | Equals, Not, Starts With, Ends With, Contains, Does Not Contain, Empty, Not Empty |
+| Number | ID, size, port | Equals, Not, `<`, `<=`, `>=`, `>`, Between, Not Between, Empty, Not Empty |
+| Date and time | Last deployed, last seen, created, checked in | Equals, Not, Before, After, Between, Not Between, Empty, Not Empty |
+
+A few columns cannot be filtered on and are simply not listed as choices. Two
+kinds: values FOG never sends to the browser in the first place (a host's
+security token, for instance), and columns the list *calculates* rather than
+stores — a group's member count, or a site's host count. There is nothing in
+the database for a rule to match against.
+
+>[!note]
+>The list of choices comes from the server, so a plugin's own lists get the
+>right conditions for their own columns with nothing to configure.
+
+## Filtering by date
+
+Date conditions open a calendar. Pick a day rather than typing one, and note
+that a date condition always means **the whole of that day**:
+
+- **Equals 2026-08-29** — anything that happened at any time on the 29th.
+- **Before 2026-08-29** — anything up to midnight starting the 29th. The 29th
+  itself is *not* included.
+- **After 2026-08-29** — anything from midnight starting the 30th. The 29th
+  itself is *not* included.
+- **Between 2026-08-01 and 2026-08-31** — both days included, in full.
+
+**Empty** and **Not Empty** are the ones worth knowing about. A date column is
+empty when the thing has never happened: a host that has never been deployed
+has no deploy date at all, which is a different fact from having an old one.
+Those rows are excluded from *Before* and *After* — asking for "deployed before
+today" gives you hosts that were deployed, and not the ones that never were.
+Use **Empty** when the never-happened rows are what you are looking for.
+
+## Exporting what you filtered
+
+On the pages that offer a **CSV (All)** button, the export follows the filter.
+Whatever the list is showing when you click it is what the file contains —
+every matching row, not just the page on screen.
+
+>[!note]
+>The other toolbar buttons — Copy, CSV, Excel, Print — are the browser's own
+>and can only see the rows it is currently holding, which on a long list is one
+>page. **CSV (All)** is the one that asks the server for the whole result.
+
+## Wildcards
+
+You do not need them, and they are not interpreted. The condition itself says
+where the match may fall, so *Contains* already means "anywhere". A `%` or `_`
+typed into a filter value is treated as that character — searching for `50%`
+finds the text `50%`.
+
+The free-text search box above the list behaves differently and is deliberately
+looser.

--- a/docs/management/web/index.md
+++ b/docs/management/web/index.md
@@ -15,6 +15,10 @@ tags:
 
 Documentation related to how to use the web management ui.
 
+**Using the Interface**
+
+- [[filtering-lists|Filtering Lists]]
+
 **Access & Security**
 
 - [[users|User Management]]


### PR DESCRIPTION
Documents the per-column **Filter** that landed in [fogproject#1471](https://github.com/FOGProject/fogproject/pull/1471) — a button beside Select All and Refresh on every list in the web UI (hosts, images, tasks, reports, the association tabs inside an edit page, and anything a plugin adds), building rules of one column + one condition + a value, combined with And/Or and nestable into groups.

New page: `docs/management/web/filtering-lists.md`, linked from the web management index under a new **Using the Interface** group — it is the first page there about the interface itself rather than about one kind of object.

## What it spends its length on

Most of the page is the three things that are surprising, rather than the mechanics of clicking *Add condition*:

**Which conditions a column offers varies**, because FOG picks them from what the column actually holds — text, number, or date. Worth stating plainly: a reader who saw Before/After on one column and not another would otherwise read it as a bug. Same for the handful of columns absent from the picker entirely — a value the server never sends the browser, or a count the list calculates rather than stores, has nothing to match against.

**A date condition means a whole day.** "Before the 29th" stops at midnight starting the 29th and "After the 29th" begins at midnight starting the 30th, so neither includes the 29th itself. **Empty** gets its own paragraph, because *never deployed* is a different fact from *deployed a long time ago* — those rows are in neither Before nor After, and someone hunting for them needs to be told where they are.

**CSV (All) follows the filter and the other export buttons do not**, being the browser's own and able to see only the page in front of them. The reports page already carries that distinction; this states it where someone filtering a list will meet it.

Plus a short note that wildcards are not interpreted in a filter value — the condition is what says where the match falls, so a typed `%` is a percent sign — and that the search box above the list is the loose one.

## Verification

Built the site: 116 files, no errors, the page and its og-image emitted, zero unparsed `[[` in either page, and the index's wikilink resolving to a real href.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135Lu8hmugc8hDwKZig7Q2z
