### PR TITLE
Document the removal of the ClamAV virus scan in 1.6

### DIFF
--- a/docs/1.6/index.md
+++ b/docs/1.6/index.md
@@ -56,6 +56,7 @@ apply to you as written — [[index|start there]].
 - [[1.6/kb/reference/netboot-transport-and-pki|Netboot Transport and PKI]]
 - [[1.6/kb/reference/csv_import_export|CSV Import / Export]]
 - [[1.6/kb/reference/referential-integrity|Referential Integrity]]
+- [[1.6/kb/reference/virus-scan-removed|The virus scan is gone in 1.6]]
 - [[1.6/kb/reference/bringing-your-own-ca|Bringing Your Own CA]]
 - [[1.6/kb/reference/secure-boot-trust-stores|Secure Boot: The Two Trust Stores]]
 - [[1.6/kb/reference/secure-boot-technical-details|Secure Boot Technical Details]]

--- a/docs/1.6/kb/integrations/api.md
+++ b/docs/1.6/kb/integrations/api.md
@@ -282,12 +282,15 @@ task with a `taskTypeID` key, for example:
 | 18 | Fast Wipe |
 | 19 | Normal Wipe |
 | 20 | Full Wipe |
-| 21 | Virus Scan |
-| 22 | Virus Scan - Quarantine |
 
 >[!note] The IDs are not contiguous
 >There is intentionally no task type `9`, and `8` is Multi-Cast — pass
 >the ID from the table, not the row position.
+
+>[!warning] 21 and 22 no longer exist
+>They were the two virus-scan types, and the 1.6 upgrade deletes them —
+>queueing either now fails. See
+>[[1.6/kb/reference/virus-scan-removed|The virus scan is gone in 1.6]].
 
 >[!note] Assign an image first
 >You must assign an image to the host (and the image must be enabled) before

--- a/docs/1.6/kb/reference/index.md
+++ b/docs/1.6/kb/reference/index.md
@@ -28,3 +28,7 @@ tags:
 **Database**
 
 - [[1.6/kb/reference/referential-integrity|Referential Integrity]]
+
+**Removed in 1.6**
+
+- [[1.6/kb/reference/virus-scan-removed|The virus scan is gone in 1.6]]

