### PR TITLE
Document the group split, and the Chocolatey snapin templates

### DIFF
--- a/docs/1.5/index.md
+++ b/docs/1.5/index.md
@@ -40,6 +40,7 @@ apply to you as written — [[index|start there]].
 - [[1.5/management/web/ldap|LDAP Authentication]]
 - [[1.5/management/web/site-scoping|Site Scoping]]
 - [[1.5/management/web/hosts|Host Management]]
+- [[1.5/management/web/groups|Group Management]]
 - [[1.5/management/web/reports|Report Management]]
 - [[1.5/management/web/storage-node|Storage Node Management]]
 - [[1.5/management/web/config|Fog Configuration]]

--- a/docs/1.5/management/web/groups.md
+++ b/docs/1.5/management/web/groups.md
@@ -1,19 +1,24 @@
 ---
-title: Group Management
+title: "Group Management (1.5)"
 aliases:
-    - Group Management
-    - Fog Group Management
-description: index page for groups
-context_id: groups
+    - "Group Management (1.5)"
+description: "How FOG 1.5 groups work: a group owns nothing of its own, and every group action writes onto the hosts that are members at that moment"
+context_id: "groups-1.5"
 tags:
-    - in-progress
     - management
     - web-management
     - web-ui
     - groups
+    - 1_5-legacy
 ---
 
-# Group Management
+# Group Management (1.5)
+
+>[!info] This page describes FOG 1.5.
+>See the [[1.6/management/web/groups|1.6 version]] of this page for FOG 1.6,
+>where a group **owns** its snapins and printers and applies them to every
+>member — including hosts added after the fact — instead of copying rows onto
+>whichever hosts happened to be members when you pressed the button.
 
 ## Groups
 
@@ -24,7 +29,6 @@ tags:
     Floor", it could also be a member of "Math Department", or "Dell
     PCs." Groups make using FOG possible for organizations with a very
     large number of PC's.
-    see also [[group-shared-state|Group Shared State]]
 
 ## Creating Groups
 
@@ -32,7 +36,7 @@ tags:
 
 1.  **Group Management** → **Create New Group**
 2.  Hosts section of FOG based on searches, for information on how to
