### PR TITLE
A plugin is laid out like core: src/<Bucket>/<Class>.php

### DIFF
--- a/docs/1.6/kb/reference/csv_import_export.md
+++ b/docs/1.6/kb/reference/csv_import_export.md
@@ -404,7 +404,7 @@ import and export, without patching core:
   primed simply falls back to the per-row `get` path, so listening is purely an
   optimization.
 
-The Location plugin (`addlocationimport.hook.php`) is the reference
+The Location plugin (`AddLocationImport`, in its `src/Hooks/`) is the reference
 implementation, registering a single-valued `location` type for hosts and
 listening for `EXPORT_ASSOCIATIONS_PRIME` to batch that label. The retired
 Site plugin used to follow the same pattern for a host's `site`; sites moved

--- a/docs/1.6/management/web/reports.md
+++ b/docs/1.6/management/web/reports.md
@@ -260,10 +260,16 @@ The report appears in the left-hand menu straight away.
 
 ## Writing a report
 
-A report is one PHP file in `packages/web/lib/reports/`, named after the
-class it declares. `fleet_report.report.php` declares `Fleet_Report`; the
-menu entry, the class name and the file name all have to agree, because
-FOG resolves the class from the file name.
+A report is one PHP file in `packages/web/src/Reports/`, named exactly
+after the class it declares. `Fleet_Report.php` declares `Fleet_Report`;
+the menu entry, the class name and the file name all have to agree,
+because FOG resolves the class from the file's path.
+
+**Keep the underscores.** The menu label, the base64 `f` parameter in the
+report's URL and the permission node are all derived from the file name
+with underscores turned into spaces and the whole thing lowercased — so
+`Fleet_Report` is "fleet report" in all three. Renaming it `FleetReport`
+moves the report to a different URL under a different permission node.
 
 A report needs two methods:
 
@@ -279,6 +285,8 @@ A minimal list report:
 <?php
 
 use FOG\Router\Route;
