### PR TITLE
Explain the asterisk on dates that predate the move to UTC

### DIFF
--- a/docs/management/web/display-timezone.md
+++ b/docs/management/web/display-timezone.md
@@ -21,21 +21,23 @@ that are easy to confuse, so it is worth being clear about both.
 ## The install's timezone
 
 `FOG_TZ_INFO`, under **FOG Configuration → FOG Settings**, is the timezone the
-server itself works in. It is the default everyone sees, and — importantly —
-**it is also the timezone FOG writes into the database**.
+server itself works in. It is the default everyone sees — the zone a user who
+has never chosen one of their own gets.
 
-That second part is what makes it more than a display setting. When FOG records
-that a host checked in, it writes the time as `FOG_TZ_INFO` reads it. So
-changing `FOG_TZ_INFO` does not re-present the times already recorded; it
-changes what those recorded times are taken to *mean*. A row written at 09:00
-when the setting said `America/Chicago` will be read as 09:00 `Europe/London`
-after the setting changes, which is a different moment.
+It used to be more than that. On older versions it was also the zone FOG wrote
+into the database, so changing it did not re-present the times already
+recorded, it changed what those recorded times were taken to *mean*. FOG now
+writes **UTC**, and `FOG_TZ_INFO` no longer has any bearing on what is stored.
 
-!!! warning "Changing FOG_TZ_INFO re-labels existing records"
-    Set it once, when the server is installed, and leave it alone. If you do
-    need to change it — the server physically moved, or it was wrong from the
-    start — be aware that every timestamp already in the database will be read
-    in the new zone. Nothing is rewritten, and nothing warns you.
+!!! warning "Changing FOG_TZ_INFO still re-labels the older records"
+    Dates written *before* your server moved to UTC were written in whichever
+    zone `FOG_TZ_INFO` named at the time, and that is still how they are read.
+    Changing the setting therefore changes how those older dates are
+    interpreted, though not how anything written since is. Nothing is
+    rewritten, and nothing warns you.
+
+    Those older dates are marked on screen — see
+    [[unadjusted-timestamps|Timestamps Before the UTC Change]].
 
     If you only want people to *see* a different timezone, that is the per-user
     setting below, and it is the one you almost certainly want.
@@ -66,10 +68,12 @@ Every signed-in user can set this, including an account with no role assigned.
 
 ### What it does not cover
 
-**The REST API.** Dates from `/api/…` are always in the server's timezone,
-whichever user's token was used. A script needs one stable answer, not one that
-changes depending on who is running it — and the values carry no timezone
-marker to tell the difference.
+**The REST API.** Dates from `/api/…` come back exactly as stored — **UTC** —
+whichever user's token was used, and with no timezone marker on the value. A
+script needs one stable answer, not one that changes depending on who is
+running it. Rows written before this server moved to UTC are the exception the
+API cannot signal; see
+[[unadjusted-timestamps|Timestamps Before the UTC Change]].
 
 **Scheduled tasks.** A task set to run at 02:00 runs at 02:00 on the server. The
 schedule is the server's clock, not the viewer's, and changing your display
@@ -77,10 +81,12 @@ timezone does not move it.
 
 ## What is stored
 
-FOG stores times in the server's timezone rather than in UTC. That is a known
-limitation and the reason the warning above exists. Moving storage to UTC is a
-one-way conversion of every date in the database, so it is being done as its own
-release rather than folded into the display setting.
+FOG stores times in **UTC**. Your upgrade recorded the instant it started doing
+so, and it did not convert anything that was already there — a conversion is
+one-way and there was no reliable way to know which clock had written any given
+old row. So dates on either side of that instant are read differently, and the
+older ones are marked where they appear:
+[[unadjusted-timestamps|Timestamps Before the UTC Change]].
 
-The per-user setting above works today regardless, and nothing about it is
-affected by that later change.
+The per-user setting above is unaffected either way. It has only ever decided
+what you are shown.

--- a/docs/management/web/index.md
+++ b/docs/management/web/index.md
@@ -21,6 +21,7 @@ Documentation related to how to use the web management ui.
 - [[list-layout|Arranging Lists]]
 - [[saved-filters|Saved Filters]]
 - [[display-timezone|Display Timezone]]
+- [[unadjusted-timestamps|Timestamps Before the UTC Change]]
 
 **Access & Security**
 

