### PR TITLE
Document saved filters and their sharing

### DIFF
--- a/docs/management/web/filtering-lists.md
+++ b/docs/management/web/filtering-lists.md
@@ -31,9 +31,13 @@ straight under the heading you mean. Use whichever suits the job — a quick
 "host name starts with lab" is faster in the header row, while anything with
 brackets or an *Or* in it wants the Filter panel.
 
-Neither is remembered between visits: a list always opens unfiltered. That is
-deliberate — see [[list-layout|Arranging Lists]], which covers what FOG *does*
-remember about a list and why filters are kept out of it.
+Neither is applied on its own: a list always opens unfiltered, however you
+left it. That is deliberate — see [[list-layout|Arranging Lists]], which covers
+what FOG *does* remember about a list and why filters are kept out of it.
+
+A filter worth building twice can be given a name and kept, and handed to other
+people — see [[saved-filters|Saved Filters]]. A saved filter still only runs
+when you ask for it.
 
 ## Building a filter
 
@@ -118,6 +122,10 @@ so a row has to satisfy all three.
 >[!note]
 >Turning **Column search** off clears the boxes as well as hiding them. That is
 >deliberate: a filter you cannot see looks exactly like missing data.
+
+Whether the row is *showing* is remembered against your account, so a list you
+like filtering from the headings opens that way next time. What you typed in it
+is not: the row comes back empty.
 
 Columns that cannot be filtered get no box, the same ones and for the same
 reasons as in the Filter panel. Narrow columns put the picker above the box

--- a/docs/management/web/index.md
+++ b/docs/management/web/index.md
@@ -19,6 +19,7 @@ Documentation related to how to use the web management ui.
 
 - [[filtering-lists|Filtering Lists]]
 - [[list-layout|Arranging Lists]]
+- [[saved-filters|Saved Filters]]
 - [[display-timezone|Display Timezone]]
 
 **Access & Security**

--- a/docs/management/web/list-layout.md
+++ b/docs/management/web/list-layout.md
@@ -46,6 +46,8 @@ Saved per user, per list:
 - which columns are showing
 - the sort column and direction
 - how many rows per page
+- whether the per-column search row is showing — the row itself, never what was
+  typed in it (see [[filtering-lists|Filtering Lists]])
 
 Each list is remembered separately, so the arrangement you give the host list
 has no effect on the image list.
@@ -60,6 +62,11 @@ This is on purpose. A filter that came back on its own would be invisible: the
 list would simply be missing rows, with nothing on screen to say why, and the
 obvious conclusion is that the data has gone. A layout you did not expect is
 something you can see and fix in a second; rows that are not there are not.
+
+A filter you want back can be **saved by name** and applied deliberately, which
+puts a chip above the list naming it — see [[saved-filters|Saved Filters]].
+That is the same rule from the other side: a filter is fine as long as you can
+see it is running and turn it off in one click.
 
 ## Your timezone is remembered too
 