-    create groups, please see [[1.6/management/web/hosts#Creating Host Groups]]
+    create groups, please see [[1.5/management/web/hosts#Creating Host Groups]]
 
 ## Managing Groups
 

--- a/docs/1.5/management/web/index.md
+++ b/docs/1.5/management/web/index.md
@@ -16,6 +16,7 @@ tags:
 - [[1.5/management/web/ldap|LDAP Authentication]]
 - [[1.5/management/web/site-scoping|Site Scoping]]
 - [[1.5/management/web/hosts|Host Management]]
+- [[1.5/management/web/groups|Group Management]]
 - [[1.5/management/web/reports|Report Management]]
 - [[1.5/management/web/storage-node|Storage Node Management]]
 - [[1.5/management/web/config|Fog Configuration]]

--- a/docs/1.6/index.md
+++ b/docs/1.6/index.md
@@ -40,6 +40,7 @@ apply to you as written — [[index|start there]].
 - [[1.6/management/web/ldap|LDAP Authentication]]
 - [[1.6/management/web/site-scoping|Site Scoping]]
 - [[1.6/management/web/hosts|Host Management]]
+- [[1.6/management/web/groups|Group Management]]
 - [[1.6/management/web/reports|Report Management]]
 - [[1.6/management/web/storage-node|Storage Node Management]]
 - [[1.6/management/web/config|Fog Configuration]]

--- a/docs/1.6/management/web/groups.md
+++ b/docs/1.6/management/web/groups.md
@@ -1,0 +1,287 @@
+---
+title: Group Management
+aliases:
+    - Group Management
+    - Fog Group Management
+    - Group Grants
+description: "How FOG 1.6 groups work: a group owns its snapins and printers and applies them to every member, including hosts added later"
+context_id: groups
+tags:
+    - 1_6-changes
+    - management
+    - web-management
+    - web-ui
+    - groups
+---
+
+# Group Management
+
+>[!info] FOG 1.6
+>Groups themselves are not new, but what a group **is** changed in 1.6. On
+>1.5 a group owned nothing: pressing a button on the group page wrote rows
+>onto whichever hosts were members at that instant. In 1.6 a group owns its
+>snapins and printers, and every member gets them — including hosts you add
+>tomorrow. See the [[1.5/management/web/groups|1.5 version]] of this page for
+>the old behavior.
+
+A **group** is a label you put on hosts. A host can be in as many groups as
+you like: a machine can be in *Third Floor*, *Math Department* and *Dell PCs*
+at once, and each of those groups can hand it something.
+
+## What a group gives its members
+
+A group holds three kinds of thing, and hands all of them to every member:
+
+| The group holds | Where you set it | What the member gets |
+|---|---|---|
+| **Snapins** | Associations → Snapin Associations | Included when you deploy snapins to that host |
+| **Printers** | Associations → Printer Associations | Installed by the FOG client on its next check-in |
+| **Client modules** | Service Settings → Client Settings | The module is switched on |
+
+Tick an item and the group grants it. Untick it and the grant is gone. Neither
+click touches a host record, so nothing you do here can overwrite something an
+admin set on a machine directly.
+
+>[!important] This is the change people notice first
+>**A host added to the group later gets the group's snapins and printers.** On
+>1.5 it got nothing — silently — which is why so many sites ended up with a
+>plugin, a script, or a habit of re-pressing the group's buttons after adding
+>a machine. None of that is needed now.
+>
+>**A host removed from the group loses them.** On 1.5 the copied rows stayed
+>behind forever, with nothing to say where they had come from.
+
+## What a host ends up with
+
+A host's real list is **its own assignments plus every grant from every group
+it belongs to**, worked out fresh each time FOG needs it. Two rules cover
+almost every question about it:
+
+1. **The host's own assignments come first.** A snapin you gave a machine
+   directly stays where you put it in that machine's run order; a grant never
+   reorders it.
+2. **Groups follow, in group order** — the **Group Order** field on each
+   group, lowest first, then by name for groups sharing a number. Every group
+   starts at `0`, so out of the box that is plain alphabetical order; set the
+   field only on the groups where the order actually matters. Falling back to
+   name rather than to creation date is what makes the result something you
+   can predict by reading the group list.
+
+An item assigned **both** directly and by a group appears **once**, in the
+host's position. There is no double install and no duplicate row.
+
+The **default printer** follows exactly the same precedence: a host that has
+chosen its own default keeps it, and otherwise the default comes from the
+first group in that order which names one.
+
+>[!note] If two groups grant conflicting defaults, group order decides
+>Give the group whose default should win a **lower Group Order** than the
+>other. Setting the default on the host itself also works and beats every
+>group, but that is a per-host edit you then have to remember — the order is
+>set once and keeps applying as hosts come and go.
+
+>[!tip] Where to see the result
+>The host's own Printers and Snapins tabs show what that host was assigned
+>directly. To see what it will actually *get*, look at the groups it is in —
+>the Groups column on the Hosts list names them, in the order above.
+
+## Snapins are a snapshot; printers are live
+
+These two behave differently, and the difference matters the moment you edit a
+group while work is queued.
+
+- **Snapins are resolved when the task is created.** A snapin deployment
+  records the list it is going to run at the moment you queue it. Editing the
+  group afterwards does **not** change a task that is already waiting — you
+  have to re-task to pick the change up.
+- **Printers are resolved live, on every client check-in.** Add a printer to a
+  group and members install it on their next check-in; remove one and they
+  uninstall it. There is nothing to re-task.
+
+The reason is that a task is a promise about a specific moment — you queued
+*that* set of snapins for *that* machine, and a machine that reboots into a
+job three hours later should get the job you queued, not a different one.
+Printers have no task to hang a snapshot on: the FOG client reconciles them on
+a schedule, so a removal has to be able to reach the machine on its own.
+
+>[!warning] Printer level "FOG Handles all printers"
+>On that level the list FOG sends is authoritative **in both directions** —
+>the client removes every installed printer that is not on it, including ones
+>FOG did not add. That has always been true of that mode, and it is worth
+>re-reading now that a group can add to the list.
+
+## Settings that are no longer on the group page
+
+Image, kernel, kernel arguments, primary disk, init, AD details, product key,
+printer management level, BIOS/EFI exit type, screen resolution, auto-logout
+and hostname enforcement are **not** set from a group any more. They were
+never group properties — pressing *Update* wrote the value onto each member
+host once — so they moved to where that operation belongs: the **Hosts** list.
+
+**Hosts → tick the hosts you want → Edit selected hosts.**
+
+That does the same job on any selection you can build, not only on a group,
+and you can repeat it whenever you like. Each field has its own action:
+
+| Action | What it does |
+|---|---|
+| **No change** | Leave every selected host's value alone. This is the default for every field. |
+| **Set on all** | Write the value you type to every selected host. |
+| **Clear on all** | Empty the field on every selected host. |
+
+Fields that only make sense as on/off (joining the domain, hostname
+enforcement) offer *No change*, *Enable on all* and *Disable on all* instead.
+
+>[!note] Where each setting went
+>| Was on the group page | Now |
+>|---|---|
+>| Image | Edit selected hosts → **Image** |
+>| Kernel, kernel arguments, primary disk, init | Edit selected hosts → **Host Kernel** / **Host Kernel Arguments** / **Host Primary Disk** / **Host Init** |
+>| Product key | Edit selected hosts → **Product Key** |
+>| BIOS / EFI exit type | Edit selected hosts → **Host BIOS Exit Type** / **Host EFI Exit Type** |
+>| Printer management level | Edit selected hosts → **Host Printer Management Level** |
+>| Active Directory (join, domain, OU, username, password) | Edit selected hosts → the **Active Directory** fields |
+>| Enforce hostname changes | Edit selected hosts → **Host Enforce Hostname Changes** |
+>| Screen resolution | Edit selected hosts → **Host Screen Resolution** |
+>| Auto log out time | Edit selected hosts → **Auto Log Out Time (in minutes)** |
+>| Building | **Removed.** Nothing read it and nothing wrote it — it was a leftover column, not a setting. |
+
+The old controls are **still on the group page in 1.6**, marked deprecated, so
+nobody loses a workflow in the middle of an upgrade. They are removed in a
+later release. Where they remain, they still behave the old way: the value is
+applied **once**, to the hosts that are members at that moment.
+
+## Groups as labels: doing it from the Hosts list
+
+Group membership is editable from the host side in bulk, which is usually the
+faster way round. Labelling forty machines is one action rather than three
+trips through Group Management:
+
+1. **Hosts** → filter or search until you have the machines on screen. The
+   **Groups** column shows each host's groups and can be searched and filtered
+   like any other column, so "everything in *Third Floor* that is not in
+   *Dell PCs*" is a filter rather than a cross-referencing exercise.
+2. Tick the hosts you want.
+3. **Edit groups** → pick one or more groups → **Add** or **Remove**.
+
+Typing a name that is not a group yet **creates it** when you add. *Remove*
+only works on groups that already exist.
+
+Because a group grants rather than copies, adding those forty machines to a
+group is all it takes for them to receive that group's snapins and printers —
+there is no second step, and no button to press afterwards.
+
+## The rest of the group page
+
+- **General** — the group's own name and description, plus the deprecated
+  push-to-all fields described above.
+- **Image** — the deprecated one-time image push.
+- **Tasks** — deploy, capture, multicast, wake, and the rest, run across every
+  current member. Tasking is unchanged: it acts on the membership at the
+  moment you start the task, which is what you want from a task.
+- **Associations → Host Associations** — who is in the group. Add and remove
+  members here, or from the Hosts list as above.
+- **Associations → Printer Associations** — the group's printers, plus which
+  of them is the group's default.
+- **Associations → Snapin Associations** — the group's snapins, plus the
+  **Snapin Run Order** card, which orders the group's own snapins. A host runs
+  its own snapins first, then these, in this order. Order only changes
+  anything when *Abort snapin sequence on failure* is enabled for the task.
+- **Service Settings → Client Settings** — the group's modules, plus the
+  deprecated screen-resolution and auto-logout pushes.
+- **Service Settings → Active Directory** — deprecated; see the table above.
+- **Service Settings → Power Management** — schedules power tasks across
+  members. Not deprecated: it creates tasks rather than copying a value.
+- **Inventory**, **Login History**, **History Items** — reporting across the
+  group's members.
+- **Site** — which site the group belongs to, if you use site scoping.
+
+## Modules have one extra rule: only a host can turn one off
+
+A snapin or a printer is a thing a host either has or does not. A **module** is
+a switch, so it needs a third answer, and 1.6 gives it one.
+
+A group can turn a module **on** and can never turn one **off** — there is no
+"disabled" a group can express. That means two groups can never contradict
+each other over a module, and there is no "this group says on, that one says
+off, which wins" to resolve.
+
+A host can say all three, on its own **Modules** tab, which is a dropdown
+rather than a checkbox:
+
+| The host says | Result |
+|---|---|
+| **On** | The module runs on this host. |
+| **Off** | The module does not run, no matter how many groups grant it. |
+| **Not set** | The host has no opinion; a group grant switches it on, and nothing else does. |
+
+*Off* is the host's own answer and beats every grant. Note that this is the
+one place where unticking used to mean something different: on the old
+checkbox, unticking deleted the row, which under these rules means *Not set* —
+so a group granting the module would have switched it straight back on.
+
+## Hosts that already carry copies
+
+An upgraded server keeps every association it had. That is deliberate — an
+upgrade that removed assignments would be an upgrade that changed what
+installs on your machines — but it has a consequence worth understanding
+before you go looking for it:
+
+**Nothing distinguishes a row that a 1.5 group copied onto a host years ago
+from one an admin chose for that host deliberately.** They are the same row in
+the same table, and the copy never recorded where it came from. FOG cannot
+tell them apart, so it does not try, and neither will any script you write.
+
+So the most likely surprise reads like this:
+
+> *"I removed the host from the group and it still has the snapin."*
+
+That is the old copy, sitting on the host as a direct assignment. Removing the
+host from the group removed the **grant**; it cannot remove an assignment that
+was never a grant in the first place. Look at the host's own Snapins or
+Printers tab and you will see it listed there.
+
+Nothing needs cleaning up for FOG to work correctly — a host holding both the
+direct copy and the grant gets the item **once**. Clean up only if you want the
+group to be the single place that decides, in which case the routine is:
+
+1. Confirm the group grants the item (Associations → Snapin Associations).
+2. On the Hosts list, filter to the group's members.
+3. Open each host's Snapins or Printers tab and remove the direct assignment.
+
+After that the group is the only thing granting it, and adding or removing a
+host does the whole job.
+
+>[!tip] New groups do not have this problem
+>Anything you set up on 1.6 is a grant from the start. This only affects
+>associations that existed before the upgrade.
+
+## persistentgroups is retired
+
+The **persistentgroups** plugin existed to work around exactly the defect this
+release fixes: it copied settings from a template host onto every machine that
+joined a group, because a group could not hand anything to a machine by
+itself. A group can now, so the plugin is gone and the template-host naming
+convention it needed goes with it.
+
+Upgrading handles the removal for you. The plugin's code disappears with the
+upgrade like any other bundled plugin, and — importantly — the upgrade also
+**drops the database trigger it installed**. That matters because removing the
+plugin's files never removed the trigger: it would otherwise have kept copying
+settings onto every new group member, silently, long after the plugin that
+created it was gone.
+
+You do not need to do anything. If you had it installed, check afterwards that
+the groups which relied on it now grant the snapins and printers you expect —
+the grants are the replacement, and they are more capable than what they
+replace, because they also apply to hosts that were already members.
+
+## See also
+
+- [[group-shared-state|Group Shared State]] — the detail behind resolution
+  order, precedence, and the deprecated push-to-all controls.
+- [[1.6/management/web/hosts|Host Management]] — the Hosts list, mass edit and
+  bulk group membership.
+- [[management/web/snapins|Snapin Management]] and
+  [[management/web/printers|Printer Management]] — creating the things a group
+  grants.

--- a/docs/1.6/management/web/hosts.md
+++ b/docs/1.6/management/web/hosts.md
@@ -367,15 +367,66 @@ where the two disagree:
 The second row is the one worth acting on. Full detail, including how to pick a
 port for a mixed fleet: [[kb/reference/ping-hosts-service|The Ping Hosts Service]].
 
+### Editing many hosts at once
+
+Tick the hosts you want on the Hosts list and use **Edit selected hosts**.
+This is where the settings that used to be pushed from a group page now live —
+image, kernel, kernel arguments, primary disk, init, product key, BIOS and EFI
+exit type, printer management level, Active Directory, hostname enforcement,
+screen resolution and auto-logout.
+
+Every field carries its own action, and the default is always to do nothing:
+
+| Action | What it does |
+|---|---|
+| **No change** | Leave every selected host's value alone |
+| **Set on all** | Write the value you type to every selected host |
+| **Clear on all** | Empty the field on every selected host |
+
+Fields that are only on or off — joining the domain, hostname enforcement —
+offer *No change*, *Enable on all* and *Disable on all* instead.
+
+Two things follow from the action being separate from the value:
+
+- **A form you open and submit without touching anything changes nothing.**
+  There is no way to overwrite a field by forgetting about it.
+- **"Set this to blank" and "leave this alone" are different instructions.**
+  Choosing *Set on all* with an empty box makes the field blank; that is what
+  *Clear on all* does explicitly, and it is why you never have to type a magic
+  word to clear something.
+
+Where the selection holds different values, the form says so — `(varies)` —
+rather than picking one of them to show you.
+
+>[!info] Coming from FOG 1.5?
+>On 1.5 the only way to change a setting across many machines was to put them
+>in a group and press *Update* on the group page. That wrote the value onto
+>whichever hosts were members at that moment. *Edit selected hosts* works on
+>any selection you can build — a search, a filter, a handful of ticks — and
+>can be repeated. The group-page controls still exist on 1.6, marked
+>deprecated, and are removed in a later release. See
+>[[1.6/management/web/groups#Settings that are no longer on the group page|Group Management]].
+
 ### Creating Host Groups
 
--   FOG allows you to create groups of hosts which then allows you to
-    take action on a whole grouping of hosts.
--   Hosts can be created either on the "List All Hosts" section or by
-    doing a search for hosts.
--   To create a group select the computer you would like to be member of
-    the group by placing a check in the box next to the hostname, or by
-    clicking the check all button in the title row. After the hosts are
-    selected scroll to the bottom of the screen and then enter a name in
-    the create to group box or select a group to add the hosts to. Then
-    click on the "Process Group Changes" button.
+Group membership is editable straight from the Hosts list, which is usually
+the fastest way to label a fleet:
+
+1.  Filter or search until the machines you want are on screen. The **Groups**
+    column shows each host's groups as links, in the order group assignments
+    are applied, and it can be searched and filtered like any other column —
+    so "everything in *Third Floor* that is not in *Dell PCs*" is a filter
+    rather than a cross-referencing exercise.
+2.  Tick the hosts, or use the check-all box in the title row.
+3.  Click **Edit groups**, pick one or more groups, and choose **Add** or
+    **Remove**.
+
+Typing a name that is not a group yet **creates it** when you add. *Remove*
+only works on groups that already exist.
+
+>[!important] On FOG 1.6 that is the whole job
+>A group **grants** its snapins and printers to its members rather than
+>copying them, so adding forty machines to a group is all it takes for those
+>machines to receive what the group holds — there is no second step and no
+>button to press afterwards. Removing a host takes them away again. See
+>[[1.6/management/web/groups|Group Management]].

--- a/docs/1.6/management/web/index.md
+++ b/docs/1.6/management/web/index.md
@@ -16,6 +16,7 @@ tags:
 - [[1.6/management/web/ldap|LDAP Authentication]]
 - [[1.6/management/web/site-scoping|Site Scoping]]
 - [[1.6/management/web/hosts|Host Management]]
+- [[1.6/management/web/groups|Group Management]]
 - [[1.6/management/web/reports|Report Management]]
 - [[1.6/management/web/storage-node|Storage Node Management]]
 - [[1.6/management/web/config|Fog Configuration]]

--- a/docs/1.6/management/web/plugins.md
+++ b/docs/1.6/management/web/plugins.md
@@ -227,7 +227,6 @@ this page for how it differs on the older line.
 | **ntfy** | Notifications via ntfy.sh or your own ntfy server |
 | **oidc** | Sign in to FOG with an OpenID Connect identity provider (Entra ID, Keycloak, Okta, ...). See [[oidc\|OpenID Connect Sign-in]] |
 | **ou** | Predefine Active Directory OUs and associate them with hosts |
-| **persistentgroups** | When a host joins a group, copy image, AD, printer, snapin and location settings onto it from a template host named after that group |
 | **pushbullet** | Pushbullet notifications |
 | **slack** | Slack notifications |
 | **subnetgroup** | Assign hosts to groups automatically based on their IP subnet |
@@ -240,6 +239,20 @@ this page for how it differs on the older line.
 >The Access Control plugin was replaced by native roles and permissions in
 >1.6. For what happens to plugin-era roles on upgrade, see
 >[[management/web/roles#Upgrading from the Access Control plugin|Roles & Permissions]].
+
+>[!note] persistentgroups is gone, because the defect it worked around is fixed
+>The plugin copied settings from a template host onto every machine that
+>joined a group, because on 1.5 a group could not hand anything to a machine
+>by itself. In 1.6 a group **grants** its snapins and printers to every
+>member, including hosts added later, so there is nothing left to work around
+>— and the template-host naming convention goes with it.
+>
+>**Upgrading removes it for you, trigger included.** The plugin installed a
+>database trigger, and deleting the plugin's files never removed that: it
+>would have kept copying settings onto every new group member, silently, long
+>after the plugin that created it was gone. The upgrade drops the trigger and
+>retires the plugin's row. See
+>[[1.6/management/web/groups#persistentgroups is retired|Group Management]].
 
 >[!note] Site is gone too, and for the same reason
 >Sites and per-site host visibility moved into 1.6 core, so there is no

--- a/docs/kb/how-tos/chocolatey-snapins.md
+++ b/docs/kb/how-tos/chocolatey-snapins.md
@@ -1,0 +1,238 @@
+---
+title: Install software with Chocolatey snapins
+aliases:
+    - Install software with Chocolatey snapins
+    - Chocolatey Snapins
+    - Chocolatey
+description: "Use the Chocolatey snapin templates to install packages on Windows hosts, either from the public repository or from an offline package set you ship with the snapin"
+context_id: chocolatey-snapins
+tags:
+    - how-to
+    - snapins
+    - 1_6-changes
+---
+
+# Install software with Chocolatey snapins
+
+>[!info] FOG 1.6
+>The two Chocolatey templates described here are new in FOG 1.6. The
+>technique works on 1.5 as well — a snapin is still just a command — but you
+>have to type the fields in yourself, and the placeholder-file workaround
+>described under [Why you no longer need a placeholder .bat](#why-you-no-longer-need-a-placeholder-bat)
+>still applies there.
+
+[Chocolatey](https://chocolatey.org/) is a package manager for Windows. If
+your hosts already have it, you can let it do the fetching and installing and
+keep FOG doing what it is good at — deciding *which* machines get *what*, and
+when.
+
+FOG ships two templates for this, and they solve two different problems:
+
+| Template | Snapin type | Where the packages come from |
+|---|---|---|
+| **Chocolatey (packages.config)** | Normal | Downloaded by the client, from whatever sources Chocolatey is configured with |
+| **Chocolatey (offline source)** | Snapin Pack | `.nupkg` files you ship inside the snapin itself |
+
+Pick the first when your hosts can reach a package repository. Pick the second
+when they cannot, or when you need every machine to get a byte-identical
+package regardless of what the repository is serving today.
+
+## Before you start
+
+**Chocolatey must already be installed on the host.** Neither template
+installs it — they call `choco.exe`, and if it is not there the snapin fails.
+Install it as part of your image, or as a separate snapin that runs the
+official bootstrap script, and only then use these templates.
+
+>[!note] Why the templates use a full path to `choco.exe`
+>Both templates set **Snapin Run With** to
+>`%ProgramData%\chocolatey\bin\choco.exe` rather than a bare `choco`.
+>
+>The FOG client runs as a Windows service. It expands environment variables
+>in that field, but it inherits the `PATH` it was **started** with — and on
+>any machine where Chocolatey was installed after the FOG client, that `PATH`
+>predates Chocolatey's entry in it. A bare `choco` works fine when you try it
+>by hand in a console and then fails as a snapin, which is a miserable thing
+>to debug. The full path sidesteps it.
+
+## Chocolatey (packages.config)
+
+This is the everyday one. You upload a Chocolatey **packages.config** — an XML
+file listing the packages you want — and the client hands it to
+`choco install`.
+
+### 1. Write the packages.config
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="googlechrome" />
+  <package id="7zip" />
+  <package id="skypeforbusiness" version="12130.20272" />
+</packages>
+```
+
+Omit `version` to take whatever is current; pin it when you need every machine
+on the same build.
+
+>[!important] The file must be named with a `.config` extension
+>`choco install` decides how to read its argument by looking at the name: an
+>argument ending in `.config` is treated as a package list, and anything else
+>is treated as the name of a single package. FOG stores your snapin under the
+>filename you uploaded it with and the client writes it out under that same
+>name, so the extension survives — but only if it was there to begin with.
+>
+>Upload `office.config`, not `office.xml` or `office.txt`. A file named
+>`office.xml` produces `choco install "…\office.xml"`, and Chocolatey will go
+>looking for a package literally called `office.xml`.
+
+### 2. Create the snapin
+
+1. **Snapin Management → Create New Snapin.**
+2. Give it a name and description.
+3. Leave **Snapin Type** as **Normal**.
+4. Browse to your `.config` file.
+5. In **Template**, choose **Chocolatey (packages.config)**.
+
+The template fills in three fields:
+
+| Field | Value |
+|---|---|
+| Snapin Run With | `%ProgramData%\chocolatey\bin\choco.exe` |
+| Snapin Run With Arguments | `install` |
+| Snapin Arguments | `-y -r --no-progress` |
+
+You can edit them afterward — the template only seeds the fields, it does not
+constrain them.
+
+### 3. What the client actually runs
+
+The client builds the command by joining those fields **around the file it
+downloaded**:
+
+```
+%ProgramData%\chocolatey\bin\choco.exe install "C:\Program Files (x86)\FOG\tmp\office.config" -y -r --no-progress
+```
+
+That injected path in the middle is the piece worth understanding, because it
+explains the whole shape of this template. The client always inserts the
+downloaded file there, in every Normal snapin — you cannot turn it off. For
+most snapins that is exactly right (it is the installer you want to run), and
+for Chocolatey it works because `choco install` accepts an absolute path to a
+`.config` in precisely that position.
+
+The three flags mean:
+
+- `-y` — answer yes to prompts, since nobody is at the keyboard.
+- `-r` — machine-readable output, which keeps the snapin log terse.
+- `--no-progress` — drop the download progress bar, which otherwise fills the
+  log with thousands of redraw lines.
+
+## Chocolatey (offline source)
+
+Use this when the hosts have no route to a package repository, or when you
+want the exact package bytes fixed.
+
+Here you ship the `.nupkg` files yourself, inside a Snapin Pack. A pack is a
+zip that the client unzips on the machine before running the command, and
+`[FOG_SNAPIN_PATH]` is replaced with the folder it unzipped into. Chocolatey
+is happy to treat a plain folder of `.nupkg` files as a `--source`.
+
+### 1. Build the archive
+
+Download the packages you need on a machine that *can* reach the repository:
+
+```
+choco download googlechrome --internalize --output-directory=C:\pkgs
+```
+
+Then zip the `.nupkg` files — the files themselves at the top level of the
+zip, not a folder containing them.
+
+### 2. Create the snapin
+
+1. **Snapin Management → Create New Snapin.**
+2. Set **Snapin Type** to **Snapin Pack**.
+3. Browse to your zip.
+4. In **Template**, choose **Chocolatey (offline source)**.
+
+That fills in:
+
+| Field | Value |
+|---|---|
+| Snapin Run With | `%ProgramData%\chocolatey\bin\choco.exe` |
+| Snapin Run With Arguments | `install MyPackage --source="[FOG_SNAPIN_PATH]" -y -r --no-progress` |
+
+**Replace `MyPackage`** with the package id you actually want — the template
+cannot guess it. Name several separated by spaces to install more than one.
+
+### 3. What the client actually runs
+
+```
+%ProgramData%\chocolatey\bin\choco.exe install googlechrome --source="C:\Program Files (x86)\FOG\tmp\ChromeOffline" -y -r --no-progress
+```
+
+No file is injected here. That is the difference between the two templates: a
+pack has already been unzipped, so there is no single file to point at, and
+the command is whatever you wrote. It is why this template names the package
+directly and the other one cannot.
+
+## Why there is no `choco upgrade` template
+
+Because it would not work with the shape above. `choco upgrade` rejects a
+packages.config outright:
+
+```
+A packages.config file is only used with installs.
+```
+
+Since a Normal snapin always has the downloaded file injected into the
+command, and that file is the packages.config, there is no way to build a
+working upgrade command from this template. If you want upgrades, use `install`
+— Chocolatey will upgrade a package to the pinned or current version — or
+write a snapin that calls `choco upgrade` with package names and a throwaway
+uploaded file.
+
+>[!note] Installing straight from a `.nupkg` path is deliberately not offered
+>It works today but is deprecated upstream, so a template built on it would
+>break on some future Chocolatey release. The offline `--source` folder above
+>does the same job and is the supported route.
+
+## Why you no longer need a placeholder .bat
+
+A long-standing workaround for this was to write a one-line batch file whose
+only job was to call `choco install`, and upload *that*, because the snapin
+form insists on a file and there was nothing else to give it.
+
+That workaround was never working around a missing feature — it was working
+around the injected-file rule. FOG requires a file because the client refuses
+to run a snapin with no file to verify, and it puts that file into the command
+whether or not the command wants it. The packages.config template turns that
+requirement into the useful part: the file you are forced to upload *is* the
+list of what to install, so the batch file has nothing left to do.
+
+If you have existing `.bat` snapins built this way, they keep working. There is
+no need to convert them unless you want the package list to be something you
+can read and edit on the FOG server rather than buried in a script.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| Snapin fails immediately, no Chocolatey output | `choco.exe` is not at `%ProgramData%\chocolatey\bin\` — Chocolatey is not installed on that host |
+| "The package … was not found" naming your own file | The uploaded file does not end in `.config`, so it was read as a package name |
+| Works by hand, fails as a snapin | Usually the `PATH` problem described above — check **Snapin Run With** is the full path, not bare `choco` |
+| Offline source finds nothing | The zip has a folder inside it; `[FOG_SNAPIN_PATH]` points at the unzip root, so the `.nupkg` files must be at the top level |
+| Log is enormous | `--no-progress` was removed from the arguments |
+
+Snapin exit codes come from Chocolatey, not from FOG — a non-zero result in
+the snapin log is Chocolatey's own return code, and its meaning is
+[documented upstream](https://docs.chocolatey.org/en-us/choco/commands/install).
+
+## See also
+
+- [[snapins|Snapin Management]] — creating snapins generally, and the
+  Normal vs Snapin Pack distinction
+- [[1.6/management/web/groups|Group Management]] — granting a snapin to every
+  host in a group, including hosts added later
+- [[fog-client-example-tasks|Example tasks with the FOG client]]

--- a/docs/kb/how-tos/deploy-an-image.md
+++ b/docs/kb/how-tos/deploy-an-image.md
@@ -67,11 +67,17 @@ this machine.
 ### Host Groups
 
 You are asked if you would like to associate this machine with host
-Groups in FOG. In FOG you can group hosts and you can assign certain
-settings and snapins to a group. Group membership can later be managed
-in the Web UI.
+Groups in FOG. In FOG you can group hosts and assign snapins and printers
+to a group. Group membership can later be managed in the Web UI.
 
 For now we will say 'N' here.
+
+>[!info] FOG 1.6
+>Joining a group later is enough: a 1.6 group **owns** its snapins and
+>printers and hands them to every member, including hosts added after the
+>fact. On 1.5 a host had to be a member at the moment somebody pressed the
+>group's buttons, so answering 'N' here and joining later meant the machine
+>quietly got nothing. See [[1.6/management/web/groups|Group Management]].
 
 ### Snapins
 

--- a/docs/kb/how-tos/index.md
+++ b/docs/kb/how-tos/index.md
@@ -25,6 +25,7 @@ More advanced/situational guides:
 - [[uefi-boot-entries|Managing UEFI Boot Entries (efibootmgr)]]
 - [[deploy-dual-boot-multi-disk-image|Deploying a Dual-Boot Multi-Disk Image]]
 - [[add-extend-a-2nd-virtual-hdd|Add & Extend a 2nd Virtual HDD]]
+- [[chocolatey-snapins|Install software with Chocolatey snapins]]
 - [[post-download-scripts|Post Download Scripts]]
 - [[unify-certificates-across-fog-servers|Unify Certificates Across FOG Servers]]
 - [[lets-encrypt-setup|Set up Let's Encrypt on a FOG server]]

--- a/docs/kb/reference/group-shared-state.md
+++ b/docs/kb/reference/group-shared-state.md
@@ -1,10 +1,11 @@
 ---
 title: Group Shared State
-description: Describes new Fog 1.6 group state changes
+description: How FOG 1.6 works out what a host actually gets from its groups, and what the group page's remaining push-to-all controls do
 context_id: group-shared-state
 aliases:
     - Group Shared State
     - Group State
+    - Group Resolution
 tags:
     - 1_6-changes
     - groups
@@ -15,94 +16,162 @@ tags:
 
 # Group Shared State
 
-A **group** owns no settings of its own — it is a lens over its **member hosts**.
-The group edit page therefore *derives* what it shows from the union of its
-members, so an admin can see what hosts already have in common before changing
-anything.
+>[!info] FOG 1.6
+>This page describes FOG 1.6, where a group **owns** its snapins, printers and
+>modules. On FOG 1.5 a group owned nothing at all and every group action wrote
+>onto its members — see [[1.5/management/web/groups|Group Management (1.5)]].
 
-> **Two kinds of shared state:**
-> 1. **Associations** (snapins, printers, modules) — a host either *has* the
->    item or not, shown as a tri-state checkbox: **All / Some / None** member
->    hosts have it.
-> 2. **Configuration values** (Active Directory, auto-logout, kernel/general
->    fields, default printer) — a host holds a *value*, shown as a muted
->    **`Hosts: …`** hint: the shared value when every member agrees, or
->    `(varies)` when they differ.
->
-> Acting on a group still pushes to **all** member hosts — but config fields are
-> **no-clobber**: a blank field leaves each host's value alone, so you only
-> change what you intend to.
+[[1.6/management/web/groups|Group Management]] is the page to start on. This
+one is the detail behind it: exactly how FOG decides what a host gets, and
+what the group page's remaining push-to-all controls do.
+
+> **Two kinds of state on a group page, and they behave differently:**
+> 1. **Grants** — snapins, printers and modules. The group **owns** these. A
+>    ticked box is a row about the group, and every member gets the item,
+>    including hosts added later. Nothing is written onto a host.
+> 2. **Pushed values** — Active Directory, auto-logout, kernel and general
+>    fields, screen resolution, image, product key. These are **not** group
+>    properties. Pressing *Update* writes the value onto the hosts that are
+>    members at that instant, once. They are **deprecated** in 1.6 and removed
+>    in a later release; use *Edit selected hosts* on the Hosts list instead.
 
 ---
 
 ## Table of contents
 
-- [Associations (tri-state)](#associations-tri-state)
-  - [What "has it" means](#what-has-it-means)
-  - [The badge and Has/Missing drill-down](#the-badge-and-hasmissing-drill-down)
-  - [Toggling](#toggling)
-- [Configuration values (shared hints)](#configuration-values-shared-hints)
+- [What a host actually gets](#what-a-host-actually-gets)
+  - [Precedence](#precedence)
+  - [The default printer](#the-default-printer)
+  - [Modules: the third state](#modules-the-third-state)
+- [When it is worked out](#when-it-is-worked-out)
+- [Pushed values (deprecated)](#pushed-values-deprecated)
+  - [The shared-value hints](#the-shared-value-hints)
   - [The no-clobber convention](#the-no-clobber-convention)
   - [Active Directory](#active-directory)
   - [Auto-logout](#auto-logout)
   - [General fields](#general-fields)
-  - [Default printer](#default-printer)
+  - [Enforce hostname / AD-join reboots](#enforce-hostname--ad-join-reboots)
 - [Out of scope](#out-of-scope)
 
 ---
 
-## Associations (tri-state)
+## What a host actually gets
 
-The **Snapins**, **Printers**, and **Modules** tabs each render every item with a
-coverage checkbox:
+A host's effective list is its **own** assignments unioned with the grants of
+**every** group it belongs to. Nothing is copied: the union is computed each
+time FOG needs it, so membership changes take effect on their own.
 
-| State | Checkbox | Meaning |
-|-------|----------|---------|
-| **All** | checked | every member host has the item |
-| **Some** | indeterminate | at least one, but not all, hosts have it |
-| **None** | unchecked | no host has it |
+That gives you two properties the 1.5 model could not offer:
 
-A **`n / total`** badge sits next to each checkbox (e.g. `5 / 15`).
+- **adding a host to a group is enough** for it to gain that group's snapins
+  and printers; and
+- **removing it is enough** to lose them again.
 
-### What "has it" means
+A host's own assignments are untouched by either. A snapin given to one machine
+directly stays with that machine when the group revokes its grant, because a
+direct assignment and a grant are two separate facts.
 
-- **Snapins, printers** — a host "has it" when the association row exists. The
-  printer **default** flag (`paIsDefault`) is ignored here; it's a separate
-  shared *value* (see [Default printer](#default-printer)).
-- **Modules** — a host counts only when the module is **enabled**
-  (`moduleStatusByHost.msState = 1`). A disabled override pulls the item out of
-  *All* into *Some*. This asymmetry is deliberate (see `docs/adr/0001`): showing
-  a module as "All hosts have it" while some have it disabled would mislead.
+### Precedence
 
-### The badge and Has/Missing drill-down
+Order matters when the same item comes from more than one place.
 
-Clicking the badge expands an on-demand row listing, for that one item:
+1. **The host's own assignments come first**, in the order set on the host.
+2. **Then each group**, sorted by `groups.groupOrder`, then by group **name**,
+   then by internal id.
+3. Within a group, in the order set on that group's **Snapin Run Order** card.
 
-- **Hosts with this (n)** — the member hosts that have it, and
-- **Hosts without it (n)** — the member hosts that don't.
+An item present in more than one of those places is included **once**, at the
+earliest position it appears. So a snapin a host holds directly and also
+receives from two groups runs once, in the host's position.
 
-The *without* set is exactly what a push-to-all will change. The lists are
-fetched per item, so large groups stay responsive.
+`groupOrder` is the **Group Order** field on the group's General tab, and it
+defaults to `0` on every group — so an install that never touches it resolves
+groups alphabetically. Set it only where two groups genuinely disagree.
 
-### Toggling
+Falling back to name rather than to id is deliberate: it makes the resolved
+order a property of what you configured rather than of what you created first.
+The id tiebreak behind it is what stops two identically named groups — which
+the database does not allow, but which a hand-edited one could hold — from
+resolving unpredictably.
 
-Clicking the checkbox acts on **all** member hosts:
+### The default printer
 
-```
-None  --click-->  All        (add to every host)
-Some  --click-->  All        (add to the hosts that lack it; modules flip
-                              a disabled override back to enabled)
-All   --click-->  None       (remove from every host)
-```
+Same precedence, applied to one value:
 
-So an indeterminate item resolves to *All* first; the destructive
-remove-from-all only happens on a second click through the checked state.
+- a host that has set its own default printer keeps it;
+- otherwise the default is taken from the **first group in the resolved
+  order** that names one — the lowest **Group Order**, and alphabetically
+  first among groups sharing one;
+- if no group names one, the host has no default.
+
+A group's default is set on **Associations → Printer Associations → Group
+Default Printer**, and the hint there reads `Group default: <printer>` or
+`Group default: (none)` — it is the group's own answer, not a summary of what
+its members happen to have.
+
+### Modules: the third state
+
+A snapin or printer is a thing a host either has or does not. A module is a
+**switch**, so it takes a third answer.
+
+| Tier | What it means | Beats |
+|---|---|---|
+| Host says **Off** | The module does not run on this host | everything |
+| Host says **On** | The module runs on this host | group grants |
+| A group **grants** it | The module runs on this host | nothing below |
+| Nothing anywhere | The module does not run | — |
+
+**Lowest tier wins, and only a host may say Off.** A group grant is
+presence-only — a group either grants a module or says nothing about it — so
+two groups can only ever union and can never contradict each other. That
+absence of a "disabled" grant is the whole reason there is no conflict to
+resolve.
+
+The host's **Modules** tab is therefore a dropdown, not a checkbox: *On*,
+*Off*, *Not set*. *Not set* is the absence of an opinion, and it is what
+unticking the old checkbox actually meant — which is why a checkbox could not
+express this and had to go.
 
 ---
 
-## Configuration values (shared hints)
+## When it is worked out
 
-Per-host configuration fields show a muted hint beneath the control:
+| | Resolved | Editing the group afterwards |
+|---|---|---|
+| **Snapins** | at task creation | does **not** change a queued task — re-task to pick it up |
+| **Printers** | live, on every client check-in | reaches machines on their next check-in |
+| **Modules** | live, on every client check-in | reaches machines on their next check-in |
+
+A task is a promise about a specific moment: you queued *that* set of snapins
+for *that* machine, and a machine that reboots into the job three hours later
+should get the job you queued. Printers and modules have no task to hang a
+snapshot on — the FOG client reconciles them on a schedule — so a removal has
+to be able to reach the machine on its own.
+
+>[!warning] Printer level "FOG Handles all printers"
+>On that level the list FOG sends is authoritative in **both** directions: the
+>client removes every installed printer that is not on it, including printers
+>FOG did not install. That has always been true of that mode, and is worth
+>re-reading now that a group can add to the list.
+
+---
+
+## Pushed values (deprecated)
+
+Everything in this section applies a value **once**, to the hosts that are
+members at the moment you press *Update*. A host added afterwards does not get
+it; a host removed keeps it. Nothing records that the write happened, so
+nothing can replay it.
+
+These controls carry a deprecation notice on the group page and are removed in
+a later release. **Use Hosts → tick → Edit selected hosts instead** — it does
+the same job over any selection, with an explicit *No change* / *Set on all* /
+*Clear on all* per field.
+
+### The shared-value hints
+
+Because these fields are per-host, the group page shows a muted hint beneath
+each control saying what the members currently hold:
 
 | Hint | Meaning |
 |------|---------|
@@ -114,57 +183,54 @@ The hint is **information only** — it never prefills the input.
 
 ### The no-clobber convention
 
-Saving a group config tab pushes to all member hosts, but:
+Saving one of these tabs pushes to all current members, but:
 
-- **Blank field** → leave each host's value **unchanged** (no clobber).
-- Literal **`NULL`** (case-insensitive) → **clear** the field on every host.
-- **Any other value** → push that value to every host.
+- **blank field** → leave each host's value **unchanged**;
+- literal **`NULL`** (case-insensitive) → **clear** the field on every host;
+- **any other value** → push that value to every host.
 
-This is what lets you, say, set one kernel argument across a group without
-wiping every other per-host field.
+That is what lets you set one kernel argument across a group without wiping
+every other per-host field. It is also the convention *Edit selected hosts*
+replaces with something explicit, because "blank means leave alone" is
+undiscoverable and gives you no way to store the literal string `NULL`.
 
 ### Active Directory
 
-- **Domain joining** is a tri-state select: **No change** (leave each host's
-  join state alone), **Enable on all**, or **Disable on all**.
-- Domain / OU / username follow the no-clobber convention above. The password's
-  32-asterisk placeholder means "unchanged".
-- Selecting **Enable on all** populates the blank fields from the FOG AD
-  defaults (same as the host page) — only when you choose it, never just from
-  existing state.
+- **Domain joining** is a tri-state select: **No change**, **Enable on all**,
+  **Disable on all**.
+- Domain, OU and username follow the no-clobber convention above. The
+  password's 32-asterisk placeholder means "unchanged".
+- Choosing **Enable on all** populates the blank fields from the FOG AD
+  defaults — only when you choose it, never just from existing state.
 - A **Current member-host AD state** summary shows join/domain/OU/username
   uniformity above the form.
 
 ### Auto-logout
 
-Blank by default (the global minimum is shown only as a placeholder). A blank
-save leaves each host's auto-logout alone; a number pushes to all (under five
-minutes disables it). The hint reads `Hosts: N min (all)`, `(varies)`, or
+Blank by default, with the global minimum shown only as a placeholder. A blank
+save leaves each host alone; a number pushes to all, and under five minutes
+disables it. The hint reads `Hosts: N min (all)`, `(varies)` or
 `(default on all)`.
 
 ### General fields
 
-Kernel, kernel arguments, init, primary disk, BIOS/EFI exit, and product key
-each carry a `Hosts: …` hint. The kernel/args/init/disk inputs prefill from the
-**group's own template** (the group stores these); the hint reports the
-*members'* state independently. Push still honors the no-clobber convention.
-
-### Default printer
-
-The printer **Default** selector shows a `Hosts default: <printer> (all)`,
-`(varies)`, or `(none on all)` hint. Setting a default is an explicit action
-that only touches member hosts which have that printer associated.
+Kernel, kernel arguments, init, primary disk, BIOS/EFI exit and product key
+each carry a `Hosts: …` hint. The kernel, args, init and disk inputs prefill
+from the **group's own template** — a group does store those four for itself —
+while the hint reports the *members'* state independently. Pushing still
+honors the no-clobber convention.
 
 ### Enforce hostname / AD-join reboots
 
 A tri-state select — **No change / Enable on all / Disable on all** — with a
-`Hosts: enabled (all) / disabled (all) / (varies)` hint. *No change* leaves each
-host alone. (Stored in the `hostEnforce` `enum('0','1')` column, written as a
-string — passing an int would index the enum rather than match its value.)
+`Hosts: enabled (all) / disabled (all) / (varies)` hint.
 
 ---
 
 ## Out of scope
 
-- **Force reboot** is a global setting (`FOG_TASK_FORCE_REBOOT`) and a per-task
-  option, not per-host configuration, so it has no group shared-state control.
+- **Force reboot** is a global setting (`FOG_TASK_FORCE_REBOOT`) and a
+  per-task option, not per-host configuration, so it has no group control.
+- **Tasking** is not shared state. A task acts on the membership at the moment
+  you start it, which is what a task should do, and is unaffected by
+  everything on this page.

--- a/docs/management/web/ad-integration.md
+++ b/docs/management/web/ad-integration.md
@@ -59,6 +59,18 @@ three different levels, applied in order of most to least specific:
 -   **Individual host** — Web UI: Host Management → select a host →
     Active Directory. See below for the field-by-field walkthrough.
 
+>[!warning] FOG 1.6: use the Hosts list, not the group page
+>The group-level batch apply above is **deprecated in FOG 1.6** and is
+>removed in a later release. It still works and still behaves exactly as
+>described — one-time, to current members only — but the supported way to set
+>AD across many hosts is now **Hosts → tick the hosts → Edit selected
+>hosts**, where each field carries an explicit *No change* / *Set on all* /
+>*Clear on all*. That works on any selection, not only on a group, and can be
+>repeated whenever you like.
+>
+>Nothing changes on FOG 1.5, where the group page is the only way to do this.
+>See [[1.6/management/web/groups#Settings that are no longer on the group page|Group Management]].
+
 To set up a single host to use AD:
 
 -   Navigate to the hosts section of the FOG management portal and

--- a/docs/management/web/dashboard.md
+++ b/docs/management/web/dashboard.md
@@ -92,7 +92,7 @@ Menu Logo | Name | Description
 ![[dashboard-ico.png]] | **Home/Dashboard** | This is the home screen of the FOG management portal.
  ![[users-ico.png]] | **[User Management](users.md)** |  Individual administrators of the FOG resources.
 ![[hosts-ico.png]] | **[hosts](hosts.md)** |  This section houses the hosts, which are the pcs to be imaged or to extract images from.
-![[groups.ico.png]] | **[groups](groups.md)** | This section houses groups, which are similar PCS' that need tasks done en-masse.
+![[groups.ico.png]] | **[[1.6/management/web/groups\| Group Management]]** | This section houses groups, which are similar PCs that need tasks done en-masse. On FOG 1.6 a group also **owns** the snapins and printers it hands to its members.
 ![[images-ico.png]] | **[[1.6/management/web/images\| Image Management]]** | This section allows you to manage the image files stored on the FOG server.
 ![[Storage-ico.png]] | **[storage-node](storage-node.md)** | This section allows you to add/remove storage nodes from the FOG system.
 ![[snapin-ico.png]] | **[Snapin Management](snapins.md)** | This section provides ways to automate various post-imaging tasks such as silently installing programs

--- a/docs/management/web/index.md
+++ b/docs/management/web/index.md
@@ -15,11 +15,16 @@ tags:
 
 Documentation related to how to use the web management ui.
 
->[!info] Site Scoping, LDAP, Host Management, Image Management, Storage Node
->Management, Multicast Sessions, Report Management, Fog Configuration and
->Plugins differ between FOG 1.5 and 1.6 and are covered separately — see
->[[1.5/management/web/index|the 1.5 pages]] or
+>[!info] Site Scoping, LDAP, Host Management, **Group Management**, Image
+>Management, Storage Node Management, Multicast Sessions, Report Management,
+>Fog Configuration and Plugins differ between FOG 1.5 and 1.6 and are covered
+>separately — see [[1.5/management/web/index|the 1.5 pages]] or
 >[[1.6/management/web/index|the 1.6 pages]].
+>
+>Group Management is the newest of those and the difference is the largest: on
+>1.6 a group **owns** its snapins and printers and hands them to every member,
+>including hosts added later, where 1.5 copied rows onto whichever hosts were
+>members at the time.
 
 **Using the Interface**
 
@@ -39,7 +44,6 @@ Documentation related to how to use the web management ui.
 
 **Imaging Objects**
 
-- [[groups|Group Management]]
 - [[snapins|Snapin Management]]
 - [[printers|Printer Management]]
 

--- a/docs/management/web/printers.md
+++ b/docs/management/web/printers.md
@@ -238,6 +238,15 @@ A printer shared through a linux CUPS setup
 
 -   Linking printers to hosts can be done from either the hosts section
     or the groups section.
+
+>[!info] FOG 1.6: the two are not the same operation
+>On FOG 1.5 both write the same thing — a printer row on each host. On 1.6 the
+>**group** side is a grant: the printer belongs to the group and reaches every
+>member, including hosts added later, and revoking it takes the printer off
+>those machines again. The **host** side is still a direct assignment that
+>belongs to that machine and is unaffected by any group. A host that gets the
+>same printer both ways installs it once. See
+>[[1.6/management/web/groups|Group Management]].
 -   In the hosts section find the host you would like to add a printer
     to, click on the edit button associated with that host.
 -   In the host menu, click on the **Printers** button.

--- a/docs/management/web/snapins.md
+++ b/docs/management/web/snapins.md
@@ -139,6 +139,13 @@ For a Snapin Pack, use the `[FOG_SNAPIN_PATH]` token in the argument fields to p
 
 The optional **Template** drop-down on the create form is a convenience only: pick a type (MSI, PowerShell, etc.) to pre-fill the command fields with a sensible starting point, then edit them as needed. It does not change what is stored — only what the fields are seeded with.
 
+>[!info] FOG 1.6: Chocolatey templates
+>1.6 adds two [Chocolatey](https://chocolatey.org/) entries to the template
+>lists — one for each snapin type — so you can hand package installs to
+>Chocolatey instead of packaging installers yourself. They need a little
+>setting up to be useful, so they have their own page:
+>[[chocolatey-snapins|Install software with Chocolatey snapins]].
+
 ## Linking the Snapin to Hosts
 
 In order for a snapin to be deployed it must be linked with a host. To do this perform the following:

--- a/quartz/quartz.config.yaml
+++ b/quartz/quartz.config.yaml
@@ -177,10 +177,10 @@ plugins:
           const explicitOrder = {
             "installation/server": ["requirements", "virtualization"],
             "kb/how-tos": ["capture-an-image", "deploy-an-image", "fog-client-example-tasks", "change-fog-server-ip-address", "bios-and-uefi-co-existence", "uefi-boot-entries", "deploy-dual-boot-multi-disk-image", "add-extend-a-2nd-virtual-hdd", "post-download-scripts"],
-            "management/web": ["users", "roles", "oidc", "ad-integration", "groups", "snapins", "printers", "tasks", "dashboard", "service"],
-            "1.5/management/web": ["plugins", "ldap", "site-scoping", "hosts", "reports", "storage-node", "config", "images", "multicast"],
+            "management/web": ["users", "roles", "oidc", "ad-integration", "snapins", "printers", "tasks", "dashboard", "service"],
+            "1.5/management/web": ["plugins", "ldap", "site-scoping", "hosts", "groups", "reports", "storage-node", "config", "images", "multicast"],
             "1.5/kb/reference": ["pki-zones", "netboot-transport-and-pki", "pki-glossary", "bringing-your-own-ca", "secure-boot-trust-stores", "secure-boot-technical-details", "csv_import_export", "ping-hosts-service", "referential-integrity"],
-            "1.6/management/web": ["plugins", "ldap", "site-scoping", "hosts", "reports", "storage-node", "config", "images", "multicast"],
+            "1.6/management/web": ["plugins", "ldap", "site-scoping", "hosts", "groups", "reports", "storage-node", "config", "images", "multicast"],
             "1.6/kb/reference": ["pki-zones", "netboot-transport-and-pki", "pki-glossary", "bringing-your-own-ca", "secure-boot-trust-stores", "secure-boot-technical-details", "csv_import_export", "ping-hosts-service", "referential-integrity"],
           }
 


### PR DESCRIPTION
## Groups

ADR 0038 changed what a group **is**, and the published pages describe the model it replaced. On 1.5 a group owned nothing: pressing a button on the group page wrote rows onto whichever hosts were members at that instant. In 1.6 a group owns its snapins and printers, and every member gets them — including hosts added later.

`docs/management/web/groups.md` is **forked rather than edited**, because the two behaviors cannot share a page. 1.5's becomes `docs/1.5/management/web/groups.md` with its body untouched; `docs/1.6/management/web/groups.md` is written from scratch. It describes how groups work *now* rather than what changed, with the 1.5 differences placed where a 1.5 admin lands.

Three sections exist because of specific questions people will ask:

- **"Settings that are no longer on the group page"** maps every imperative control to its **Edit selected hosts** field, and records that Building was *removed*, not moved. Someone will look for the image field, not find it, and conclude it was deleted.
- **"Snapins are a snapshot, printers are live"** exists because people will assume both work the same way. They do not — a snapin resolves when a task is created, a printer resolves on every check-in — so *"did my change take effect?"* has two different answers depending on which tab you were on.
- **"Hosts that already carry copies"** answers *"I removed the host from the group and it still has the snapin."* Pre-1.6 copies are real host-owned rows, the grant model has no record they came from a group, and nothing retroactively cleans them.

`docs/1.6/management/web/hosts.md` gains the mass-edit workflow and a rewritten *Creating Host Groups*, since that is where the moved settings now live. `group-shared-state.md` is rewritten as the reference companion. persistentgroups' retirement, including the trigger drop, is recorded on the plugins page.

### Unversioned pages

Checked rather than assumed. Five described the old model and are **marked rather than forked**, each being one paragraph out of date rather than wrong throughout: `ad-integration` (setting AD on a group to push it), `printers` (treating the group and host operations as the same thing), `dashboard` (link only), `deploy-an-image` (the Host Groups step). **`tasks.md` needed nothing** — group tasking is genuinely unchanged.

## Chocolatey

Separately: 1.6 adds two Chocolatey snapin templates (fogproject GH-356, PR FOGProject/fogproject#1602). They need enough setting up to warrant their own page rather than a paragraph:

- Chocolatey must already be installed — neither template installs it.
- The full path to `choco.exe` matters, because the client runs as a service and inherits the `PATH` it was *started* with. A bare `choco` works by hand and fails as a snapin.
- **The uploaded file must end in `.config`** or `choco` reads it as a package name. This is load-bearing and non-obvious, so the page says *why*: `SnapinManagement.php` stores the uploaded filename verbatim, the client writes it out under that same name, and `choco install` decides how to read its argument from the extension.

The page also covers why there is no `upgrade` counterpart (`choco upgrade` rejects a packages.config outright) and why the placeholder `.bat` workaround is no longer needed — that workaround is what the issue was built around, so leaving it unexplained would leave people still doing it.

## Verification

Site builds clean: 181 files, no errors, no broken links. `/groups` redirects to the 1.6 page, `/groups-1.5` to the old one; every inbound cross-link and anchor resolves.

Depends on FOGProject/fogproject#1649 for the **Group Order** field this documents.