### PR TITLE
Power Management is still a push, and the mass edit form has tabs

### DIFF
--- a/docs/1.6/management/web/groups.md
+++ b/docs/1.6/management/web/groups.md
@@ -195,12 +195,40 @@ there is no second step, and no button to press afterwards.
 - **Service Settings → Client Settings** — the group's modules. Just the
   grant: screen resolution and auto-logout are set from the Hosts list.
 - **Service Settings → Power Management** — schedules power tasks across
-  members. This one stays, because it creates tasks rather than copying a
-  value: a scheduled task is a real thing the group owns, not a value stamped
-  onto whoever happened to be a member.
+  members. **This one still behaves the 1.5 way**, and knowingly so: see the
+  warning below.
 - **Inventory**, **Login History**, **History Items** — reporting across the
   group's members.
 - **Site** — which site the group belongs to, if you use site scoping.
+
+>[!warning] Power Management is still a one-time push
+>Saving a power schedule on a group writes **one row per host that is a
+>member at that instant**, exactly as the removed controls above did. It is
+>the last control on the group page that still works this way.
+>
+>What that means in practice:
+>
+>- a host **added** to the group afterward gets **no** schedule;
+>- a host **removed** from the group **keeps** the schedule it was given, and
+>  nothing on the group page will take it away — *Delete all* on the group's
+>  Power Management tab only reaches current members;
+>- saving **adds** a schedule rather than replacing the one that is there, so
+>  a host accumulates every schedule any of its groups ever gave it. Saving
+>  the *same* schedule twice is harmless — the row is keyed on the host plus
+>  the cron expression plus the action, so an identical save lands on the row
+>  that already exists — but changing the time and saving again leaves the old
+>  time in place alongside the new one.
+>
+>It was left alone in 1.6 rather than moved, because a schedule is a cron
+>expression plus an action rather than a single value — it does not fit the
+>*No change / Set on all / Clear on all* shape that *Edit selected hosts*
+>uses, and forcing it into that shape would have been worse than leaving it
+>honest. Making it a grant like snapins and printers is the right fix and is
+>a change to the schema, so it is not in this release.
+>
+>Until then, treat the group's Power Management tab as **"apply to whoever is
+>in the group right now"**, and check a host's own Power Management tab when
+>you want to know what it is actually scheduled to do.
 
 ## Modules have one extra rule: only a host can turn one off
 

--- a/docs/1.6/management/web/hosts.md
+++ b/docs/1.6/management/web/hosts.md
@@ -375,6 +375,20 @@ image, kernel, kernel arguments, primary disk, init, product key, BIOS and EFI
 exit type, printer management level, Active Directory, hostname enforcement,
 screen resolution and auto-logout.
 
+The form is split into tabs the same way a single host's own page is —
+**General**, **Active Directory** and **FOG Client**, plus a **Plugins** tab
+when a plugin has added a field — so a setting is in the same place here as it
+is on the host you would otherwise open. The tabs are only a layout: every
+field is submitted whichever tab is on top, so you never have to visit a tab
+to "confirm" the fields you left alone.
+
+**Host Printer Management Level** is the one field whose tab may surprise you.
+On a host's own page it sits on *Printer Associations*, and there is no such
+tab here — you cannot assign printers in bulk, because printers are granted by
+a group rather than copied onto hosts. What is left is the setting that decides
+how hard the FOG client works on printers at each check-in, so it is on **FOG
+Client** alongside screen resolution and auto-logout.
+
 Every field carries its own action, and the default is always to do nothing:
 
 | Action | What it does |
@@ -409,9 +423,14 @@ rather than picking one of them to show you.
 >in a group and press *Update* on the group page. That wrote the value onto
 >whichever hosts were members at that moment. *Edit selected hosts* works on
 >any selection you can build — a search, a filter, a handful of ticks — and