--- a/docs/management/web/saved-filters.md
+++ b/docs/management/web/saved-filters.md
@@ -1,0 +1,119 @@
+---
+title: Saved Filters
+aliases:
+    - Saved Filters
+    - Sharing Filters
+    - Saved Searches
+description: how to save a filter you have built on a FOG list, apply it again later, and share it with a person, a user group, a role or everybody
+context_id: saved-filters
+tags:
+    - management
+    - web-management
+    - web-ui
+---
+
+# Saved Filters
+
+A filter you have built once — see [[filtering-lists|Filtering Lists]] — can be
+given a name and kept. **Saved filters** is the button beside **Filter** on any
+list, and it does two jobs: it hands back the filters you have kept, and it
+saves the one you have on screen right now.
+
+Filters are saved per list. A filter you save on the host list is offered on
+the host list and nowhere else, because the columns it names only exist there.
+
+## Saving one
+
+1. Build the filter you want with the **Filter** panel, so the list is showing
+   what you are after.
+2. Click **Saved filters**.
+3. Type a name at the bottom, under *Save the current filter*, and click
+   **Save**.
+
+If nothing is filtered when you open it, that section says so instead — there
+is nothing to save.
+
+Saving under a name you have already used replaces that filter, which is how
+you adjust one: apply it, change the rules, and save it under the same name.
+
+## Applying one
+
+Open **Saved filters** and click **Apply** next to the one you want. The list
+filters immediately and a **chip** appears above it naming the filter that is
+in force.
+
+>[!note]
+>**A saved filter is never applied on its own.** Coming back to a list, or
+>signing in tomorrow, always gives you the whole list. This is the same rule
+>that keeps searches out of a saved layout — a list that came back short with
+>nothing on screen to explain it looks exactly like data that has gone missing.
+>See [[list-layout|Arranging Lists]].
+
+## Turning one off
+
+Click the **×** on the chip. That is the whole gesture — one click, from
+anywhere on the page, and the list is complete again.
+
+The chip is the only thing on screen that says a saved filter is running, so it
+goes away by itself if you clear the filter some other way, such as **Clear
+All** in the Filter panel.
+
+## Sharing
+
+A filter can be handed to other people. Open **Saved filters**, click **Share**
+next to one you own, and tick who should have it:
+
+| Share with | They see it | Good for |
+| --- | --- | --- |
+| **Users** | the people you tick, and nobody else | a filter you want one person to look over |
+| **User groups** | everyone in the group, including people added later | a team's standing view of a list |
+| **Roles** | everyone holding that role | "every helpdesk operator should have this" |
+
+You can tick any combination. Sharing does not give anything away: the people
+you share with can *apply* the filter, and only you can rename, re-share or
+delete it.
+
+You can only share with users, groups and roles you are already allowed to see.
+If you have no permission to view users, that column is simply not offered —
+you can still save filters for yourself.
+
+### Sharing with everybody
+
+**Share with everyone** makes a filter appear in every user's picker on that
+list. It is a separate permission (`savedfilter.create`) precisely because it
+changes what other people see, so the option is only shown to an account whose
+role grants it. See [[roles|Roles & Permissions]].
+
+A global filter has no owner, so it stays where it is if the person who created
+it is later deleted.
+
+### Which reason is shown
+
+The same filter can reach you several ways at once — a colleague ticks your
+name, *and* you are in the group they shared it with, *and* you hold the role.
+It is still one entry in your picker, labeled with the most specific reason you
+can see it:
+
+    yours → shared with you → shared with a group you are in →
+    shared with a role you hold → everyone
+
+So a filter your manager shared with you directly says *Shared with you by*
+them, even if it also went to your whole team.
+
+## Renaming and deleting
+
+**Rename** and **Delete** sit next to **Share**, on filters you own. Deleting
+one removes it for everybody it was shared with; nothing is left behind.
+
+You cannot delete a filter somebody shared with you — it is not yours, and for
+a filter shared to a role it was never a decision one person makes. If you do
+not want it, ignore it: it sits in a picker you only open on purpose, and
+nothing about it changes what your lists show until you apply it.
+
+## What is remembered, and what is not
+
+Whether the **Column search** row is showing is remembered against your
+account, so a list you like filtering from the headings opens that way. What
+you *typed* in those boxes is not remembered — the row comes back empty. The
+same distinction runs through all of this: FOG remembers how you like to work,
+and never a question you asked once.


### PR DESCRIPTION
Documents the saved-filters feature in
[fogproject#1490](https://github.com/FOGProject/fogproject/pull/1490).

New page **Saved Filters** (`docs/management/web/saved-filters.md`), indexed
under *Using the Interface*: saving the filter on screen, applying one from the
picker, the chip that names the running filter and clears it in one click, and
sharing to users / user groups / roles / everybody — with the precedence that
decides which reason is shown when the same filter reaches you several ways at
once.

Two existing pages needed a real edit rather than a mention:

- **Filtering Lists** said neither control is "remembered between visits". That
  was the whole truth before this feature and is now half of it — nothing is
  *applied* on its own, but a filter can be kept and applied deliberately. Also
  notes that whether the Column search row is *showing* is remembered while
  what was typed in it is not.
- **Arranging Lists** gains the search row in *What FOG remembers*, and its
  *deliberately does not remember* section now points at the saved-filter rule,
  which is the same rule from the other side: a filter is fine as long as you
  can see it is running and can turn it off in one click.

`scripts/check-anchors.mjs` reports only the two broken links that were already
there (`fog_on_a_mac#architecture`, `knowledge_base#storage_nodes`).