--- a/docs/1.6/kb/reference/virus-scan-removed.md
+++ b/docs/1.6/kb/reference/virus-scan-removed.md
@@ -1,0 +1,147 @@
+---
+title: The virus scan is gone in 1.6
+aliases:
+    - The virus scan is gone in 1.6
+    - Virus Scan
+    - Virus Scan - Quarantine
+    - Virus History
+    - ClamAV
+    - Anti-Virus
+    - Antivirus
+description: "FOG 1.6 removes the ClamAV virus scan task types and the virus table. Why it went, what the upgrade deletes, and what to do instead"
+context_id: virus-scan-removed
+tags:
+    - 1_6-changes
+    - kb
+    - reference
+    - tasks
+---
+
+# The virus scan is gone in 1.6
+
+>[!info] FOG 1.6
+>FOG 1.5 offers two virus-scan task types and a Virus History view. **FOG 1.6
+>removes both**, and the database upgrade drops the table behind them. This
+>page explains what went and why. On 1.5 the feature is unchanged — see
+>[[1.5/management/web/reports|Report Management (1.5)]].
+
+If you have upgraded to 1.6 and the **Virus Scan** and **Virus Scan -
+Quarantine** entries are missing from a host's or group's task list, they were
+removed deliberately. Nothing is misconfigured and there is no setting to turn
+them back on.
+
+## Why it was removed
+
+**It had not worked on 1.6 for the whole life of the branch.**
+
+The scan itself ran on the client. FOS — the small Linux image a machine boots
+into for FOG tasks — carried a script, `bin/fog.av`, that loaded ClamAV,
+updated its definitions, scanned the disk, and then posted what it found back
+to the server at `service/av.php`.
+
+FOG 1.6 never carried that endpoint across from 1.5. Look for it in the
+webroot of each and only one of them has it:
+
+```
+$ ls /var/www/html/fog/service/av.php
+# on a 1.5 server:  /var/www/html/fog/service/av.php
+# on a 1.6 server:  No such file or directory
+```
+
+So on 1.6 the whole sequence ran and then threw its results away against a
+404. The machine booted, downloaded definitions, scanned every file on the
+disk, and reported into nothing.
+
+And there was nothing waiting to receive them in any case. 1.6 has no virus
+model, no manager, no report and no page — the only thing left of the feature
+was the `virus` database table, holding rows a 1.5 install had written before
+the upgrade, which 1.6 has had no way to display since.
+
+What remained on offer, then, was two task types for a scan that could not
+report, and a `clamav=` kernel argument pointing at a boot image with nowhere
+to send its findings. Removing them is removing an option that could only
+waste a machine's time.
+
+>[!note] This is a removal, not a regression
+>The scan being broken on 1.6 was not noticed for a long time precisely
+>because nothing errors: the task queues, the machine boots, the scan runs,
+>and the machine reboots. Everything looks like it worked. Only the results
+>are missing, and there was no page on which to notice their absence.
+
+## What the upgrade does
+
+When you run the 1.6 database upgrade, it:
+
+- **deletes the two task types** — `Virus Scan` (21) and `Virus Scan -
+  Quarantine` (22), plus the original 1.x `Virus Scan` (9) if you are
+  restoring from a very old database;
+- **deletes any tasks of those types**, queued, scheduled or historical;
+- **drops the `virus` table.**
+
+Every task list in the web UI is built from the task-types table itself, so
+removing those rows is what clears the entries from the host page, the group
+page, the queue-task modal and the API — all at once, with no separate step.
+
+The upgrade records how many rows of each kind it removed, in the server log
+and in the audit log, so you can find out afterward exactly what went.
+
+### What you lose, stated plainly
+
+| Thing | What happens |
+|---|---|
+| A **scheduled** virus scan | Deleted. It could never have run again, so nothing usable is lost. |
+| A queued or historical **task** row | Deleted. |
+| The **run history** of past scans | **Kept.** |
+| Rows in the **`virus` table** | Deleted with the table. These are 1.5-era leftovers 1.6 could not display. |
+
+The run history survives because FOG already keeps task history somewhere
+else, deliberately: the **task log** stores the task type as *text* rather
+than as a reference. A scan that ran in 2024 still appears there, still named
+`Virus Scan`, after the task type it pointed at has gone. That is the same
+reasoning that let the old imaging log be retired — the log of what happened
+is not the same record as the definition of what could be done.
+
+>[!important] Take a database backup before upgrading
+>Good practice for any upgrade, and this one drops a table. If you want the
+>contents of `virus` from a 1.5 install for your own records, export it
+>before you upgrade — afterward it is gone.
+
+## What to do instead
+
+**Scan from inside the running operating system, not from a boot image.** That
+is where antivirus is designed to work: it can see the running processes, the
+registry, the user profiles and the files that are actually in use, and it can
+act on what it finds. An offline scan of a mounted partition sees a subset of
+that and cannot quarantine anything the OS will not later undo.
+
+FOG's part in this is deployment and scheduling, which it is good at:
+
+- **Install your antivirus with a snapin.** If your hosts use Chocolatey,
+  [[chocolatey-snapins|the Chocolatey templates]] will install and update a
+  package for you; otherwise a normal snapin running the vendor's silent
+  installer does the job.
+- **Grant it to a group** so every member gets it, including hosts you add
+  later — see [[1.6/management/web/groups|Group Management]].
+- **Let the antivirus schedule its own scans.** Every product worth deploying
+  has scheduling built in, and it will run against a live system rather than
+  against a disk that is not booted.
+
+If what you actually want is to inspect a machine that will not boot, that is
+a different job from routine antivirus, and a rescue medium is the right tool
+for it.
+
+## The FOS side
+
+`bin/fog.av` and ClamAV in the FOS buildroot configuration are removed
+separately, in the FOS repository. Once the server change above is in, nothing
+can set `mode=clamav`, so the script is unreachable regardless of which FOS
+version a server is serving — an older FOS on a 1.6 server simply never gets
+asked to scan.
+
+## See also
+
+- [[tasks|Task Management]] — the task types that remain
+- [[snapins|Snapin Management]] and
+  [[chocolatey-snapins|Install software with Chocolatey snapins]]
+- [[1.6/management/web/groups|Group Management]] — granting a snapin to every
+  member of a group

--- a/docs/1.6/management/web/hosts.md
+++ b/docs/1.6/management/web/hosts.md
@@ -261,7 +261,7 @@ $subnets | ForEach-Object { # loop through each subnet
     button or on the Host Name itself. Clicking on the edit button will
     display all the properties that were shown during host creation with
     the addition of snapin, printers, active directory, service
-    settings, hardware, virus history, and login information.
+    settings, hardware, and login information.
 -   The entire host object can be removed from the FOG system by
     clicking on the delete option at the bottom of the Host Menu.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -47,7 +47,8 @@ imaging/cloning and network management solution.
 -   Change hostname and join domain
 -   Track user access on computers, automatic log off and shutdown on
     idle timeouts
--   Anti-Virus
+-   Anti-Virus — *FOG 1.5 only;*
+    *[[1.6/kb/reference/virus-scan-removed|removed in 1.6]]*
 -   Disk wiping
 -   Restore deleted files
 -   Bad blocks scan

--- a/docs/management/web/tasks.md
+++ b/docs/management/web/tasks.md
@@ -37,8 +37,8 @@ tags:
 	-   Fast Wipe
 	-   Normal Wipe
 	-   Full Wipe
-	-   Virus Scan
-	-   Virus Scan - Quarantine
+	-   Virus Scan *(FOG 1.5 only)*
+	-   Virus Scan - Quarantine *(FOG 1.5 only)*
 	-   Donate
 	-   Torrent-Cast
 
@@ -122,6 +122,14 @@ This task will look for bad blocks on the hard disk and report them back to the 
 This task will load an application that can be used to recover lost files from the hard disk.
 
 ### Virus Scan
+
+>[!warning] Removed in FOG 1.6
+>Both virus-scan task types are gone in 1.6, and the upgrade drops the table
+>behind them. On 1.6 the scan had no working endpoint to report to, so it
+>scanned and discarded every result. See
+>[[1.6/kb/reference/virus-scan-removed|The virus scan is gone in 1.6]] for
+>what the upgrade removes and what to do instead. The description below
+>applies to **FOG 1.5**.
 
 This task will update and load ClamAV and scan the partition for viruses. It will either scan and report or scan and quarantine files, it will also report back to the management portal with the results of the scan.
 

--- a/quartz/quartz.config.yaml
+++ b/quartz/quartz.config.yaml
@@ -176,10 +176,10 @@ plugins:
 
           const explicitOrder = {
             "installation/server": ["requirements", "virtualization"],
-            "kb/how-tos": ["capture-an-image", "deploy-an-image", "fog-client-example-tasks", "change-fog-server-ip-address", "bios-and-uefi-co-existence", "uefi-boot-entries", "deploy-dual-boot-multi-disk-image", "add-extend-a-2nd-virtual-hdd", "post-download-scripts"],
+            "kb/how-tos": ["capture-an-image", "deploy-an-image", "fog-client-example-tasks", "change-fog-server-ip-address", "bios-and-uefi-co-existence", "uefi-boot-entries", "deploy-dual-boot-multi-disk-image", "add-extend-a-2nd-virtual-hdd", "chocolatey-snapins", "post-download-scripts"],
             "management/web": ["users", "roles", "oidc", "ad-integration", "snapins", "printers", "tasks", "dashboard", "service"],
             "1.5/management/web": ["plugins", "ldap", "site-scoping", "hosts", "groups", "reports", "storage-node", "config", "images", "multicast"],
-            "1.5/kb/reference": ["pki-zones", "netboot-transport-and-pki", "pki-glossary", "bringing-your-own-ca", "secure-boot-trust-stores", "secure-boot-technical-details", "csv_import_export", "ping-hosts-service", "referential-integrity"],
+            "1.5/kb/reference": ["pki-zones", "netboot-transport-and-pki", "pki-glossary", "bringing-your-own-ca", "secure-boot-trust-stores", "secure-boot-technical-details", "csv_import_export", "ping-hosts-service", "referential-integrity", "virus-scan-removed"],
             "1.6/management/web": ["plugins", "ldap", "site-scoping", "hosts", "groups", "reports", "storage-node", "config", "images", "multicast"],
             "1.6/kb/reference": ["pki-zones", "netboot-transport-and-pki", "pki-glossary", "bringing-your-own-ca", "secure-boot-trust-stores", "secure-boot-technical-details", "csv_import_export", "ping-hosts-service", "referential-integrity"],
           }


### PR DESCRIPTION
fogproject [GH-328](https://github.com/FOGProject/fogproject/issues/328) / FOGProject/fogproject#1608 removes the two virus-scan task types and drops the `virus` table. **Six pages still described the feature as available.**

## The new page

`docs/1.6/kb/reference/virus-scan-removed.md` exists because the removal will read as a regression to anyone who doesn't know the history. It wasn't.

**The scan had not worked on 1.6 for the whole life of the branch.** FOS `bin/fog.av` posts its findings to `service/av.php`, and 1.6 never carried that endpoint across from 1.5 — verifiable on any pair of servers, so the page says how to check:

```
$ ls /var/www/html/fog/service/av.php
# on a 1.5 server:  /var/www/html/fog/service/av.php
# on a 1.6 server:  No such file or directory
```

A machine booted, downloaded definitions, scanned every file on the disk, and posted the results into a 404. Nothing errors anywhere in that sequence, which is why it went unnoticed — and there was no page on which to notice the missing results either, since 1.6 has no virus model, manager, report or page, only rows a 1.5 install left behind.

The page then covers:

- **What the upgrade deletes** — both task types, any tasks of those types including scheduled ones, and the table.
- **What survives** — the run history, because `taskLog` stores the task type as *text* rather than as a reference, so a scan from 2024 still appears under its own name after the type it pointed at has gone. Worth stating explicitly, since "my task history is gone" is the obvious next worry.
- **Take a backup first**, since a table is dropped and the `virus` rows are unrecoverable afterward.
- **What to do instead** — deploy real antivirus with a snapin, grant it to a group, and let it schedule its own scans against a live system rather than a mounted partition.

## The five existing pages

| Page | Problem |
|---|---|
| `1.6/kb/integrations/api.md` | Listed task type ids **21 and 22**, which no longer exist — queueing either now fails. Removed, with a note saying where they went. |
| `1.6/management/web/hosts.md` | Listed **virus history** among what the host page shows. It does not. |
| `management/web/tasks.md` | Unversioned. Task-type entries get a *(FOG 1.5 only)* marker; the `### Virus Scan` section gets a callout above the 1.5 description, which is left intact. |
| `docs/introduction.md` | Unversioned. "Anti-Virus" in the feature list, now marked 1.5-only. |
| `1.5/*` | **Correct as-is** — 1.5 still has the endpoint and the feature. Untouched. |

`management/web/tasks.md` and `introduction.md` are marked rather than forked: each is one item out of date rather than wrong throughout, and forking a 193-line page over two entries buys nothing.

## Verification

Builds clean — 182 files, no errors, no broken links. All five inbound links resolve, `/virus-scan-removed` redirects correctly, and the page carries `Virus Scan`, `ClamAV`, `Antivirus` and `Virus History` as aliases so a search for any of them lands on it.