--- a/docs/management/web/unadjusted-timestamps.md
+++ b/docs/management/web/unadjusted-timestamps.md
@@ -1,0 +1,97 @@
+---
+title: Timestamps Before the UTC Change
+aliases:
+    - Unadjusted Timestamps
+    - UTC Change
+    - Old Timestamps
+description: what the asterisk on an older date means, why FOG cannot correct those dates, and what still works normally
+context_id: unadjusted-timestamps
+tags:
+    - management
+    - web-management
+    - troubleshooting
+---
+
+# Timestamps Before the UTC Change
+
+FOG records every date and time in **UTC**, and shows it to you in your own
+timezone — see [[display-timezone|Display Timezone]]. Dates recorded *before*
+your server made that change are marked with an asterisk, and this page
+explains what the mark means.
+
+On a list, hovering the asterisk gives you:
+
+> recorded before this server moved to UTC; written in `America/Chicago`
+
+naming whichever timezone your own server was using at the time. On an edit or
+detail page the asterisk sits after the date and the same sentence appears once
+at the bottom of the panel, rather than on every line.
+
+## What it means
+
+The date is real and it is very probably exactly what you think it is. What FOG
+cannot promise is the *zone* it was written in, and therefore it cannot
+confidently convert it into yours.
+
+That is the whole of it. An unadjusted date is not corrupt, not missing, and
+not an error. It is a date FOG is declining to guess about.
+
+## Why FOG cannot just fix them
+
+The honest answer is that the information needed to fix them was never
+recorded, and it was not one single thing that went unrecorded:
+
+- **Older FOG versions stored the server's local time**, with no note of which
+  zone that was. Changing the **FOG_TZ_INFO** setting changed how every
+  existing date was read, without changing any of them.
+- **Not every date came from the same clock.** Some were written by FOG itself,
+  some by the database server, and some by the fog-client on the machine that
+  checked in. On an install where those are in different timezones they
+  disagree — in the same table, sometimes in the same row.
+- **Daylight saving makes one hour a year ambiguous** even when the zone is
+  known.
+
+So a bulk correction would have to assume one answer for values that had
+several. Where it guessed wrong it would move a date that was already right,
+and it would do it silently and permanently: once a stored time has been
+shifted there is nothing left to say what it was. Leaving the value alone and
+telling you it is unadjusted is the only version of this that can be undone,
+because nothing was done.
+
+## What still works normally
+
+- **Sorting** an older date column. Within the pre-change era the dates are
+  consistent with each other, so their order is right.
+- **Filtering** on them, for the same reason.
+- **Reading them.** If your server has always been in one timezone — which is
+  the ordinary case — an unadjusted date is simply that timezone's local time,
+  and the tooltip names it.
+
+## What to be careful about
+
+- **Comparing an unadjusted date with an adjusted one** across the change, if
+  the difference matters to within a few hours. Around the moment your server
+  switched, FOG marks a window of dates unadjusted deliberately rather than
+  claiming a precision it does not have.
+- **Exports and API clients.** The asterisk is added to the page, not to the
+  value. A **CSV or Excel export** carries the plain date with no marker, and
+  the **REST API** likewise sends the plain date and says nothing about which
+  era it belongs to. A script that treats every timestamp as UTC will be out by
+  your old timezone's offset for the older rows, and nothing in the data warns
+  it. Where that matters, the screen is currently the only place that tells
+  you.
+
+## When the markers go away
+
+They do not, and that is on purpose. They are decided per value rather than by
+a setting, so they disappear only as the rows they belong to age out — through
+normal use, or through the retention policies on the log tables. There is
+nothing to turn off and nothing to run.
+
+## Where the record lives
+
+The changeover instant, and the timezone your server was using at the time, are
+recorded once during the upgrade and are not editable — not in **FOG
+Configuration**, not through the API. That is deliberate: it is the single
+reference point that decides how every older date is read, so it is stored
+where an accidental edit cannot reach it.


### PR DESCRIPTION
Companion to fogproject#1508, which put the marker on screen.

### New page — `management/web/unadjusted-timestamps.md`

What the asterisk on an older date means, and the part that actually needs
saying: the date is real, it is the **zone** FOG cannot promise, so it declines
to guess rather than shifting the value. Also why a bulk correction would be
worse (up to five clocks wrote those columns, and a conversion is one-way), and
what is unaffected — sorting and filtering are both fine, because within the
pre-change era the values are consistent with each other.

### `display-timezone.md` — two claims that were true when written

- **`FOG_TZ_INFO` is no longer the zone FOG writes into the database.** After
  the boundary row exists, `storageTimeZone()` returns UTC and the setting only
  decides what people are *shown*. The warning about changing it stays, narrowed
  to what it still re-labels: the older rows, which are still read in whatever
  it names.
- **The REST API no longer answers in the server's timezone.** `displayDates()`
  returns rows untouched for an API request, so `/api/…` sends the stored value
  — UTC for anything recent, the old local time for anything older, with nothing
  on the value to tell them apart. That is the gap worth being explicit about,
  because a script has no marker to read where the UI has one.

`npm run docs:build` completes clean (120 files, no broken wikilinks, no
duplicate `context_id`).