### PR TITLE
Hide the 1.5/1.6 trees from the sidebar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,12 @@ The rules that must not be broken:
   — including a page linking its own headings. An unversioned link there
   resolves to the chooser and silently drops the `#anchor`. From outside the
   trees, an unversioned link is correct: it lands on the chooser.
+- **The version trees are hidden from the sidebar** by the Explorer's
+  `filterFn`, so each forked topic appears in the nav exactly once — as its
+  chooser, in its own section. The 1.5/1.6 pages are reached through the
+  chooser, the pinned pills, and search. Supplying a `filterFn` replaces the
+  plugin default, so the `tags` exclusion must be repeated in it, and
+  `prev-next-nav` must exclude the same trees.
 - **Reading order is encoded twice and both copies must be edited together**:
   `quartz.config.yaml`'s Explorer `sortFn` and `prev-next-nav`'s
   `TOP_ORDER`/`EXPLICIT_ORDER`. The `sortFn` is a string inside YAML, so they

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -129,6 +129,34 @@ it cannot be justified to a reader. List it in `docs/1.5/index.md` under
 - Any wikilink carrying an `#anchor` must be path-qualified. See `CLAUDE.md`
   for why a bare one loses the fragment.
 
+## The version trees are not in the sidebar
+
+The Explorer's `filterFn` hides `docs/1.5/` and `docs/1.6/` from the tree. Their
+pages are reached three ways: the chooser that sits at each forked topic's
+normal place in the tree, the pinned **FOG 1.5** / **FOG 1.6** pills above the
+tree, and search.
+
+This is deliberate. When the trees were shown, the sidebar had six top-level
+sections instead of four, and every forked page appeared in it three times —
+once as its chooser and once inside each version tree. That is more navigation,
+not less, and it buries the topic tree the choosers exist to restore. The
+choosers put each forked topic in exactly one place; showing the trees as well
+undoes that.
+
+Two things follow, and both are enforced by `check-version-split.mjs`:
+
+- **Supplying a `filterFn` replaces the plugin default**, which was
+  `node.slugSegment !== "tags"`. That exclusion has to be repeated, or the tag
+  tree reappears in the sidebar.
+- **`prev-next-nav` applies the same exclusion** (`VERSION_TREES`). Without it,
+  "Next" on the last Development page steps into a tree the reader cannot see.
+  Pages inside a version tree therefore get no Previous/Next of their own, which
+  is correct: they are reached deliberately from a chooser, not by reading the
+  site in order.
+
+The pills stay. The two landing pages list every difference in one place, which
+is the right entry point for "what changed overall" as opposed to one topic.
+
 ## The two nav-order tables
 
 Reading order is encoded **twice**, and the copies must agree:

--- a/quartz/local-plugins/prev-next-nav/dist/components/index.js
+++ b/quartz/local-plugins/prev-next-nav/dist/components/index.js
@@ -166,9 +166,30 @@ function flatten(node, out) {
   for (const child of children) flatten(child, out)
 }
 
+// Mirrors the Explorer's filterFn in quartz.config.yaml. The 1.5/1.6 trees are
+// not in the sidebar, so Previous/Next must not walk into them either --
+// otherwise "Next" from the last Development page steps into a tree the reader
+// cannot see in the nav. Pages inside those trees get no Previous/Next of their
+// own, which is right: they are reached deliberately from a chooser, not by
+// reading the site in order.
+const VERSION_TREES = ["1.5", "1.6"]
+const inVersionTree = (slug) =>
+  VERSION_TREES.some((v) => slug === v || slug.startsWith(v + "/"))
+
+// allFiles carries Quartz's generated 404 page, which is not in the content
+// index and must never be a Previous/Next target. It only surfaced once the
+// version trees stopped being the last thing in reading order, at which point
+// "Next" on the final Development page read "Not Found".
+const NOT_A_DESTINATION = new Set(["404", "tags"])
+
 function buildOrderedList(allFiles) {
   const visible = allFiles.filter(
-    (f) => f.slug && !f.unlisted && f.slug !== "tags" && !f.slug.startsWith("tags/"),
+    (f) =>
+      f.slug &&
+      !f.unlisted &&
+      !NOT_A_DESTINATION.has(f.slug) &&
+      !f.slug.startsWith("tags/") &&
+      !inVersionTree(f.slug),
   )
   const root = new TrieNode([])
   for (const file of visible) root.insert(file.slug.split("/"), file)

--- a/quartz/quartz.config.yaml
+++ b/quartz/quartz.config.yaml
@@ -160,6 +160,27 @@ plugins:
   - source: "@quartz-community/explorer"
     enabled: true
     options:
+      # Keep the 1.5/1.6 version trees out of the sidebar. Their pages are
+      # reached through the version chooser that sits at each forked topic's
+      # normal place in the tree, through the pinned FOG 1.5 / FOG 1.6 pills
+      # above it, and through search. Showing the trees here as well listed
+      # every forked page three times -- once as its chooser and once inside
+      # each version tree -- which is more nav, not less, and buries the topic
+      # tree the choosers exist to restore.
+      #
+      # Supplying filterFn REPLACES the plugin default, so the "tags" exclusion
+      # has to be repeated here or the tag tree comes back.
+      #
+      # prev-next-nav applies the same exclusion, so Previous/Next cannot walk
+      # into a tree the sidebar does not show.
+      filterFn: |
+        (node) => {
+          if (node.slugSegment === "tags") return false
+          if (node.slugSegments.length === 1) {
+            if (node.slugSegment === "1.5" || node.slugSegment === "1.6") return false
+          }
+          return true
+        }
       # Order top-level folders (installation, management, kb, development,
       # then the 1.5/1.6 version trees); alphabetical otherwise. Also applies
       # an explicit per-directory order for sections where plain alphabetical

--- a/scripts/check-version-split.mjs
+++ b/scripts/check-version-split.mjs
@@ -190,6 +190,59 @@ if (!existsSync(cfgPath) || !existsSync(pnnPath)) {
   const cfgOrder = literalAfter(cfg, "const explicitOrder = ")
   const pnnOrder = literalAfter(pnn, "const EXPLICIT_ORDER = ")
 
+  // The version trees are hidden from the sidebar by the Explorer's filterFn.
+  // prev-next-nav must hide them too, or "Next" walks into a tree the reader
+  // cannot see in the nav.
+  const blockScalar = (key) => {
+    const at = cfg.indexOf(`${key}: |`)
+    if (at === -1) return null
+    const out = []
+    for (const line of cfg.slice(at + `${key}: |`.length).split("\n")) {
+      if (line.trim() === "") {
+        out.push("")
+        continue
+      }
+      if (line.match(/^ */)[0].length < 8) break
+      out.push(line.slice(8))
+    }
+    try {
+      return Function(`"use strict";return (${out.join("\n")})`)()
+    } catch {
+      return null
+    }
+  }
+  const explorerFilter = blockScalar("filterFn")
+  const pnnTrees = literalAfter(pnn, "const VERSION_TREES = ")
+
+  if (explorerFilter) {
+    const hiddenByExplorer = VERSIONS.filter(
+      (v) => !explorerFilter({ slugSegment: v, slugSegments: [v], isFolder: true, data: null, children: [] }),
+    )
+    const hiddenByPrevNext = Array.isArray(pnnTrees) ? pnnTrees : []
+    for (const v of hiddenByExplorer) {
+      if (!hiddenByPrevNext.includes(v)) {
+        note(
+          "nav-tables",
+          `the Explorer hides the ${v} tree from the sidebar, but prev-next-nav does not exclude it (VERSION_TREES)`,
+        )
+      }
+    }
+    for (const v of hiddenByPrevNext) {
+      if (!hiddenByExplorer.includes(v)) {
+        note(
+          "nav-tables",
+          `prev-next-nav excludes the ${v} tree, but the Explorer still shows it in the sidebar (filterFn)`,
+        )
+      }
+    }
+    if (explorerFilter({ slugSegment: "tags", slugSegments: ["tags"], isFolder: true, data: null, children: [] })) {
+      note(
+        "nav-tables",
+        'the Explorer filterFn no longer excludes "tags" -- supplying a filterFn replaces the plugin default, so that exclusion has to be repeated',
+      )
+    }
+  }
+
   if (!cfgTop || !pnnTop || !cfgOrder || !pnnOrder) {
     note(
       "nav-tables",

--- a/scripts/check-version-split.test.mjs
+++ b/scripts/check-version-split.test.mjs
@@ -38,6 +38,8 @@ const makeRepo = (opts = {}) => {
     linkIn16 = "[[1.6/management/web/hosts|Host Management]]",
     navOrder = NAV_ORDER,
     topOrder = TOP_ORDER,
+    filterTags = true,
+    versionTrees = ["1.5", "1.6"],
   } = opts
 
   const fm = (o) =>
@@ -93,6 +95,14 @@ const makeRepo = (opts = {}) => {
       "plugins:",
       "  - source: explorer",
       "    options:",
+      "      filterFn: |",
+      "        (node) => {",
+      ...(filterTags ? ['          if (node.slugSegment === "tags") return false'] : []),
+      "          if (node.slugSegments.length === 1) {",
+      `            if (${["1.5", "1.6"].map((v) => `node.slugSegment === "${v}"`).join(" || ")}) return false`,
+      "          }",
+      "          return true",
+      "        }",
       "      sortFn: |",
       "        (a, b) => {",
       `          const topOrder = ${JSON.stringify(topOrder)}`,
@@ -105,6 +115,7 @@ const makeRepo = (opts = {}) => {
     root,
     "quartz/local-plugins/prev-next-nav/dist/components/index.js",
     [
+      `const VERSION_TREES = ${JSON.stringify(versionTrees)}`,
       `const TOP_ORDER = ${JSON.stringify(topOrder)}`,
       `const EXPLICIT_ORDER = ${JSON.stringify(navOrder)}`,
       "",
@@ -196,6 +207,22 @@ test("fails when only one table lists a directory", () => {
   const { code, out } = run(root)
   assert.equal(code, 1)
   assert.match(out, /"kb\/reference" is only in prev-next-nav/)
+  cleanup(root)
+})
+
+test("fails when prev-next-nav does not hide a tree the Explorer hides", () => {
+  const root = makeRepo({ versionTrees: ["1.6"] })
+  const { code, out } = run(root)
+  assert.equal(code, 1)
+  assert.match(out, /Explorer hides the 1\.5 tree .* but prev-next-nav does not exclude it/)
+  cleanup(root)
+})
+
+test("fails when the Explorer filterFn drops the tags exclusion", () => {
+  const root = makeRepo({ filterTags: false })
+  const { code, out } = run(root)
+  assert.equal(code, 1)
+  assert.match(out, /no longer excludes "tags"/)
   cleanup(root)
 })
 

--- a/scripts/show-nav.mjs
+++ b/scripts/show-nav.mjs
@@ -19,8 +19,7 @@
 //   node scripts/show-nav.mjs installation/server management/web
 //   node scripts/show-nav.mjs ""          # top level
 
-import { existsSync } from "node:fs"
-import { readFileSync } from "node:fs"
+import { existsSync, readFileSync } from "node:fs"
 
 const INDEX = "quartz/public/static/contentIndex.json"
 if (!existsSync(INDEX)) {
@@ -30,17 +29,29 @@ if (!existsSync(INDEX)) {
 const index = JSON.parse(readFileSync(INDEX, "utf8"))
 const yaml = readFileSync("quartz/quartz.config.yaml", "utf8")
 
-// pull the sortFn body out of the YAML block scalar
-const at = yaml.indexOf("sortFn: |")
-const rest = yaml.slice(at + "sortFn: |".length)
-const lines = []
-for (const line of rest.split("\n")) {
-  if (line.trim() === "") { lines.push(""); continue }
-  const indent = line.match(/^ */)[0].length
-  if (indent < 8) break
-  lines.push(line.slice(8))
+// Pull a YAML block scalar ("<key>: |") out of the config and evaluate it. Both
+// sortFn and filterFn are shipped to the browser as strings, so reading them
+// back the same way is what keeps this honest -- the config is the only source.
+const blockScalar = (key) => {
+  const at = yaml.indexOf(`${key}: |`)
+  if (at === -1) return null
+  const rest = yaml.slice(at + `${key}: |`.length)
+  const lines = []
+  for (const line of rest.split("\n")) {
+    if (line.trim() === "") {
+      lines.push("")
+      continue
+    }
+    const indent = line.match(/^ */)[0].length
+    if (indent < 8) break
+    lines.push(line.slice(8))
+  }
+  return Function(`"use strict";return (${lines.join("\n")})`)()
 }
-const sortFn = Function(`"use strict";return (${lines.join("\n")})`)()
+
+const sortFn = blockScalar("sortFn")
+// The plugin's own default when no filterFn is configured.
+const filterFn = blockScalar("filterFn") ?? ((node) => node.slugSegment !== "tags")
 
 class FileTrieNode {
   constructor(slugSegments, data) {
@@ -83,7 +94,7 @@ class FileTrieNode {
 
 const root = new FileTrieNode([], null)
 for (const [slug, data] of Object.entries(index)) root.add({ ...data, slug })
-root.filter((n) => n.slugSegment !== "tags")
+root.filter(filterFn)
 root.sort(sortFn)
 
 const find = (path) => {


### PR DESCRIPTION
#167 restored the 31 missing pages to the topic tree, but left the two version trees in the nav beside them. The result was **more** navigation, not less:

| | Top-level sections | Times a forked page appears in the nav |
|---|---|---|
| Before the split | 4 | 1 |
| After the split (#160/#161) | 6 | 2 — and missing from its own section |
| After #167 | 6 | **3** |
| After this PR | **4** | **1** |

Six top-level sections, and every forked page listed three times — once as its chooser, once inside `FOG 1.5 Differences`, once inside `FOG 1.6 Differences`. That buries the topic tree the choosers exist to restore.

## The change

The Explorer's `filterFn` now drops `docs/1.5/` and `docs/1.6/` from the sidebar.

```
Installation            Installation
Management              Management
Knowledge Base    →     Knowledge Base
Development             Development
FOG 1.5 Differences     What is FOG
FOG 1.6 Differences
What is FOG
```

**No page moves and nothing becomes unreachable.** A forked topic is reached through the chooser sitting at its normal place in the tree; the two version landing pages stay one click away on the pinned **FOG 1.5** / **FOG 1.6** pills, which are the right entry point for "what changed overall" as opposed to one topic. Search is unaffected, and every `/{context_id}` permalink still resolves to the 1.6 page.

## Two consequences, both now enforced

**Supplying a `filterFn` replaces the plugin default** (`node.slugSegment !== "tags"`), so that exclusion is repeated in ours. Without it the tag tree reappears in the sidebar and nothing warns.

**`prev-next-nav` takes the same exclusion**, so Previous/Next cannot walk into a tree the sidebar does not show. Pages inside a version tree get no Previous/Next of their own — correct, since they are reached deliberately from a chooser rather than by reading the site in order.

`check-version-split.mjs` now fails if the Explorer hides a tree that `prev-next-nav` does not (or vice versa), and if the `filterFn` drops the `tags` exclusion. Two tests cover both.

## A latent bug this exposed

`prev-next-nav` walks `allFiles`, which carries Quartz's generated **404 page**, and never excluded it. That was invisible only because the version trees sorted last, so nothing ever fell through to it. With them gone, "Next" on the final Development page read **"Not Found"**. The 404 page is now excluded explicitly.

`show-nav.mjs` reads `filterFn` out of the config the same way it already read `sortFn`, so it keeps reporting the real sidebar rather than a stale one.

## Verification

- `npm run docs:build` — clean, 214 files, exit 0
- `node --test "scripts/*.test.mjs"` — 63 pass, 0 fail
- `node scripts/check-version-split.mjs` — 32 forked topics, consistent
- `node scripts/check-anchors.mjs` — same 3 pre-existing findings, no new ones
- Both pills resolve to their landing pages (`./1.5/`, `./1.6/`, both present)
- `/plugins` still redirects to `./1.6/management/web/plugins`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gxx8f94y8Ns8oyZmmnguHv
