### PR TITLE
The group page's push-to-all controls are gone, not deprecated

### DIFF
--- a/docs/1.6/management/web/groups.md
+++ b/docs/1.6/management/web/groups.md
@@ -145,11 +145,16 @@ enforcement) offer *No change*, *Enable on all* and *Disable on all* instead.
 >| Screen resolution | Edit selected hosts → **Host Screen Resolution** |
 >| Auto log out time | Edit selected hosts → **Auto Log Out Time (in minutes)** |
 >| Building | **Removed.** Nothing read it and nothing wrote it — it was a leftover column, not a setting. |
+>| Location, OU *(plugins)* | Edit selected hosts → **Host Location** / **Host OU** |
 
-The old controls are **still on the group page in 1.6**, marked deprecated, so
-nobody loses a workflow in the middle of an upgrade. They are removed in a
-later release. Where they remain, they still behave the old way: the value is
-applied **once**, to the hosts that are members at that moment.
+>[!important] These controls are gone from the group page, not hidden
+>If you are looking for one of them on a group and cannot find it, that is
+>why. There is no setting to bring them back and no compatibility mode. The
+>table above is the complete map of where each one went.
+>
+>The `location` and `ou` plugins each had a group tab doing the same thing.
+>Those are gone too, and both settings appear in **Edit selected hosts**
+>alongside the built-in fields.
 
 ## Groups as labels: doing it from the Hosts list
 
@@ -173,9 +178,9 @@ there is no second step, and no button to press afterwards.
 
 ## The rest of the group page
 
-- **General** — the group's own name and description, plus the deprecated
-  push-to-all fields described above.
-- **Image** — the deprecated one-time image push.
+- **General** — the group's own name, description and *Group Order*. That is
+  all it holds now; everything else that used to be on this card is in the
+  table above.
 - **Tasks** — deploy, capture, multicast, wake, and the rest, run across every
   current member. Tasking is unchanged: it acts on the membership at the
   moment you start the task, which is what you want from a task.
@@ -187,11 +192,12 @@ there is no second step, and no button to press afterwards.
   **Snapin Run Order** card, which orders the group's own snapins. A host runs
   its own snapins first, then these, in this order. Order only changes
   anything when *Abort snapin sequence on failure* is enabled for the task.
-- **Service Settings → Client Settings** — the group's modules, plus the
-  deprecated screen-resolution and auto-logout pushes.
-- **Service Settings → Active Directory** — deprecated; see the table above.
+- **Service Settings → Client Settings** — the group's modules. Just the
+  grant: screen resolution and auto-logout are set from the Hosts list.
 - **Service Settings → Power Management** — schedules power tasks across
-  members. Not deprecated: it creates tasks rather than copying a value.
+  members. This one stays, because it creates tasks rather than copying a
+  value: a scheduled task is a real thing the group owns, not a value stamped
+  onto whoever happened to be a member.
 - **Inventory**, **Login History**, **History Items** — reporting across the
   group's members.
 - **Site** — which site the group belongs to, if you use site scoping.
@@ -279,7 +285,7 @@ replace, because they also apply to hosts that were already members.
 ## See also
 
 - [[group-shared-state|Group Shared State]] — the detail behind resolution
-  order, precedence, and the deprecated push-to-all controls.
+  order and precedence.
 - [[1.6/management/web/hosts|Host Management]] — the Hosts list, mass edit and
   bulk group membership.
 - [[management/web/snapins|Snapin Management]] and

--- a/docs/1.6/management/web/hosts.md
+++ b/docs/1.6/management/web/hosts.md
@@ -386,6 +386,12 @@ Every field carries its own action, and the default is always to do nothing:
 Fields that are only on or off — joining the domain, hostname enforcement —
 offer *No change*, *Enable on all* and *Disable on all* instead.
 
+>[!note] Plugins can add fields here
+>If you run the **Location** or **OU** plugins, their settings appear in this
+>form alongside the built-in ones. Both used to have their own group tab that
+>rewrote the value on every member; they use this form now, so *No change*
+>works for them exactly as it does for everything else.
+
 Two things follow from the action being separate from the value:
 
 - **A form you open and submit without touching anything changes nothing.**

--- a/docs/kb/reference/group-shared-state.md
+++ b/docs/kb/reference/group-shared-state.md
@@ -30,10 +30,11 @@ what the group page's remaining push-to-all controls do.
 >    ticked box is a row about the group, and every member gets the item,
 >    including hosts added later. Nothing is written onto a host.
 > 2. **Pushed values** — Active Directory, auto-logout, kernel and general
->    fields, screen resolution, image, product key. These are **not** group
->    properties. Pressing *Update* writes the value onto the hosts that are
->    members at that instant, once. They are **deprecated** in 1.6 and removed
->    in a later release; use *Edit selected hosts* on the Hosts list instead.
+>    fields, screen resolution, image, product key. These were **not** group
+>    properties: pressing *Update* wrote the value onto the hosts that were
+>    members at that instant, once. **They are gone from the group page in
+>    1.6.** Use *Edit selected hosts* on the Hosts list instead. The section
+>    below is kept as the record of what they did and why they went.
 
 ---
 
@@ -44,7 +45,7 @@ what the group page's remaining push-to-all controls do.
   - [The default printer](#the-default-printer)
   - [Modules: the third state](#modules-the-third-state)
 - [When it is worked out](#when-it-is-worked-out)
-- [Pushed values (deprecated)](#pushed-values-deprecated)
+- [Pushed values, and why they are gone](#pushed-values-and-why-they-are-gone)
   - [The shared-value hints](#the-shared-value-hints)
   - [The no-clobber convention](#the-no-clobber-convention)
   - [Active Directory](#active-directory)
@@ -156,22 +157,34 @@ to be able to reach the machine on its own.
 
 ---
 
-## Pushed values (deprecated)
+## Pushed values, and why they are gone
 
-Everything in this section applies a value **once**, to the hosts that are
-members at the moment you press *Update*. A host added afterwards does not get
-it; a host removed keeps it. Nothing records that the write happened, so
-nothing can replay it.
+>[!warning] Removed from the group page in FOG 1.6
+>Everything in this section describes how these controls behaved **on FOG
+>1.5**, and on 1.6 before they were removed. They are no longer on the group
+>page. **Use Hosts → tick → Edit selected hosts instead** — it does the same
+>job over any selection, with an explicit *No change* / *Set on all* /
+>*Clear on all* per field.
+>
+>It is kept because the behavior explains a class of question that will keep
+>arriving from 1.5 installs: values that appear on a host with no record of
+>how they got there.
 
-These controls carry a deprecation notice on the group page and are removed in
-a later release. **Use Hosts → tick → Edit selected hosts instead** — it does
-the same job over any selection, with an explicit *No change* / *Set on all* /
-*Clear on all* per field.
+Everything in this section applied a value **once**, to the hosts that were
+members at the moment you pressed *Update*. A host added afterwards did not
+get it; a host removed kept it. Nothing recorded that the write had happened,
+so nothing could replay it — which is the whole reason the model was replaced
+rather than repaired.
+
+The two plugin equivalents, the `location` and `ou` group tabs, went the same
+way and for the same reason, with one extra defect: they had no *No change*
+state at all, so saving either tab rewrote the value on **every** member.
 
 ### The shared-value hints
 
-Because these fields are per-host, the group page shows a muted hint beneath
-each control saying what the members currently hold:
+Because these fields were per-host, the group page showed a muted hint beneath
+each control saying what the members held. The same hints appear in **Edit
+selected hosts**, computed over your selection rather than over a group:
 
 | Hint | Meaning |
 |------|---------|

--- a/docs/management/web/ad-integration.md
+++ b/docs/management/web/ad-integration.md
@@ -59,14 +59,16 @@ three different levels, applied in order of most to least specific:
 -   **Individual host** — Web UI: Host Management → select a host →
     Active Directory. See below for the field-by-field walkthrough.
 
->[!warning] FOG 1.6: use the Hosts list, not the group page
->The group-level batch apply above is **deprecated in FOG 1.6** and is
->removed in a later release. It still works and still behaves exactly as
->described — one-time, to current members only — but the supported way to set
->AD across many hosts is now **Hosts → tick the hosts → Edit selected
->hosts**, where each field carries an explicit *No change* / *Set on all* /
->*Clear on all*. That works on any selection, not only on a group, and can be
->repeated whenever you like.
+>[!warning] FOG 1.6: the group page has no Active Directory tab
+>The group-level batch apply described above is **FOG 1.5 only**. It was
+>removed in 1.6, where AD across many hosts is set from **Hosts → tick the
+>hosts → Edit selected hosts**, with each field carrying an explicit
+>*No change* / *Set on all* / *Clear on all*. That works on any selection,
+>not only on a group, and can be repeated whenever you like.
+>
+>The old behavior is why it went: it wrote the AD details onto whichever
+>hosts were members at that instant, so a host added to the group afterward
+>never got them.
 >
 >Nothing changes on FOG 1.5, where the group page is the only way to do this.
 >See [[1.6/management/web/groups#Settings that are no longer on the group page|Group Management]].


### PR DESCRIPTION
These pages were written while the controls carried a deprecation notice, and said so — *"still on the group page in 1.6, marked deprecated ... removed in a later release"*. FOGProject/fogproject#1651 is that release, so the pages now describe a state that does not exist.

## What stays

**The "Where each setting went" table is unchanged.** That is the part someone hunting for the image field actually needs, and it was right the first time.

## What changes

The tense — plus an explicit callout that the controls are **gone**, not moved or hidden:

>These controls are gone from the group page, not hidden. If you are looking for one of them on a group and cannot find it, that is why. There is no setting to bring them back and no compatibility mode.

That distinction matters because *"I can't find it"* and *"it must be elsewhere on this page"* send people looking in different places.

Also updated: the group page's tab-by-tab list (General now holds only name, description and Group Order; the Image and Active Directory tabs are gone), and the note on why **Power Management** survives — it creates tasks rather than copying a value, which is the distinction the whole decision turns on.

## Two additions

**Location and OU join the table.** The plugins had their own group tabs doing the same push, and those went the same way in FOGProject/fog-plugins#36 — so the same question will arrive about them.

**The hosts page notes that plugins can contribute to the mass edit form,** since a reader running those plugins will see fields there that the built-in list does not mention.

## One judgement call

The reference page **keeps** its pushed-values section rather than deleting it, under a warning that it describes 1.5 behavior. It explains a class of question that will keep arriving from 1.5 installs — values sitting on a host with no record of how they got there — and deleting it would leave that unanswerable.

The AD page's callout said the group tab was deprecated but still worked. It is now a plain statement that 1.6 has no group AD tab, with the reason it went.

## Verification

Builds clean — no errors, no broken links. No "deprecated" language remains on any of the three pages.