->can be repeated. The group-page controls still exist on 1.6, marked
->deprecated, and are removed in a later release. See
->[[1.6/management/web/groups#Settings that are no longer on the group page|Group Management]].
+>can be repeated. Those group-page controls are **gone** in 1.6 — not hidden,
+>and there is no compatibility mode. See
+>[[1.6/management/web/groups#Settings that are no longer on the group page|Group Management]]
+>for the complete map of where each one went.
+>
+>One control on the group page still behaves the 1.5 way: **Power Management**.
+>It is unchanged in 1.6 and still writes to whoever is a member when you press
+>save.
 
 ### Creating Host Groups
 

--- a/docs/kb/reference/group-shared-state.md
+++ b/docs/kb/reference/group-shared-state.md
@@ -35,6 +35,8 @@ what the group page's remaining push-to-all controls do.
 >    members at that instant, once. **They are gone from the group page in
 >    1.6.** Use *Edit selected hosts* on the Hosts list instead. The section
 >    below is kept as the record of what they did and why they went.
+> 3. **Power Management** — the one push that is **still there** in 1.6, and
+>    still a push. See [Power Management](#power-management) below.
 
 ---
 
@@ -52,6 +54,7 @@ what the group page's remaining push-to-all controls do.
   - [Auto-logout](#auto-logout)
   - [General fields](#general-fields)
   - [Enforce hostname / AD-join reboots](#enforce-hostname--ad-join-reboots)
+- [Power Management](#power-management)
 - [Out of scope](#out-of-scope)
 
 ---
@@ -237,6 +240,37 @@ honors the no-clobber convention.
 
 A tri-state select — **No change / Enable on all / Disable on all** — with a
 `Hosts: enabled (all) / disabled (all) / (varies)` hint.
+
+---
+
+## Power Management
+
+The one control on the group page that is **still** a push in 1.6, and the only
+reason the "pushed values" model above is worth understanding as current
+behavior rather than as history.
+
+Saving a schedule on a group's **Service Settings → Power Management** tab
+writes one `powerManagement` row per host that is a member at that instant. It
+is not a group property and nothing records that the write came from a group.
+
+| | Behavior |
+|---|---|
+| Host added to the group afterward | gets **no** schedule |
+| Host removed from the group | **keeps** the schedule |
+| *Delete all* on the group tab | reaches **current members only** |
+| Saving a second, different schedule | **adds** it; the first stays |
+| Saving the same schedule twice | no-op — the row is keyed on host + cron expression + action |
+
+It was not moved into *Edit selected hosts* with the rest, because a schedule
+is a cron expression plus an action rather than a single value: it has no
+meaningful *Clear on all*, a host may legitimately hold several at once, and
+squeezing it into the three-state shape would have made the form lie about what
+it does. The correct fix is to make it a **grant**, resolved at read time like
+snapins and printers, which needs a group-owned table — a schema change, and so
+not part of this release.
+
+Reading a host's own Power Management tab is the only reliable answer to "what
+is this machine actually scheduled to do".
 
 ---
 


### PR DESCRIPTION
Three corrections and one addition, all to pages written in this same group-split series — so all four are my own errors or my own omissions.

## 1. Power Management is still a one-time push (correction)

`groups.md` said the group's Power Management tab *"stays, because it creates tasks rather than copying a value: a scheduled task is a real thing the group owns"*.

That is wrong. `GroupManagement::groupPowermanagementPost()` reads `$this->obj->get('hosts')` and `insertBatch()`es **one `powerManagement` row per host that is a member at that instant** — the same one-time push as every control ADR 0038 decision 10 removed, and now the last one left on the group page.

The docs now say so, with what actually follows:

| | Behavior |
|---|---|
| Host added to the group afterward | gets **no** schedule |
| Host removed | **keeps** the schedule |
| *Delete all* on the group tab | current members only |
| A second, different schedule | **added**; the first stays |
| The same schedule twice | no-op |

That last row is checked, not assumed — `powerManagement` carries `UNIQUE KEY cron (pmHostID, pmMin, pmHour, pmDom, pmMonth, pmDow, pmAction)` (`commons/schema-expected.php:603`) and `insertBatch` upserts on it. My first draft of that bullet claimed the opposite.

**No code change is proposed here.** A schedule is a cron expression plus an action, not a single value: it has no meaningful *Clear on all* and a host may legitimately hold several, so it does not fit the three-state shape *Edit selected hosts* uses. Making it a **grant** resolved at read time like snapins and printers is the right fix and needs a group-owned table — a schema change, so not this release. The docs say that too, rather than leaving a reader to wonder why one control was left behind.

## 2. Stale deprecation notice (correction)

`hosts.md` still said the group-page push controls *"still exist on 1.6, marked deprecated, and are removed in a later release"*. FOGProject/fogproject#1651 removed them.

## 3. The mass edit tabs (new)

FOGProject/fogproject#1653 and #1654 split the modal into **General / Active Directory / FOG Client**, plus **Plugins** when a plugin contributed a field, mirroring a single host's own page.

Documented with the two things people will actually trip over:

- the tabs are **layout only** — every field posts whichever tab is on top, so you never have to visit a tab to confirm the fields you left alone;
- **Host Printer Management Level** is on FOG Client rather than a printers tab, because you cannot assign printers in bulk — a group grants them.

## 4. `group-shared-state.md`

Gains a Power Management section and lists it as a third kind of group state alongside grants and the removed pushed values.

Built clean: 214 files, 1394 emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166dqQEjAs9fhqUw5zCjvxM