### PR TITLE
Show the actual JSON the API returns for a refused delete

### DIFF
--- a/docs/kb/reference/referential-integrity.md
+++ b/docs/kb/reference/referential-integrity.md
@@ -134,10 +134,15 @@ changed** — a refused delete leaves the record and everything pointing at it
 exactly as they were.
 
 Over the API the same message comes back as **HTTP 409 Conflict**, with the
-sentence as the response body. 409 rather than a generic error is
-deliberate: it means the request itself was fine and will work once the
-blocking record is dealt with, so a script can tell "fix this and retry"
-apart from "this request was wrong".
+sentence under `error` in the response body:
+
+```json
+{"error": "Cannot delete this storage group because a location still refers to it. Reassign or remove it first."}
+```
+
+409 rather than a generic error is deliberate: it means the request itself
+was fine and will work once the blocking record is dealt with, so a script
+can tell "fix this and retry" apart from "this request was wrong".
 
 >[!note]
 >Occasionally the message is the database's own instead:


### PR DESCRIPTION
Follows FOGProject/fogproject#1475, which makes the router send every error message as a JSON object rather than a bare string.

The page said the sentence arrives "as the response body" — true of the code when #150 landed, and no longer. A script reads `.error`, so the page now shows the literal body:

```json
{"error": "Cannot delete this storage group because a location still refers to it. Reassign or remove it first."}
```

Shown rather than described, because the reason to document it at all is so somebody can write the parse.

`scripts/check-anchors.mjs` reports the same 2 broken anchors before and after — both pre-existing legacy `../../` links, untouched here.

Merge after FOGProject/fogproject#1475.