+
+namespace FOG\Reports;
 
 class Example_Report extends \FOG\Pages\ReportManagement
 {
@@ -311,20 +319,19 @@ class Example_Report extends \FOG\Pages\ReportManagement
 }
 ```
 
-A standalone report file like this one stays in the **global namespace**, and
-extends core by its fully qualified name. FOG finds it by its filename, so the
-class it declares has to answer to that bare name — which a global-namespace
-file does for free.
+A report is found by its **path**, not by its filename, so where it sits
+and what it declares are the same fact written twice. A core report at
+`packages/web/src/Reports/Example_Report.php` declares `namespace
+FOG\Reports;`.
 
-A report shipped **inside a plugin** is different: it lives in the plugin's own
-`reports/` directory and declares that plugin's namespace, so
-`<plugin>/reports/example_report.report.php` declares `namespace
-FOG\Plugins\<Plugin>;`. Nothing else about it changes, and it needs no
-`class_alias()` either — see the plugin development guide.
+A report shipped **inside a plugin** is the same shape with a different
+root: `<plugin>/src/Reports/Example_Report.php` declares `namespace
+FOG\Plugins\<Segment>\Reports;`. Nothing else about it changes, and it
+needs no `class_alias()` — see the plugin development guide.
 
 The table is wired up in JavaScript, which for a plugin lives in the
-plugin's own `js/` directory and for a single uploaded file can be
-echoed inline from `file()`:
+plugin's own `js/` directory and for a standalone report can be echoed
+inline from `file()`:
 
 ``` javascript
 $('#examplereport-table').registerReportTable(

--- a/docs/development/plugin-development.md
+++ b/docs/development/plugin-development.md
@@ -83,24 +83,20 @@ The running example, `helloworld`, manages a trivial entity with a `name` and a
 - **Boot chain.** Every entry point loads `commons/base.inc.php` →
   `commons/init.php` → `LoadGlobals`, which sets the shared singletons
   (`FOGBase::$DB`, `$HookManager`, `$EventManager`, `$currentUser`).
-- **Autoloader.** `Initiator` scans `BASEPATH` recursively, builds a
-  lowercased-basename → path map of every
-  `*.{class,page,hook,event,report,task}.php` file, and registers that ahead of
-  PHP's default `spl_autoload` (which stays registered as a fallback). Lookup
-  **lowercases the class name** to find the file. So:
+- **Autoloader.** `Initiator` turns a class name into a path and loads that
+  file. Core's `FOG\Items\Host` is `packages/web/src/Items/Host.php`; your
+  `FOG\Plugins\HelloWorld\Items\HelloWorld` is
+  `<root>/helloworld/src/Items/HelloWorld.php`. Nothing is scanned, nothing is
+  guessed and there is no `spl_autoload` fallback — the path **is** the name,
+  which is why it has to be exact:
 
-  > **The filename must be `strtolower(ClassName)` + the suffix.**
-  > `class HelloWorldManagement` ⇒ `helloworldmanagement.page.php`.
-  > `class AddHelloWorldJS` ⇒ `addhelloworldjs.hook.php`.
+  > **`<plugin>/src/<Bucket>/<Class>.php` declares
+  > `FOG\Plugins\<Segment>\<Bucket>\<Class>`.** File name equals class name,
+  > character for character; `strtolower(<Segment>)` equals the plugin's
+  > directory name.
 
-  (Class names in code are PascalCase; the files on disk are all-lowercase.)
-
-  **That rule is about YOUR files.** Core is not found this way any more — it
-  lives under `packages/web/src/` and is reached by its fully qualified name.
-  See [§7a](#7a-class-names-and-the-fog-namespace), which is the one thing to
-  read before writing any class.
-
-  The filename rule is unchanged and still applies to every file you ship.
+  That is the same PSR-4 arrangement core uses on itself, and it is the one
+  thing to get right before writing any class — §7a is the long version.
 - **Routing.** The whole UI is driven by `?node=<x>&sub=<y>&id=<n>`. `node` maps
   to a page class (`helloworld` → `HelloWorldManagement`, matched by its
   `public $node = 'helloworld'`), and `sub` maps to a method on it
@@ -120,25 +116,51 @@ The running example, `helloworld`, manages a trivial entity with a `name` and a
 ```
 <root>/helloworld/                  # <root> = lib/plugins (bundled) or /opt/fog/plugins
 ├── config/
-│   └── plugin.config.php          # the manifest ($fog_plugin[...])
-├── class/
-│   ├── helloworld.class.php        # HelloWorld         (model, FOGController)
-│   └── helloworldmanager.class.php # HelloWorldManager  (manager + schema())
-├── pages/
-│   └── helloworldmanagement.page.php  # HelloWorldManagement (FOGPage)
-├── hooks/
-│   ├── addhelloworldmenuitem.hook.php # menu entry + search/objects
-│   ├── addhelloworldjs.hook.php       # JS injection
-│   └── addhelloworldapi.hook.php      # REST API exposure
-└── js/
-    ├── fog.helloworld.list.js
-    ├── fog.helloworld.add.js
-    └── fog.helloworld.edit.js
+│   └── plugin.config.php            # the manifest ($fog_plugin[...])
+├── src/                             # ALL PHP, laid out exactly like core's src/
+│   ├── Items/
+│   │   └── HelloWorld.php           # …\Items\HelloWorld      (model, FOGController)
+│   ├── Managers/
+│   │   └── HelloWorldManager.php    # …\Managers\…          (manager + schema())
+│   ├── Pages/
+│   │   └── HelloWorldManagement.php # …\Pages\…             (FOGPage)
+│   ├── Hooks/
+│   │   ├── AddHelloWorldMenuItem.php  # menu entry + search/objects
+│   │   ├── AddHelloWorldJS.php        # JS injection
+│   │   └── AddHelloWorldAPI.php       # REST API exposure
+│   └── Tasks/
+│       └── HelloWorldHeartbeat.php  # …\Tasks\…             (PluginTask)     
+├── js/
+│   ├── fog.helloworld.list.js
+│   ├── fog.helloworld.add.js
+│   └── fog.helloworld.edit.js
+└── vendor/                          # optional — Composer dependencies, see 7b
+    └── autoload.php
 ```
+
+Everything under `src/` is `FOG\Plugins\HelloWorld\<Bucket>\<Class>`. Five
+bucket names are **enumerated** — core lists the directory to find things to
+register, so a class only takes effect if it is in the right one:
+
+| Bucket | Holds | What core does with it |
+|---|---|---|
+| `Pages/` | `FOGPage` subclasses | routes `?node=<x>` to them |
+| `Hooks/` | `Hook` subclasses | constructs them so they can register callbacks |
+| `Events/` | `Event` subclasses | constructs them |
+| `Reports/` | report pages | lists them in the Reports menu — see §9a |
+| `Tasks/` | `PluginTask` subclasses | runs them on their interval — see ADR 0010 |
+
+Every other bucket is **autoload-only**: `Items/`, `Managers/`, `Util/`, or
+anything else you invent. Nothing enumerates them, so the name is yours to
+choose — it just has to match the namespace. The convention above is core's,
+and following it means someone who knows core knows your plugin.
 
 The directory name **is** the plugin's machine name and routing `node`. Keep it
 lowercase and use it consistently (`$fog_plugin['name']`, each hook's
-`public $node`, the page's `public $node`).
+`public $node`, the page's `public $node`). The namespace segment is that same
+name with whatever casing reads well — `helloworld/` → `FOG\Plugins\HelloWorld`,
+`ldap/` → `FOG\Plugins\LDAP` — and the only rule is that lowercasing it gets
+you back to the directory name.
 
 ---
 
@@ -197,10 +219,10 @@ existed keeps working untouched.
 > named, and routing goes through the `node` → page-class mapping. Both are
 > gone; if your manifest still sets them they are simply ignored.
 
-### 4.2 Model — `class/helloworld.class.php`
+### 4.2 Model — `src/Items/HelloWorld.php`
 
 ```php
-namespace FOG\Plugins\Helloworld;
+namespace FOG\Plugins\HelloWorld\Items;
 
 class HelloWorld extends \FOG\Base\FOGController
 {
@@ -218,13 +240,13 @@ That's the entire ORM contract. `$databaseFields` maps friendly names (used in
 code and in the API) to real column names. `$databaseFieldsRequired` is enforced
 on `save()`.
 
-### 4.3 Manager + migrations — `class/helloworldmanager.class.php`
+### 4.3 Manager + migrations — `src/Managers/HelloWorldManager.php`
 
 The manager owns table creation and **schema evolution**. This is the most
 important part to get right, so it gets its own section (§5). The shape:
 
 ```php
-namespace FOG\Plugins\Helloworld;
+namespace FOG\Plugins\HelloWorld\Managers;
 
 class HelloWorldManager extends \FOG\Base\FOGManagerController
 {
@@ -251,7 +273,7 @@ class HelloWorldManager extends \FOG\Base\FOGManagerController
 }
 ```
 
-### 4.4 Page — `pages/helloworldmanagement.page.php`
+### 4.4 Page — `src/Pages/HelloWorldManagement.php`
 
 The page extends `\FOG\Base\FOGPage`, declares `public $node = 'helloworld'`, and sets the
 list columns in its constructor:
@@ -304,8 +326,8 @@ public function addPost()
         $msg  = json_encode(['msg' => _('…'), 'title' => _('…')]);
     } catch (Exception $e) {
         $code = $serverFault
-            ? \FOG\Router\HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR   // 500 = our fault
-            : \FOG\Router\HTTPResponseCodes::HTTP_BAD_REQUEST;            // 400 = bad input
+            ? \FOG\Router\HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR
+            : \FOG\Router\HTTPResponseCodes::HTTP_BAD_REQUEST;
         $msg  = json_encode(['error' => $e->getMessage(), 'title' => _('…')]);
     }
     http_response_code($code);
@@ -323,7 +345,7 @@ The **edit** page uses tabs. `edit()` builds `$tabData` and calls
 (`helloworldGeneral()`), and `editPost()` dispatches on the global `$tab` to the
 matching `*GeneralPost()` that mutates `$this->obj` before the shared `save()`.
 
-### 4.5 Hooks — `hooks/*.hook.php`
+### 4.5 Hooks — `src/Hooks/*.php`
 
 Each hook is a small class extending `\FOG\Base\Hook`, with `public $node`, that registers
 callbacks **in its constructor**. Use `registerInstalled()` — it applies the
@@ -426,8 +448,7 @@ Shared helpers you'll use: `Common.node`, `Common.id`, `Common.search`,
 FOG has **no automatic per-column migration**. `Schema::createTable()` emits
 `CREATE TABLE IF NOT EXISTS`, which does nothing on a table that already
 exists — so simply adding a column to `createSql()` will **not** reach existing
-installs. Use the **`schema()` contract** instead — covered in depth in
-[[plugin-schema-migrations|Plugin Schema Migrations]].
+installs. Use the **`schema()` contract** instead.
 
 **`schema()` returns an ordered, append-only list of steps.** Each step is a SQL
 string (or a closure returning SQL). On install/upgrade the framework
@@ -461,7 +482,14 @@ safe. A closure step may return a string to signal a hard error and stop.
 
 Seed data (e.g. default `globalSettings` rows) is just another step — return the
 `INSERT` SQL, or a closure for anything that needs runtime values (see
-`accesscontrolmanager`'s `schema()` for the closure pattern).
+`persistentgroupsmanager`'s `schema()` for the closure pattern).
+
+**Retiring a table works the same way: append a `DROP`, never delete the
+`CREATE`.** Deleting step 3 renumbers everything after it, so an install that
+had applied four steps now believes it has applied a different four. The same
+goes for *editing* a step in place — an install that already passed it never
+sees the change, which is invisible until somebody upgrades from an older
+version. The `ldap` plugin's steps 10–16 exist to repair exactly that.
 
 > **Legacy note.** Older plugins implement a destructive `install()` that calls
 > `uninstall()` (drop) then recreates. New plugins should implement `schema()`
@@ -511,40 +539,63 @@ Global configuration lives in the `globalSettings` table.
 
 ---
 
-## 7a. Class names and the `FOG\` namespace
+## 7a. Where a class lives and what it is called
 
-**Read this before you write a class.** Core moved to PSR-4 under
-`packages/web/src/` and is now reachable **only by its fully qualified name**.
-Bare `FOGController`, `Host`, `Hook` no longer resolve to anything. Plugins
-have since followed core: every plugin class now declares its own namespace
-too.
+**Read this before you write a class.** A plugin is laid out exactly like core
+and discovered by exactly the mechanism core uses on itself: PSR-4 under
+`src/`, bucketed by kind, no filename suffixes and no scanning. Core is
+reachable **only by its fully qualified name** — bare `FOGController`, `Host`,
+`Hook` resolve to nothing — and so is your own code.
 
 ### The rule
 
-**Declare `namespace FOG\Plugins\<Ucfirst-plugin-directory>;` at the top of
-every file, and reference core by its FQCN with a leading backslash.** The
-namespace segment is `ucfirst()` of the plugin's directory name — mechanical,
-no lookup table, no exceptions: `helloworld/` → `FOG\Plugins\Helloworld`,
-`ldap/` → `FOG\Plugins\Ldap`. The **subdirectory is not part of it** — every
-class in a plugin, whatever mix of `class/`, `pages/`, `hooks/`, `events/`,
-`reports/` and `tasks/` it ships, shares that one flat namespace.
-(`FOGController::getManager()` derives a model's manager class as
-`qualify(shortName($this) . 'Manager')`, so a model and its manager have to
-resolve in the same namespace or the derivation breaks.)
+**`<plugin>/src/<Bucket>/<Class>.php` declares
+`FOG\Plugins\<Segment>\<Bucket>\<Class>`.** Three halves, all load-bearing:
+
+1. **File name equals class name**, character for character. `HelloWorld.php`
+   declares `HelloWorld` — not `helloworld.php`, not `HelloWorld.class.php`.
+2. **Directory path equals namespace tail.** A file in `src/Managers/` declares
+   `…\Managers\…`. Move the file, change the namespace.
+3. **`strtolower(<Segment>)` equals the plugin's directory name.** The segment
+   carries readable casing — `helloworld/` → `FOG\Plugins\HelloWorld`, `ldap/`
+   → `FOG\Plugins\LDAP` — but lowercasing it must land back on the directory,
+   because the directory name is also `plugins.pName`, the `?node=` value, the
+   `<node>.view` permission string and your `js/` URL.
+
+Both 1 and 3 are checked by a test in fog-plugins' own suite, so a mistake is a
+red build rather than a page that silently never appears.
 
 ```php
-namespace FOG\Plugins\Helloworld;
+// src/Items/HelloWorld.php
+namespace FOG\Plugins\HelloWorld\Items;
 
-class HelloWorld           extends \FOG\Base\FOGController {}
-class HelloWorldManager    extends \FOG\Base\FOGManagerController {}
-class HelloWorldManagement extends \FOG\Base\FOGPage {}
-class AddHelloWorldMenuItem extends \FOG\Base\Hook {}
-class HelloWorldHeartbeat  extends \FOG\Base\PluginTask {}
+class HelloWorld extends \FOG\Base\FOGController {}
 ```
 
-This is what every bundled plugin does now — copying one gets you the house
-style. The names you reference on core stay **bucketed**, matching the
-directory they live in under `src/` — there is no flat `FOG\Host`:
+```php
+// src/Managers/HelloWorldManager.php
+namespace FOG\Plugins\HelloWorld\Managers;
+
+class HelloWorldManager extends \FOG\Base\FOGManagerController {}
+```
+
+```php
+// src/Pages/HelloWorldManagement.php
+namespace FOG\Plugins\HelloWorld\Pages;
+
+class HelloWorldManagement extends \FOG\Base\FOGPage {}
+```
+
+A model and its manager sit in **different** buckets and that is fine:
+`FOGController::getManager()` derives the manager as
+`qualify(shortName($this) . 'Manager')` — a *short* name, resolved through the
+same map that answers `getClass('HelloWorld')` — so it finds
+`…\Managers\HelloWorldManager` from `…\Items\HelloWorld` without either
+class naming the other.
+
+This is what every bundled plugin does — copying one gets you the house
+style. The names you reference on core are bucketed the same way, matching the
+directory they live in under `src/`; there is no flat `FOG\Host`:
 
 | Bare name you used to write | Now |
 |---|---|
@@ -565,7 +616,7 @@ A `use` import works too, and is the better shape if you name a class many
 times — it sits below your own `namespace` declaration, not instead of it:
 
 ```php
-namespace FOG\Plugins\Helloworld;
+namespace FOG\Plugins\HelloWorld\Items;
 
 use FOG\Base\FOGController;
 
@@ -575,49 +626,53 @@ class HelloWorld extends FOGController {}
 Both forms are correct. The FQCN form is what most of the bundled plugins use,
 so copying one of them gets you the house style.
 
-### Discovery still works by filename
+### Discovery reads bucket directories, not filenames
 
-File layout does not change, and neither does the rule about it: a **page,
-hook, event, report or task** is still found by its filename, and the class
-it declares must still be named after that file — `class
-HelloWorldManagement` in `helloworldmanagement.page.php`, same as always. The
-`.page.php` / `.hook.php` / `.event.php` / `.report.php` / `.task.php` suffix
-is how the file gets found at all, so nothing moved and nothing was renamed.
-This is namespacing, not a move to PSR-4 autoloading.
+There are no `.page.php` / `.hook.php` / `.event.php` / `.report.php` /
+`.task.php` suffixes any more, and nothing walks your plugin looking for them.
+A page is a page because it is in `src/Pages/`; core lists that directory —
+`FOGBase::pluginitems('Pages')`, the exact counterpart of `coreitems('Pages')`
+— and derives the class name from the path. Same for the other four enumerated
+buckets. Anything else you ship is simply autoloaded when something names it.
 
-What changed is what core does once it has found the bare name. It now reads
-each plugin file's actual `namespace` declaration and maps the plugin's bare
-short name to its namespaced FQCN, so discovery, `getClass('HelloWorld')`,
-`FOGController::getManager()`, `FOGPage::$childClass`, `Route::_newEntity()`
-and `Authorization`'s object-scope lookup all keep resolving the class from
-the bare spelling you've always used. You never have to spell the namespace
-out anywhere except the `namespace` declaration itself.
+Bare spellings still work wherever **core** does the resolving:
+`getClass('HelloWorld')`, `FOGController::getManager()`, `FOGPage::$childClass`,
+`Route::_newEntity()` and `Authorization`'s object-scope lookup all take a
+short name. Core builds that map from the file *paths* now rather than by
+reading every plugin file, so you never spell the namespace out anywhere except
+the `namespace` declaration itself.
 
-**`class_alias()` is no longer needed, and should not be used.** It used to
-be the workaround for exactly this gap: discovery derived a bare class name
-from `basename($file)`, so a plugin that declared its own namespace had to
-alias itself back into the global one or its page/hook/event/report silently
-never registered. That gap is closed at the source now — core builds the
-bare-name → FQCN map from the declaration itself — so there is nothing left
-for an alias to do, and shipping one just adds a second, redundant name for
-the same class.
+**`class_alias()` is not needed and should not be used.** It was the workaround
+for a gap that no longer exists — discovery once derived a bare class name from
+`basename($file)`, so a namespaced plugin had to alias itself back into the
+global namespace or never register. Shipping one now just adds a second,
+redundant name for the same class.
 
-### Backwards compatible
+### A plugin on the pre-1.6 layout is refused, out loud
 
-A plugin that declares **no** namespace keeps working exactly as it did
-before this change. Core reads each plugin file's actual `namespace`
-declaration rather than assuming every plugin has one now — an unconverted
-third-party plugin produces no entry in the map and keeps resolving by its
-bare name, in the global namespace, same as always. Nothing here requires a
-third-party author to do anything before their plugin keeps loading.
+This replaced the old `class/ pages/ hooks/ …` layout, and it is not
+backwards compatible — that was decided deliberately (see
+[ADR 0035](https://github.com/FOGProject/fogproject/blob/working-1.6/docs/adr/0035-a-plugin-is-laid-out-like-core.md)). One consistent way to
+write FOG code was judged worth breaking third-party plugins written against
+the old shape.
+
+The failure is at least a loud one. A plugin directory with no `src/` but with
+a `class/` gets one line in the log naming itself and this guide, rather than
+being silently absent the way a missing class used to be. **Porting is a move
+and a namespace line**, per the table in §11b — no logic changes.
 
 ### Two plugins, one class name, no collision
 
-Because the namespace segment comes from the plugin's own directory, two
-plugins can now each ship a class called `Settings` without one shadowing the
-other. Before this, every plugin class shared one global basename keyspace —
-whichever plugin's `Settings` loaded first silently won, and the other's was
-unreachable.
+Two plugins can each ship a class called `Settings` without one shadowing the
+other, and so can a plugin and core: the FQCNs differ, so the paths differ, so
+both files load. This is now *structural* rather than a rule anyone enforces —
+`FOG\Plugins\Alpha\Items\Settings` and `FOG\Items\Settings` cannot resolve
+to the same file, because each name derives its own.
+
+The one keyspace still shared is the **short** name, used by `getClass()` and
+friends. Core wins it: a plugin class whose short name matches a core class is
+reachable only by its FQCN. Pick a distinctive name and the question never
+arises.
 
 ### The one place a bare name still bites
 
@@ -628,12 +683,12 @@ resolved exactly as written, with no such mapping behind it. So
 `self::getClass('LDAPGroupManager')` inside a plugin is fine — core resolves
 it — but a raw `new $someString` or `is_subclass_of($x, 'SomeClass')` naming
 a bare plugin class in your own code is not. Spell those fully qualified
-(`\FOG\Plugins\Ldap\LDAPGroupManager`) or route them through
+(`\FOG\Plugins\LDAP\Managers\LDAPGroupManager`) or route them through
 `self::getClass()` instead.
 
 ### What the failure looks like
 
-A bare core name does not fail quietly. `Initiator::autoload()` recognises it
+A bare core name does not fail quietly. `Initiator::autoload()` recognizes it
 and writes one line before giving up:
 
 ```
@@ -661,7 +716,7 @@ building a column name or an array key from it, putting it in a filename or a
 log line:
 
 ```php
-// Wrong: 'FOG\Plugins\Helloworld\HelloWorld', and the comparison silently fails.
+// Wrong: 'FOG\Plugins\HelloWorld\Items\HelloWorld' -- comparison silently fails.
 if (get_class($obj) === 'HelloWorld') { /* ... */ }
 
 // Right: 'HelloWorld', namespaced or not.
@@ -677,10 +732,17 @@ ADR 0013 originally kept a `class_alias()` in every core file re-exporting it
 into the global namespace, and called that alias the 1.6 plugin ABI. **All 202
 were deleted before 1.6.0 shipped and the ADR is amended accordingly** — there
 was no released 1.6 for the promise to have been made to, and carrying the shim
-through a major version bought compatibility with nothing. Plugins have now
-followed the same path: the `class_alias()` a plugin author would once have
-had to write to stay reachable is gone too, for the same reason — core
-resolves the namespaced class directly instead of leaning on a shim to do it.
+through a major version bought compatibility with nothing.
+
+Plugins then followed in two steps, both before 1.6.0. First the namespace:
+every plugin class moved into `FOG\Plugins\<Plugin>`, discovered by reading
+each file's `namespace` declaration, with the files left where they were. That
+half-migration is what this section used to describe, and it was the confusing
+state — the namespace said `FOG\Plugins\…` while the file said
+`class/ldapmanager.class.php`, and core carried a whole scan-and-cache
+mechanism to reconcile the two. Then the layout followed the namespace
+(ADR 0035), which deleted that mechanism rather than replacing it: the path is
+derived from the name, so there is nothing left to scan, read or cache.
 
 ## 7b. Composer dependencies
 
@@ -904,6 +966,28 @@ just-provisioned account has no id before then.
 
   Prefer `always` unless you can name the consumer that reads the field back.
 
+- **Columns only your code should write:** `Route::edit()` and `Route::create()`
+  copy a JSON body straight into your model's `databaseFields`, so by default
+  anyone who can reach the API can set any column you declare. Declare the ones
+  your server-side code maintains — a token you issue, a counter, a timestamp
+  you stamp — through `API_SERVER_OWNED_FIELDS`:
+
+  ```php
+  public function declareServerOwnedFields($arguments)
+  {
+      $arguments['fields'][$this->node][] = 'apiToken';
+  }
+  ```
+
+  A request that tries to **change** one gets a 400. A request that carries the
+  same value it already had is let through, so a client that GETs your object
+  and PUTs the whole thing back keeps working — don't "fix" that by rejecting
+  the field's mere presence.
+
+  This is a different question from `API_SENSITIVE_FIELDS`, which is about what
+  leaves the server. A field can be one, the other, or both: `host.ADPass` is
+  sensitive but genuinely settable over the API, so it is only in the first list.
+
 ---
 
 ## 8a. Object scope — narrowing *which* objects a user reaches
@@ -989,6 +1073,7 @@ fire for page routes too: [ADR 0006](https://github.com/FOGProject/fogproject/bl
 |---|---|
 | `MAIN_MENU_DATA` | add the top-level sidebar entry (`hook_main[node] = [label, icon]`) |
 | `SUB_MENULINK_DATA` | add sub-links (Export/Import/…) under the node |
+| `REPORT_TITLE_DATA` | name your report in the Reports menu — see §9a |
 | `SEARCH_PAGES` | make the node searchable |
 | `PAGES_WITH_OBJECTS` | enable the object (edit/delete) flow for the node |
 | `PAGE_JS_FILES` | inject JS files for the current page |
@@ -1004,6 +1089,74 @@ fire for page routes too: [ADR 0006](https://github.com/FOGProject/fogproject/bl
 Fire your own events with `&`-by-reference args so listeners can mutate them
 (see the example's `HELLOWORLD_*` events).
 
+### 9a. Naming your report
+
+A file at `<plugin>/src/Reports/<Class>.php` becomes an entry in the Reports
+menu automatically. **Report class names keep their underscores** — `OU_Report`,
+`LDAP_Report` — exactly as core names its own (`src/Reports/Fleet_Report.php`),
+because the menu key, the base64 `f` URL parameter and the permission node are
+all derived from the file name with underscores turned into spaces and the whole
+thing lowercased. Renaming `OU_Report` to `OuReport` would move the report to a
+different URL under a different permission node.
+
+The label it gets, if you do nothing, is that same derived name title-cased —
+so `OU_Report.php` appears as "Ou Report" while the page it opens is headed
+"Export OUs". Two names for one screen.
+
+Name it once, in a hook, and both agree:
+
+```php
+$this->registerInstalled([
+    ['REPORT_TITLE_DATA', 'reportTitle'],
+]);
+
+public function reportTitle($arguments)
+{
+    // Keyed by the FILE name with underscores as spaces, lower case --
+    // the same key the menu and the base64 `f` parameter use.
+    $arguments['titles']['ou report'] = _('Export OUs');
+}
+```
+
+Then let the report itself read the same map, so the heading cannot drift
+away from the menu entry again:
+
+```php
+public function file()
+{
+    $this->title = self::reportTitle();   // derived from the class name
+    ...
+}
+```
+
+The event fires **once per request**, not once per label: the map is memoized
+after the first build. A listener registered later in the request does not
+appear.
+
+**The rows, and the export.** Put your query in `reportRows()`, returning the
+DataTables envelope, and let `ReportManagement::getList()` emit it:
+
+```php
+protected function reportRows()
+{
+    \FOG\Router\Route::listem('ou');
+    return (array) json_decode(\FOG\Router\Route::getData(), true);
+}
+```
+
+That is what the "CSV (All)" toolbar button serves — the DataTables export
+buttons can only see the rows the browser is currently holding, which on a
+serverSide table is one page. Ask for the button with `fullExport` once
+`reportRows()` is in place:
+
+```js
+$('#ou-report-table').registerReportTable(columns, {fullExport: true});
+```
+
+A report that still overrides `getList()` must NOT pass `fullExport`: the
+export serves `reportRows()`, so it would hand back an empty file rather than
+an error.
+
 ---
 
 ## 10. Gotchas (learned the hard way)
@@ -1013,23 +1166,36 @@ Fire your own events with `&`-by-reference args so listeners can mutate them
 - **Core is FQCN-only.** `extends FOGController` is a fatal error, not a
   deprecation — see §7a. The autoloader logs one line naming the class and the
   name to use before the request dies, so check the error log first.
-- **Every plugin class declares `namespace FOG\Plugins\<Ucfirst-directory>;`.**
-  One flat namespace per plugin, whatever subdirectory the file lives in — a
-  model and its manager must resolve in the same one. No `class_alias()`
-  needed, not even for a page/hook/event/report/task: core maps the bare name
-  to the namespaced FQCN for you. §7a has the shape. A plugin with no
-  namespace declared keeps working unchanged.
-- **Filename = `strtolower(ClassName)` + suffix.** A mismatch means the class
-  won't autoload. Silently, for most classes — but not for your manager:
-  install refuses outright if `class/<name>manager.class.php` exists and does
-  not declare `<Name>Manager`, because the fallback used to make the install
-  report success having created nothing.
+- **The class list is cached, and the installer drops it.** Both roots are
+  listed once and memoized to `/opt/fog/cache/` for 300 seconds, so a file you
+  add by hand can take that long to be seen. `installfog.sh` clears the cache
+  for you; while developing, delete `/opt/fog/cache/*.json` or wait it out.
+- **Path equals name.** `src/<Bucket>/<Class>.php` declares
+  `FOG\Plugins\<Segment>\<Bucket>\<Class>`, and `strtolower(<Segment>)` is
+  the plugin's directory name. A mismatch means the class does not load — the
+  autoloader derives one path and only one. No `class_alias()` needed, not even
+  for a page/hook/event/report/task. §7a has the shape.
+- **A class in the wrong bucket is loadable but invisible.** Autoloading and
+  discovery are separate: a `FOGPage` subclass under `src/Items/` resolves fine
+  if something names it, and is never routed, because only `src/Pages/` is
+  listed for pages. If your page exists but `?node=` 404s, check the directory
+  before you check the code.
+- **Your manager's name is checked at install.** If `src/Managers/` holds a
+  file whose base name matches the manager the plugin expects but which
+  declares something else, install refuses outright rather than reporting
+  success having created nothing.
 - **`menuicon`** beginning with `fa` is rendered as a font-awesome icon;
   anything else is treated as an `<img>` `src`.
 - **`$serverFault`** must be `true` only for server-side failures, so HTTP
   status codes are honest (`500` vs `400`).
 - **Hook constructors must early-return** when the node isn't in
   `$pluginsinstalled`, or your hooks run for a plugin that isn't enabled.
+  `registerInstalled()` does this for you.
+- **A registration that fails is logged, not thrown.** `register()` catches an
+  unusable listener, writes one line naming the class and the event, and
+  returns — so a typo in a method name costs you a hook that silently never
+  fires. If a callback isn't running, check the log before you check the event
+  name.
 - **List columns** in the JS must match `$headerData` order and the keys the
   router emits (`mainlink`, `id`, friendly field names).
 - **An external plugin's assets are served through a symlink FOG maintains for
@@ -1046,11 +1212,11 @@ Fire your own events with `&`-by-reference args so listeners can mutate them
 
 1. Copy `helloworld/` to `/opt/fog/plugins/<yourname>/` (or, for a plugin you
    intend to bundle with FOG itself, `packages/web/lib/plugins/<yourname>/`) and
-   rename the directory, the classes, the files (lowercased), every `$node`, and
-   the `$fog_plugin['name']`.
-2. Get it into the web root — only needed for a bundled plugin, since
-   `/opt/fog/plugins/` is already live and outside the docroot on purpose.
-   Whatever you normally use to sync a working tree onto the server will do.
+   rename the directory, the classes, the files (each file keeps its class's
+   exact name), the `FOG\Plugins\<Segment>` in every `namespace` line, every
+   `$node`, and the `$fog_plugin['name']`.
+2. Deploy to the web root (e.g. `copybacktrunk.sh "" "" "1.6"`) — only needed
+   for a bundled plugin; `/opt/fog/plugins/` is already live.
 3. In the UI: **Plugin System → Plugin Management → install/activate** your
    plugin.
 4. Confirm: the sidebar entry appears, **Create New** saves a row (check the
@@ -1108,9 +1274,7 @@ files are here" and "this code is running" stay separate decisions.
 
 ### Turning uploads on (admins)
 
-The admin-side walkthrough is on the
-[[1.6/management/web/plugins#Installing a plugin from an archive|Plugins page]]; the short version
-is two independent switches, both required:
+Two independent switches, both required:
 
 1. `FOG_PLUGIN_UI_INSTALL_ENABLED` in **FOG Configuration → FOG Settings →
    Plugin System**.
@@ -1131,6 +1295,54 @@ on disk and adding new executable code to the server are different authorities.
 
 ---
 
+## 11b. Porting a plugin from the pre-1.6 layout
+
+If your plugin has a `class/` directory rather than a `src/` one, it is on the
+layout that shipped before 1.6.0 and it will not load. The port is a file move
+and a `namespace` line; **no logic changes**, and nothing about the manifest,
+the routing node, the permission strings, the JS or the database moves with it.
+
+Move each file, keeping its class's exact name and dropping the suffix:
+
+| Was | Is now | Because it extends |
+|---|---|---|
+| `class/helloworld.class.php` | `src/Items/HelloWorld.php` | `FOGController` |
+| `class/helloworldmanager.class.php` | `src/Managers/HelloWorldManager.php` | `FOGManagerController` |
+| `class/oidcflow.class.php` | `src/Util/OIDCFlow.php` | `FOGBase` — no bucket of its own |
+| `pages/helloworldmanagement.page.php` | `src/Pages/HelloWorldManagement.php` | |
+| `hooks/addhelloworldjs.hook.php` | `src/Hooks/AddHelloWorldJS.php` | |
+| `events/somethinghappened.event.php` | `src/Events/SomethingHappened.php` | |
+| `reports/ou_report.report.php` | `src/Reports/OU_Report.php` | keep the underscores — §9a |
+| `tasks/helloworldheartbeat.task.php` | `src/Tasks/HelloWorldHeartbeat.php` | |
+
+`class/` splits three ways because it used to hold everything; which bucket a
+file belongs in is decided by what its class extends, not by what it is called.
+
+Then, in each file, extend the namespace with the bucket:
+
+```php
+-namespace FOG\Plugins\Helloworld;
++namespace FOG\Plugins\HelloWorld\Items;
+```
+
+Two things to watch while you do it:
+
+- **The segment may need recasing.** It used to be `ucfirst()` of the directory
+  name, so `ldap/` was `FOG\Plugins\Ldap`. Any casing is allowed now as long
+  as lowercasing it returns the directory name, and the bundled plugins took
+  the chance to become `FOG\Plugins\LDAP`, `FOG\Plugins\OIDC`,
+  `FOG\Plugins\WOLBroadcast`. Recasing is optional; if you do it, do it in
+  every file at once.
+- **Any FQCN you spell out in your own code moves too** — a `use` import of one
+  of your own classes, a class name in a string, an `is_subclass_of()`. Core
+  resolves short names for you (§7a), but a literal you wrote is a literal.
+
+Use `git mv` so the history follows the file. If you carried a `class_alias()`
+to make discovery find a namespaced class, delete it; it has nothing left to
+do.
+
+---
+
 ## 12. Reference plugins
 
 - **`helloworld`** — this guide's minimal, complete CRUD example.
@@ -1144,13 +1356,6 @@ on disk and adding new executable code to the server are different authorities.
   a resource, contributes a login button, and turns a proven identity into a
   session. Also a six-table plugin: provider, identity links, groups, two
   association tables and the grant record.
-
->[!note] `site` used to be listed here
->It was the reference for `OBJECT_SCOPE_CHECK`, but sites and per-site host
->visibility moved into 1.6 core, so there is no `site` plugin to read any more.
->The seam it demonstrated is still a plugin seam and is documented in §8a; the
->enforcement now lives in core's `Authorization`. See
->[[1.6/management/web/site-scoping|Site Scoping]].
 
 When in doubt, copy the closest existing plugin and adapt it — the conventions
 above are followed consistently across all of them.

--- a/docs/development/plugin-schema-migrations.md
+++ b/docs/development/plugin-schema-migrations.md
@@ -81,7 +81,7 @@ and only fires from the explicit **Uninstall** button.
 ## How steps are applied
 
 `Schema::applyUpdates(array $steps, int $applied): array`
-(`lib/fog/schema.class.php`) is the shared runner. It runs steps from index
+(`src/Items/Schema.php`) is the shared runner. It runs steps from index
 `$applied` onward, returns `['applied' => int, 'error' => string|null]`, and is
 used by both the install path and the upgrade path so there is one code path.
 
@@ -201,11 +201,11 @@ have no `schema()` method, so they never report "update available" and
 
 | File | Role |
 |------|------|
-| `lib/fog/schema.class.php` | `Schema::applyUpdates()` — the shared idempotent runner |
-| `lib/fog/plugin.class.php` | `Plugin::installdb()`, `Plugin::needsSchemaUpdate()`; `pSchema` field map |
-| `lib/fog/pluginmanager.class.php` | `PluginManager::getPluginsNeedingUpdate()` |
-| `lib/pages/pluginmanagement.page.php` | `upgrade`/`upgradePost` action; list JSON enrichment |
-| `lib/pages/dashboardpage.page.php` | "needs update" dashboard banner |
+| `src/Items/Schema.php` | `Schema::applyUpdates()` — the shared idempotent runner |
+| `src/Items/Plugin.php` | `Plugin::installdb()`, `Plugin::needsSchemaUpdate()`; `pSchema` field map |
+| `src/Managers/PluginManager.php` | `PluginManager::getPluginsNeedingUpdate()` |
+| `src/Pages/PluginManagement.php` | `upgrade`/`upgradePost` action; list JSON enrichment |
+| `src/Pages/DashboardPage.php` | "needs update" dashboard banner |
 | `management/js/fog/plugin/fog.plugin.list.js` | "Update available" badge + bulk Update button |
 | `commons/schema.php` | core migration that adds the `plugins.pSchema` column |
-| `lib/plugins/location/class/locationmanager.class.php` | reference implementation |
+| `lib/plugins/location/src/Managers/LocationManager.php` | reference implementation |

--- a/docs/development/storage-node-selection-hooks.md
+++ b/docs/development/storage-node-selection-hooks.md
@@ -110,8 +110,8 @@ class MyStorageHook extends Hook
 }
 ```
 
-Register the hook the usual way (a `*.hook.php` file whose class name matches
-the filename, in `lib/hooks/` or inside a plugin's `hooks/` directory).
+Register the hook the usual way: a file whose name is the class name, in
+core's `src/Hooks/` or in a plugin's own `src/Hooks/`.
 
 The `MASTER_STORAGE_NODE` event works identically — just register on that name
 instead.
@@ -125,4 +125,4 @@ two methods is covered, including paths that don't fire the surrounding
 `*_NEW_SETTINGS` events — e.g. host tasking, the boot menu, the task queue, and
 the Capone/Location plugins.
 
-See [`packages/web/lib/fog/storagegroup.class.php`](https://github.com/FOGProject/fogproject/blob/working-1.6/packages/web/lib/fog/storagegroup.class.php).
+See [`packages/web/src/Items/StorageGroup.php`](https://github.com/FOGProject/fogproject/blob/working-1.6/packages/web/src/Items/StorageGroup.php).


### PR DESCRIPTION
Mirrors **FOGProject/fogproject#1540** and **FOGProject/fog-plugins#34**.

A plugin's PHP moved out of `class/ pages/ hooks/ events/ reports/ tasks/` and into:

```
<plugin>/src/<Bucket>/<Class>.php   declares   FOG\Plugins\<Segment>\<Bucket>\<Class>
```

— the same PSR-4 arrangement core already used on itself. The plugin **directory** does not move: it is still the routing node, the permission string and the `js/` path, so nothing user-visible changes and there is no migration for an admin to run.

## What changed here

| Doc | Change |
|---|---|
| `docs/development/plugin-development.md` | Re-ported from the fogproject copy. Rewritten §2, §3, §4.2–4.5, §7a, §9a, §10, §11; the "Discovery still works by filename" subsection is the claim being reversed and is gone; new **§11b** is the port table for a plugin still on the pre-1.6 layout. |
| `docs/development/plugin-schema-migrations.md` | Its Key files table still named `lib/fog/*.class.php` paths that moved when core itself went PSR-4. |
| `docs/1.6/management/web/reports.md` | **User-facing, and it was teaching a path that no longer exists.** A report is `packages/web/src/Reports/<Class>.php`, or `<plugin>/src/Reports/<Class>.php` inside a plugin. Also spells out why the underscores in `Fleet_Report` are load-bearing — the menu label, the base64 `f` URL parameter and the permission node are all derived from that name. |
| `docs/development/storage-node-selection-hooks.md` | Pointed at `lib/fog/storagegroup.class.php` and told authors to write a `*.hook.php` in `lib/hooks/`. |
| `docs/1.6/kb/reference/csv_import_export.md` | Named the Location plugin's import hook by its old filename. |

## Translations

Left alone deliberately. `scripts/translate.mjs` retranslates a page when its source hash moves, so the French copies refresh themselves on the next run once a provider is configured — hand-editing them now would only be overwritten.

## Not changed, and worth a separate look

`reports.md`'s **Importing a report** section documents a form that has no server-side handler: `ReportManagement::upload()` renders the Import Reports form, and there is no `uploadPost()` anywhere in `packages/web` — nor has there ever been on `working-1.6` (`git log -S uploadPost` is empty). That is a pre-existing defect, independent of this move, so the section is untouched here rather than quietly deleted.
