### PR TITLE
Document arranging lists and what FOG remembers

### DIFF
--- a/docs/management/web/filtering-lists.md
+++ b/docs/management/web/filtering-lists.md
@@ -31,6 +31,10 @@ straight under the heading you mean. Use whichever suits the job — a quick
 "host name starts with lab" is faster in the header row, while anything with
 brackets or an *Or* in it wants the Filter panel.
 
+Neither is remembered between visits: a list always opens unfiltered. That is
+deliberate — see [[list-layout|Arranging Lists]], which covers what FOG *does*
+remember about a list and why filters are kept out of it.
+
 ## Building a filter
 
 Click **Filter**, then **Add condition**. A rule has three parts:

--- a/docs/management/web/index.md
+++ b/docs/management/web/index.md
@@ -18,6 +18,7 @@ Documentation related to how to use the web management ui.
 **Using the Interface**
 
 - [[filtering-lists|Filtering Lists]]
+- [[list-layout|Arranging Lists]]
 
 **Access & Security**
 

--- a/docs/management/web/list-layout.md
+++ b/docs/management/web/list-layout.md
@@ -1,0 +1,71 @@
+---
+title: Arranging Lists
+aliases:
+    - Arranging Lists
+    - Column Layout
+    - Column Order
+    - Remembering Columns
+description: how to reorder, hide and resize the columns in any FOG list, and how FOG remembers each user's arrangement
+context_id: list-layout
+tags:
+    - management
+    - web-management
+    - web-ui
+---
+
+# Arranging Lists
+
+Every list in FOG — hosts, images, snapins, tasks, the association tabs inside
+an edit page, and the lists a plugin adds — can be arranged to suit the work
+you actually do with it, and **FOG remembers your arrangement**.
+
+The arrangement is saved against your user account, not against the browser,
+so it follows you to another machine and survives clearing your browser data.
+Two people looking at the same list can each have it arranged their own way.
+
+## What you can change
+
+**Move a column.** Drag a column heading sideways and drop it where you want
+it. Put the columns you read first on the left.
+
+**Show or hide columns.** The **Column visibility** button above the list lists
+every column with a tick beside the ones currently showing. Hiding the columns
+you never read makes the rest wider and stops the table scrolling sideways.
+
+**Resize a column.** Drag the divider between two headings.
+
+**Sort.** Click a heading to sort by it; click again to reverse it.
+
+**Rows per page.** The selector above the list.
+
+## What FOG remembers
+
+Saved per user, per list:
+
+- the order the columns are in
+- which columns are showing
+- the sort column and direction
+- how many rows per page
+
+Each list is remembered separately, so the arrangement you give the host list
+has no effect on the image list.
+
+## What FOG deliberately does not remember
+
+**Filters and searches are not saved.** Whatever you typed in the search box,
+built in the **Filter** panel, or typed in the **Column search** row is gone
+when you come back — see [[filtering-lists|Filtering Lists]].
+
+This is on purpose. A filter that came back on its own would be invisible: the
+list would simply be missing rows, with nothing on screen to say why, and the
+obvious conclusion is that the data has gone. A layout you did not expect is
+something you can see and fix in a second; rows that are not there are not.
+
+## Starting over
+
+To get a list back to how FOG ships it, show any columns you have hidden, drag
+the headings back, and set the sort and page length you want — the new
+arrangement replaces the old one as soon as you make it.
+
+A saved arrangement also expires on its own after a year of not being touched,
+so a list you have not used in a long time comes back in its default shape.


### PR DESCRIPTION
Companion to fogproject#1483, which makes each user's grid layout persist.

New page **Arranging Lists** (`docs/management/web/list-layout.md`): moving, hiding, resizing and sorting columns, and what FOG saves per user — column order, visibility, sort, rows per page — with each list remembered separately.

The section that matters most is what FOG *doesn't* save. **Filters and searches are deliberately not remembered**, and the page says why: a filter that came back on its own is invisible — the list is just missing rows, with nothing on screen to explain it, and the natural conclusion is that data has gone. Without that stated somewhere, it reads as a bug.

Also linked from the Web Management index and cross-linked from Filtering Lists, which is where someone will be standing when they wonder why their filter did not persist.