### PR TITLE
Put sudo in the bootstrap one-liner, and say it is safe on an existing server

### DIFF
--- a/docs/1.5/installation/server/install-fog-server.md
+++ b/docs/1.5/installation/server/install-fog-server.md
@@ -146,7 +146,11 @@ directory — there is no branch to move, so use the bootstrap installer instead
 It clones a checkout and runs the installer over your existing install, which
 it finds through `/etc/fog/fog.conf`:
 
-    curl -fsSL https://raw.githubusercontent.com/FOGProject/fogproject/working-1.6/bin/bootstrap.sh | bash -s -- --channel rc
+    curl -fsSL https://raw.githubusercontent.com/FOGProject/fogproject/working-1.6/bin/bootstrap.sh | sudo bash -s -- --channel rc
+
+`sudo` goes before `bash`, not before `curl`. It is safe to run on a server
+that already has FOG: the script finds the existing install through
+`/etc/fog/fog.conf` and upgrades it in place rather than installing beside it.
 
 > [!note]
 > `utils/FOGUpdater/fogupdater.sh` is **retired** and no longer updates

--- a/docs/1.6/installation/server/install-fog-server.md
+++ b/docs/1.6/installation/server/install-fog-server.md
@@ -33,10 +33,20 @@ first, one command does the whole of this page's *Prerequisite* and *Run the
 installer* sections. It installs `git`, clones the repository, checks out the
 branch for the channel you asked for, and starts the installer:
 
-    curl -fsSL https://raw.githubusercontent.com/FOGProject/fogproject/working-1.6/bin/bootstrap.sh | bash -s -- --channel beta
+    curl -fsSL https://raw.githubusercontent.com/FOGProject/fogproject/working-1.6/bin/bootstrap.sh | sudo bash -s -- --channel beta
 
 The installer then runs **interactively**, exactly as it does when you start it
 by hand, so you still answer every prompt yourself.
+
+> [!tip]
+> Put `sudo` where it is above — before `bash`, not before `curl`. `sudo` asks
+> for your password on the terminal rather than on standard input, so the pipe
+> is unaffected.
+>
+> If you leave it out, the script notices it is not root and re-runs itself
+> under `sudo` — but from a pipe it has no file to hand `sudo`, so it has to
+> download itself a second time to do it. Including `sudo` yourself avoids
+> that.
 
 > [!warning]
 > That runs a script from the internet as root, and the URL points at a
@@ -66,6 +76,22 @@ rest.
 If the path already contains a git checkout, the script leaves it completely
 alone and points you at `bin/updatefog.sh`. It will not clone over, reset, or
 pull a working tree that is already there.
+
+**If FOG is already installed on the machine, this is safe to run.** The script
+reads `/etc/fog/fog.conf` to find the existing server:
+
+- If that install has a git checkout recorded, the script hands over to *that*
+  checkout's `bin/updatefog.sh`, passing your `--channel` and `--yes` through.
+  Nothing is cloned, and the checkout your server was installed from is the one
+  that gets updated.
+- If it has no checkout — a tarball install — the script clones one and says
+  plainly that it is **upgrading the running server in place**. Your database
+  and settings are kept.
+
+> [!note]
+> The clone is large. The repository holds roughly 200,000 objects, so expect
+> several minutes on a first install, and longer on a slow connection. The
+> receive phase can look like nothing is happening.
 
 Everything below is the same thing done by hand, which is still the right
 choice if you want to see each step.


### PR DESCRIPTION
Pairs with FOGProject/fogproject#1656. **Draft.**

The documented one-liner had no `sudo`, so the first person to run it on a real server got:

```
FOG Installation must be run as root user
curl: (23) Failure writing output to destination
```

That was a documentation mistake, not a script one. Both one-liners now carry `sudo`.

## `sudo` goes before `bash`, not before `curl`

The page says why: `sudo` asks for the password on the *terminal*, not on standard input, so the pipe is unaffected. Leaving it out still works — the script re-runs itself under `sudo` — but from a pipe it has to download itself a second time to do that. Including `sudo` avoids the second fetch.

## Safe on a server that already has FOG

"Install script" reads like something you must not run twice, and the person who hit this was testing on a machine that already had FOG. The page now describes what actually happens:

- Existing install **with** a checkout → hands over to that checkout's `bin/updatefog.sh`, `--channel` and `--yes` passed through. Nothing cloned.
- Existing install **without** one → clones, and upgrades the running server in place. Data and settings kept.

## The clone is large

Roughly 200,000 objects. The receive phase is quiet for long enough to look like a hang, so the page says to expect several minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtZHpyWZWDPSxePdTViGZy
