### PR TITLE
The 1.6 group and host pages, brought up to what shipped

### DIFF
--- a/docs/1.6/management/web/groups.md
+++ b/docs/1.6/management/web/groups.md
@@ -361,7 +361,13 @@ plugin's files never removed the trigger: it would otherwise have kept copying
 settings onto every new group member, silently, long after the plugin that
 created it was gone.
 
-You do not need to do anything. If you had it installed, check afterwards that
+One thing you may need to do. The trigger copied `hostADPass` — the Active
+Directory join password — from the template host onto hosts that joined the
+group. If you are rotating a join account, read the warning on
+[[1.6/management/web/plugins#persistentgroups is gone, because the defect it worked around is fixed|the Plugins page]]
+before you assume the old credential is gone.
+
+If you had it installed, check afterward that
 the groups which relied on it now grant the snapins and printers you expect —
 the grants are the replacement, and they are more capable than what they
 replace, because they also apply to hosts that were already members.

--- a/docs/1.6/management/web/groups.md
+++ b/docs/1.6/management/web/groups.md
@@ -4,7 +4,7 @@ aliases:
     - Group Management
     - Fog Group Management
     - Group Grants
-description: "How FOG 1.6 groups work: a group owns its snapins and printers and applies them to every member, including hosts added later"
+description: "How FOG 1.6 groups work: a group owns its snapins, printers, modules and power schedules and applies them to every member, including hosts added later"
 context_id: groups
 tags:
     - 1_6-changes
@@ -20,8 +20,8 @@ tags:
 >Groups themselves are not new, but what a group **is** changed in 1.6. On
 >1.5 a group owned nothing: pressing a button on the group page wrote rows
 >onto whichever hosts were members at that instant. In 1.6 a group owns its
->snapins and printers, and every member gets them — including hosts you add
->tomorrow. See the [[1.5/management/web/groups|1.5 version]] of this page for
+>snapins, printers, client modules and power schedules, and every member gets
+>them — including hosts you add tomorrow. See the [[1.5/management/web/groups|1.5 version]] of this page for
 >the old behavior.
 
 A **group** is a label you put on hosts. A host can be in as many groups as
@@ -30,20 +30,21 @@ at once, and each of those groups can hand it something.
 
 ## What a group gives its members
 
-A group holds three kinds of thing, and hands all of them to every member:
+A group holds four kinds of thing, and hands all of them to every member:
 
 | The group holds | Where you set it | What the member gets |
 |---|---|---|
 | **Snapins** | Associations → Snapin Associations | Included when you deploy snapins to that host |
 | **Printers** | Associations → Printer Associations | Installed by the FOG client on its next check-in |
 | **Client modules** | Service Settings → Client Settings | The module is switched on |
+| **Power schedules** | Service Settings → Power Management | The machine shuts down, reboots or wakes on that schedule |
 
-Tick an item and the group grants it. Untick it and the grant is gone. Neither
-click touches a host record, so nothing you do here can overwrite something an
-admin set on a machine directly.
+Grant an item and the group grants it; revoke it and the grant is gone.
+Neither action touches a host record, so nothing you do here can overwrite
+something an admin set on a machine directly.
 
 >[!important] This is the change people notice first
->**A host added to the group later gets the group's snapins and printers.** On
+>**A host added to the group later gets everything in that table.** On
 >1.5 it got nothing — silently — which is why so many sites ended up with a
 >plugin, a script, or a habit of re-pressing the group's buttons after adding
 >a machine. None of that is needed now.
@@ -54,7 +55,8 @@ admin set on a machine directly.
 ## What a host ends up with
 
 A host's real list is **its own assignments plus every grant from every group
-it belongs to**, worked out fresh each time FOG needs it. Two rules cover
+it belongs to**, worked out fresh each time FOG needs it. That is one rule for
+all four kinds of grant, not four rules that happen to agree. Two things cover
 almost every question about it:
 
 1. **The host's own assignments come first.** A snapin you gave a machine
@@ -84,6 +86,29 @@ first group in that order which names one.
 >The host's own Printers and Snapins tabs show what that host was assigned
 >directly. To see what it will actually *get*, look at the groups it is in —
 >the Groups column on the Hosts list names them, in the order above.
+
+### Reading the group list
+
+The Group Management list has a **Grants** column saying what each row hands
+out — *"3 snapins, 1 printer, 2 power schedules"* — and it is worth a look
+before you touch anything, because a group is now two quite different things
+wearing the same name.
+
+A row with an empty Grants column is a **label**: it names a set of machines
+and gives them nothing, so adding a host to it changes nothing about that
+host. A row with entries in that column is machinery, and adding a host to it
+hands that host software, printers, or a shutdown time.
+
+It shows counts rather than names on purpose. The question the column answers
+is *is this row consequential*, and a group with twenty snapins would bury
+that answer under twenty names. Open the group to see which ones.
+
+>[!note] Why the column does not sort
+>It is worked out with one extra query per page of the list rather than being
+>a column of the groups table, which is what keeps a group with five hundred
+>members from costing anything to display. Nothing to sort by means nothing
+>to sort — and if what you want is "groups that grant nothing", reading down
+>the column is quicker than sorting anyway.
 
 ## Snapins are a snapshot; printers are live
 
@@ -121,7 +146,12 @@ host once — so they moved to where that operation belongs: the **Hosts** list.
 **Hosts → tick the hosts you want → Edit selected hosts.**
 
 That does the same job on any selection you can build, not only on a group,
-and you can repeat it whenever you like. Each field has its own action:
+and you can repeat it whenever you like.
+
+The fields are split across the same four tabs a single host's own page uses
+— **General**, **Active Directory**, **FOG Client** and **Plugins** — so a
+field is where you already look for it rather than somewhere in one long
+list. Each field has its own action:
 
 | Action | What it does |
 |---|---|
@@ -132,20 +162,32 @@ and you can repeat it whenever you like. Each field has its own action:
 Fields that only make sense as on/off (joining the domain, hostname
 enforcement) offer *No change*, *Enable on all* and *Disable on all* instead.
 
+>[!tip] Nothing happens on a tab you did not touch
+>Every field on every tab starts on *No change*, so opening a tab and leaving
+>it alone is the same as never opening it. You can set an image on General
+>and a printer level on FOG Client in one pass; you do not have to do one tab
+>at a time.
+
 >[!note] Where each setting went
->| Was on the group page | Now |
->|---|---|
->| Image | Edit selected hosts → **Image** |
->| Kernel, kernel arguments, primary disk, init | Edit selected hosts → **Host Kernel** / **Host Kernel Arguments** / **Host Primary Disk** / **Host Init** |
->| Product key | Edit selected hosts → **Product Key** |
->| BIOS / EFI exit type | Edit selected hosts → **Host BIOS Exit Type** / **Host EFI Exit Type** |
->| Printer management level | Edit selected hosts → **Host Printer Management Level** |
->| Active Directory (join, domain, OU, username, password) | Edit selected hosts → the **Active Directory** fields |
->| Enforce hostname changes | Edit selected hosts → **Host Enforce Hostname Changes** |
->| Screen resolution | Edit selected hosts → **Host Screen Resolution** |
->| Auto log out time | Edit selected hosts → **Auto Log Out Time (in minutes)** |
->| Building | **Removed.** Nothing read it and nothing wrote it — it was a leftover column, not a setting. |
->| Location, OU *(plugins)* | Edit selected hosts → **Host Location** / **Host OU** |
+>Every row is *Hosts → Edit selected hosts*, then the tab and field named.
+>
+>| Was on the group page | Tab | Field |
+>|---|---|---|
+>| Image | General | **Image** |
+>| Kernel, kernel arguments, primary disk, init | General | **Host Kernel** / **Host Kernel Arguments** / **Host Primary Disk** / **Host Init** |
+>| Product key | General | **Product Key** |
+>| BIOS / EFI exit type | General | **Host BIOS Exit Type** / **Host EFI Exit Type** |
+>| Enforce hostname changes | General | **Host Enforce Hostname Changes** |
+>| Printer management level | FOG Client | **Host Printer Management Level** |
+>| Screen resolution | FOG Client | **Host Screen Resolution** |
+>| Auto log out time | FOG Client | **Auto Log Out Time (in minutes)** |
+>| Active Directory (join, domain, OU, username, password) | Active Directory | the **Active Directory** fields |
+>| Location, OU *(plugins)* | Plugins | **Host Location** / **Host OU** |
+>| Building | — | **Removed.** Nothing read it and nothing wrote it — it was a leftover column, not a setting. |
+>
+>Printer management level, screen resolution and auto log out are on **FOG
+>Client** rather than General because they are settings the FOG client acts
+>on, which is where a single host's own page has always kept them.
 
 >[!important] These controls are gone from the group page, not hidden
 >If you are looking for one of them on a group and cannot find it, that is

--- a/docs/1.6/management/web/groups.md
+++ b/docs/1.6/management/web/groups.md
@@ -194,41 +194,55 @@ there is no second step, and no button to press afterwards.
   anything when *Abort snapin sequence on failure* is enabled for the task.
 - **Service Settings → Client Settings** — the group's modules. Just the
   grant: screen resolution and auto-logout are set from the Hosts list.
-- **Service Settings → Power Management** — schedules power tasks across
-  members. **This one still behaves the 1.5 way**, and knowingly so: see the
-  warning below.
+- **Service Settings → Power Management** — the group's power **grants**.
+  Every member runs these schedules, including hosts added later. Immediate
+  actions on the same tab are still a one-time push, because they are a task;
+  see below.
 - **Inventory**, **Login History**, **History Items** — reporting across the
   group's members.
 - **Site** — which site the group belongs to, if you use site scoping.
 
->[!warning] Power Management is still a one-time push
->Saving a power schedule on a group writes **one row per host that is a
->member at that instant**, exactly as the removed controls above did. It is
->the last control on the group page that still works this way.
+>[!note] Power Management: a schedule is a grant, an immediate action is a task
+>The tab holds both, and they are different kinds of thing on purpose.
 >
->What that means in practice:
+>**Create New Scheduled** writes one row **about the group**. Every host in
+>the group runs it, hosts added later included, and nothing is written onto a
+>host. Revoking it with *Delete selected* takes it away from every member at
+>once. A host's own schedules are untouched either way — what a machine
+>actually runs is its own schedules plus every grant from every group it is
+>in, worked out fresh each time, with the same schedule reached twice counted
+>once.
 >
->- a host **added** to the group afterward gets **no** schedule;
->- a host **removed** from the group **keeps** the schedule it was given, and
->  nothing on the group page will take it away — *Delete all* on the group's
->  Power Management tab only reaches current members;
->- saving **adds** a schedule rather than replacing the one that is there, so
->  a host accumulates every schedule any of its groups ever gave it. Saving
->  the *same* schedule twice is harmless — the row is keyed on the host plus
->  the cron expression plus the action, so an identical save lands on the row
->  that already exists — but changing the time and saving again leaves the old
->  time in place alongside the new one.
+>**Create New Immediate** is a task. It shuts down, reboots or wakes the hosts
+>that are in the group **right now**, and a host added a minute later is not
+>affected. That is what a task should do, and it is why it is not a grant: a
+>standing grant of "shut down immediately" would fire again for every machine
+>that ever joined the group.
 >
->It was left alone in 1.6 rather than moved, because a schedule is a cron
->expression plus an action rather than a single value — it does not fit the
->*No change / Set on all / Clear on all* shape that *Edit selected hosts*
->uses, and forcing it into that shape would have been worse than leaving it
->honest. Making it a grant like snapins and printers is the right fix and is
->a change to the schema, so it is not in this release.
+>Two schedules that differ only in time are two grants — saving a new time
+>does not replace the old one, so revoke the one you are replacing. Saving the
+>*same* schedule twice is a no-op.
 >
->Until then, treat the group's Power Management tab as **"apply to whoever is
->in the group right now"**, and check a host's own Power Management tab when
->you want to know what it is actually scheduled to do.
+>**Clear schedules from member hosts** is the odd one out, and it is not an
+>undo for the grants above. It reaches into the member hosts and deletes the
+>schedules **they** hold — which, on a server upgraded from 1.5 or from an
+>early 1.6, is where every schedule this tab ever created ended up. It also
+>removes schedules those hosts were given individually, so read it as "reset
+>the members", not "clear this group".
+>
+>A host's own Power Management tab remains the answer to *what is this machine
+>actually scheduled to do*, because it is the only place the host's own rows
+>and its groups' grants are not the same thing.
+
+>[!warning] Daily schedules were running on Sundays only, on PHP 8
+>Fixed in 1.6. A schedule whose weekday was `*` — which is every daily
+>schedule — was sent to the FOG client as `... 7`, meaning Sunday. The
+>comparison that normalizes FOG's `-1` for Sunday treated `*` as negative on
+>PHP 8, where it had not on PHP 7.4, so a working schedule stopped running
+>when the server's PHP was upgraded and nothing about FOG changed. If you have
+>power schedules that quietly stopped happening, this is why. Wake schedules
+>were never affected — those are sent by the server, which never ran that
+>comparison.
 
 ## Modules have one extra rule: only a host can turn one off
 

--- a/docs/1.6/management/web/hosts.md
+++ b/docs/1.6/management/web/hosts.md
@@ -428,9 +428,49 @@ rather than picking one of them to show you.
 >[[1.6/management/web/groups#Settings that are no longer on the group page|Group Management]]
 >for the complete map of where each one went.
 >
->One control on the group page still behaves the 1.5 way: **Power Management**.
->It is unchanged in 1.6 and still writes to whoever is a member when you press
->save.
+>**Power Management** used to be the exception here, and is not any more. A
+>group's power *schedules* are grants like everything else in that table; only
+>an immediate shut down, restart or wake is still a one-time push, because
+>that is a task and a task acts on who is a member right now.
+
+### Shutting down, restarting and waking hosts
+
+Shut down, restart and wake are on the **Queue Task** list, in a **Power**
+pane between *Basic Tasks* and *Advanced Tasks*. Tick the hosts, press *Queue
+Task*, open **Power**, pick one.
+
+They are there because they are tasks: each acts on whatever is selected the
+moment you press it and leaves nothing standing behind it. A host that joins
+the selection a minute later is not affected, and nothing is scheduled.
+
+| Action | How it reaches the machine |
+|---|---|
+| **Wake** | The server sends a wake packet over the network. Nothing has to be installed on the machine, but the network in between has to carry it. |
+| **Shut Down** | The FOG client carries it out at its next check-in. |
+| **Restart** | Same as Shut Down — the FOG client, next check-in. |
+
+>[!note] Shut Down and Restart need the FOG client
+>They are handed to the machine rather than pushed at it, so a machine that
+>is already off, or has no FOG client installed, is simply unaffected — you
+>will not get an error saying so. Wake is the other way round: it is the
+>server that sends it, so it works on a machine with nothing installed at all.
+
+The same three are on a single host's own page, on the same **Queue Task**
+button, so you do not have to go back to the list to restart one machine.
+
+>[!tip] For a *repeating* shutdown, use a schedule
+>These three are one-offs. "Every weeknight at 22:00" is a power schedule —
+>set it on the host's own **Power Management** tab, or grant it from a group
+>so every member gets it. See
+>[[1.6/management/web/groups#What a group gives its members|Group Management]].
+
+>[!info] FOG 1.6
+>Shutting down or restarting a *selection* could not be asked for before —
+>the only route was one host's Power Management tab, one machine at a time,
+>through a form built for scheduling. Wake could, but it was filed under
+>*Advanced Tasks* beside Memtest and the disk wipes. All three are together
+>now, and Wake has moved rather than been duplicated, so it is no longer
+>under Advanced.
 
 ### Creating Host Groups
 
@@ -450,8 +490,8 @@ Typing a name that is not a group yet **creates it** when you add. *Remove*
 only works on groups that already exist.
 
 >[!important] On FOG 1.6 that is the whole job
->A group **grants** its snapins and printers to its members rather than
->copying them, so adding forty machines to a group is all it takes for those
->machines to receive what the group holds — there is no second step and no
->button to press afterwards. Removing a host takes them away again. See
+>A group **grants** its snapins, printers, client modules and power schedules
+>to its members rather than copying them, so adding forty machines to a group
+>is all it takes for those machines to receive what the group holds — there is
+>no second step and no button to press afterwards. Removing a host takes them away again. See
 >[[1.6/management/web/groups|Group Management]].

--- a/docs/1.6/management/web/hosts.md
+++ b/docs/1.6/management/web/hosts.md
@@ -458,10 +458,16 @@ the selection a minute later is not affected, and nothing is scheduled.
 The same three are on a single host's own page, on the same **Queue Task**
 button, so you do not have to go back to the list to restart one machine.
 
+That is now the *only* place to ask for one. A host's **Power Management**
+tab used to carry a *Create New Immediate* button beside its schedules; it
+does not any more, and the tab is schedules only. Two things that behave
+completely differently were sharing one card, and the immediate one belongs
+with the other tasks.
+
 >[!tip] For a *repeating* shutdown, use a schedule
->These three are one-offs. "Every weeknight at 22:00" is a power schedule —
->set it on the host's own **Power Management** tab, or grant it from a group
->so every member gets it. See
+>These three are one-offs — nothing is written down and nothing repeats.
+>"Every weeknight at 22:00" is a power schedule: set it on the host's own
+>**Power Management** tab, or grant it from a group so every member gets it. See
 >[[1.6/management/web/groups#What a group gives its members|Group Management]].
 
 >[!info] FOG 1.6
@@ -470,7 +476,8 @@ button, so you do not have to go back to the list to restart one machine.
 >through a form built for scheduling. Wake could, but it was filed under
 >*Advanced Tasks* beside Memtest and the disk wipes. All three are together
 >now, and Wake has moved rather than been duplicated, so it is no longer
->under Advanced.
+>under Advanced. *Create New Immediate* has gone from the host's Power
+>Management tab in the same change — the tab is schedules only.
 
 ### Creating Host Groups
 

--- a/docs/1.6/management/web/plugins.md
+++ b/docs/1.6/management/web/plugins.md
@@ -251,8 +251,33 @@ this page for how it differs on the older line.
 >database trigger, and deleting the plugin's files never removed that: it
 >would have kept copying settings onto every new group member, silently, long
 >after the plugin that created it was gone. The upgrade drops the trigger and
->retires the plugin's row. See
+>retires the plugin's row, and 1.6 refuses to install or activate the plugin
+>again — including a copy kept in the external plugin root, which the upgrade
+>does not touch. See
 >[[1.6/management/web/groups#persistentgroups is retired|Group Management]].
+
+>[!warning] If you ran persistentgroups: it copied Active Directory join passwords between hosts
+>The plugin's trigger copied a fixed list of columns from a group's template
+>host onto each host that joined the group, and that list included
+>`hostADPass` — the AD join password. So adding a host to a group could copy
+>the template's domain join credential onto it, in the database, below the web
+>application, with no entry in the history log, for as long as the plugin
+>existed.
+>
+>The credential never left your FOG server's own database and was already
+>readable there to anything that could read the `hosts` table, so this is a
+>notification, not a security advisory. It is here because if you rotate a
+>domain join account you need to know the old one may be sitting on hosts you
+>never edited by hand, and nothing in the interface would have shown you that.
+>The copy happened only on "clean" adds — hosts sharing no printer or module
+>setting with the template — so the affected set is not "every host in the
+>group" and cannot be worked out after the fact.
+>
+>**What to do:** if you used the plugin and have rotated, or intend to rotate,
+>an AD join account, treat every host that was ever in a
+>persistentgroups-managed group as possibly carrying the template's old
+>credential and reset it. **Hosts → select them → Edit selected hosts →
+>Active Directory** does this across a selection in one action.
 
 >[!note] Site is gone too, and for the same reason
 >Sites and per-site host visibility moved into 1.6 core, so there is no

--- a/docs/development/plugin-development.md
+++ b/docs/development/plugin-development.md
@@ -1085,9 +1085,87 @@ fire for page routes too: [ADR 0006](https://github.com/FOGProject/fogproject/bl
 | `API_SERVER_OWNED_FIELDS` | refuse API writes to columns your own code maintains — see §8 |
 | `<NODE>_ADD_FIELDS` / `_GENERAL_FIELDS` | let others extend your forms |
 | `<NODE>_ADD_POST` / `_EDIT_POST` / `_ADD_SUCCESS` / `_ADD_FAIL` | extension points around your saves |
+| `HOST_MASSEDIT_FIELDS` / `HOST_MASSEDIT_APPLY` | change one of your own values across a whole host selection — see §9b |
 
 Fire your own events with `&`-by-reference args so listeners can mutate them
 (see the example's `HELLOWORLD_*` events).
+
+### 9b. Changing a value across many hosts — `HOST_MASSEDIT_*`
+
+Every other editing extension point a plugin has is a **per-object** edit with
+a loop behind it. The ABI has a bulk *read* seam (`API_MASSDATA_MAPPING`) and a
+bulk *delete* seam (`DELETEMASS_API`), and between them sat the operation
+neither covers: changing a value across a set. `HOST_MASSEDIT_*` is that seam
+(ADR 0038 decision 13).
+
+It is why `location` and `ou` each shipped a whole second hook file whose only
+job was to set one value across a group's members — and those files always
+clobbered, because there was no way to say *leave this host alone*. Both were
+converted to this seam in fog-plugins #36 and are the worked example to copy:
+`AddLocationHost::massEditFields()` / `massEditApply()`.
+
+**Contribute a field** — fired when the Mass Edit form is built, and again
+when it is applied, with the same arguments both times so the two can never
+disagree about which keys exist:
+
+```php
+public function massEditFields($arguments)
+{
+    $hostIDs = $arguments['hostIDs'];   // the selection, for your hint
+    $arguments['fields']['myplugin_thing'] = [
+        'label' => _('My Thing'),
+        'input' => '<input class="form-control" '
+            . 'name="value[myplugin_thing]" value=""/>',
+        'hint'  => $this->sharedHint($hostIDs),
+    ];
+}
+```
+
+Three things about that array:
+
+- **`name="value[<your key>]"`.** That is what the resolver reads.
+- **Render it EMPTY.** There is no read path in this form. A control
+  pre-filled from a selection has to answer *"pre-filled with which host's
+  value"*, and there is no honest answer when they differ. Say what the hosts
+  hold in the `hint` instead, where *(varies)* is sayable —
+  `FOG\Util\SharedHostValues` computes exactly that in one query.
+- **Do not draw an action control.** Core draws it. A plugin that drew its own
+  could ship a two-state field, and a two-state field in a mass edit is the
+  defect this whole design is about: it looks identical to a correct one until
+  somebody's values are gone.
+
+**Apply it** — you receive the host ids and the **resolved** instructions for
+your own keys only, already reduced to one of three states:
+
+```php
+public function massEditApply($arguments)
+{
+    foreach ($arguments['actions'] as $key => $instruction) {
+        switch ($instruction['action']) {
+            case 'leave':                       // the default, always
+                break;
+            case 'set':
+                $this->writeAll($arguments['hostIDs'], $instruction['value']);
+                break;
+            case 'clear':
+                $this->clearAll($arguments['hostIDs']);
+                break;
+        }
+    }
+}
+```
+
+You never parse a sentinel, because there is no sentinel. Anything the request
+got wrong — a missing action, a misspelled one, a key you never offered, a
+value that arrived as an array — has already resolved to `leave` before you
+see it. `FOG\Util\MassEdit` fails closed, and *leave alone* is what closed
+means.
+
+**Write in one statement, not a loop.** The core half sends one
+`UPDATE ... WHERE hostID IN (...)` for four hundred hosts, and the row-backed
+half is one delete plus one `insertBatch`. A `foreach` calling `save()` per
+host is the shape the group page had, and it is what ADR 0038 exists to
+remove.
 
 ### 9a. Naming your report
 

--- a/docs/kb/reference/group-shared-state.md
+++ b/docs/kb/reference/group-shared-state.md
@@ -25,18 +25,22 @@ tags:
 one is the detail behind it: exactly how FOG decides what a host gets, and
 what the group page's remaining push-to-all controls do.
 
-> **Two kinds of state on a group page, and they behave differently:**
-> 1. **Grants** — snapins, printers and modules. The group **owns** these. A
->    ticked box is a row about the group, and every member gets the item,
->    including hosts added later. Nothing is written onto a host.
+> **What the group page holds, and how each kind behaves:**
+> 1. **Grants** — snapins, printers, modules and power schedules. The group
+>    **owns** these. A ticked box is a row about the group, and every member
+>    gets the item, including hosts added later. Nothing is written onto a
+>    host.
 > 2. **Pushed values** — Active Directory, auto-logout, kernel and general
 >    fields, screen resolution, image, product key. These were **not** group
 >    properties: pressing *Update* wrote the value onto the hosts that were
 >    members at that instant, once. **They are gone from the group page in
 >    1.6.** Use *Edit selected hosts* on the Hosts list instead. The section
 >    below is kept as the record of what they did and why they went.
-> 3. **Power Management** — the one push that is **still there** in 1.6, and
->    still a push. See [Power Management](#power-management) below.
+> 3. **Tasks** — deploy, capture, and an *immediate* shutdown, reboot or wake
+>    from the Power Management tab. A task acts on the membership at the
+>    moment you start it, which is what a task should do. See
+>    [Power Management](#power-management) below for the one tab that holds a
+>    grant and a task side by side.
 
 ---
 
@@ -55,6 +59,9 @@ what the group page's remaining push-to-all controls do.
   - [General fields](#general-fields)
   - [Enforce hostname / AD-join reboots](#enforce-hostname--ad-join-reboots)
 - [Power Management](#power-management)
+  - [Immediate actions are tasks, not grants](#immediate-actions-are-tasks-not-grants)
+  - [Who carries out which action](#who-carries-out-which-action)
+  - [Clearing the pre-1.6 rows](#clearing-the-pre-16-rows)
 - [Out of scope](#out-of-scope)
 
 ---
@@ -145,6 +152,7 @@ express this and had to go.
 | **Snapins** | at task creation | does **not** change a queued task — re-task to pick it up |
 | **Printers** | live, on every client check-in | reaches machines on their next check-in |
 | **Modules** | live, on every client check-in | reaches machines on their next check-in |
+| **Power schedules** | live — by the client on check-in, by the server at fire time for wake | reaches machines on their next check-in; a wake grant reads membership when it fires |
 
 A task is a promise about a specific moment: you queued *that* set of snapins
 for *that* machine, and a machine that reboots into the job three hours later
@@ -245,32 +253,80 @@ A tri-state select — **No change / Enable on all / Disable on all** — with a
 
 ## Power Management
 
-The one control on the group page that is **still** a push in 1.6, and the only
-reason the "pushed values" model above is worth understanding as current
-behavior rather than as history.
+A **grant** since 1.6, with one deliberate exception.
 
-Saving a schedule on a group's **Service Settings → Power Management** tab
-writes one `powerManagement` row per host that is a member at that instant. It
-is not a group property and nothing records that the write came from a group.
+A schedule saved on a group's **Service Settings → Power Management** tab is
+one row in `groupPowerManagement`, about the group. Every member runs it,
+including hosts added later, and nothing is written onto a host. What a given
+machine actually runs is resolved at read time, exactly like snapins and
+printers: its own `powerManagement` schedules first, then the grants of every
+group it belongs to, in the [precedence](#precedence) order above.
+
+**The identity of a schedule is its cron expression plus its action.** That is
+what deduplication keys on, and it is the only key that means anything: two
+groups both saying "reboot at 03:00" is one instruction, and running it twice
+would reboot a machine that had just come back up. It is also the unique key on
+both tables, so saving an identical schedule twice is a no-op rather than a
+second row.
 
 | | Behavior |
 |---|---|
-| Host added to the group afterward | gets **no** schedule |
-| Host removed from the group | **keeps** the schedule |
-| *Delete all* on the group tab | reaches **current members only** |
-| Saving a second, different schedule | **adds** it; the first stays |
-| Saving the same schedule twice | no-op — the row is keyed on host + cron expression + action |
+| Host added to the group afterward | **runs** the schedule |
+| Host removed from the group | **stops** running it; its own schedules stay |
+| *Delete selected* on the group tab | revokes the grant for **every** member |
+| Saving a second, different schedule | **adds** it; revoke the old one to replace it |
+| Saving the same schedule twice | no-op — keyed on group + cron + action |
+| The same schedule from two groups | runs **once** |
+| The same schedule direct and granted | runs **once**, at the host's position |
 
-It was not moved into *Edit selected hosts* with the rest, because a schedule
-is a cron expression plus an action rather than a single value: it has no
-meaningful *Clear on all*, a host may legitimately hold several at once, and
-squeezing it into the three-state shape would have made the form lie about what
-it does. The correct fix is to make it a **grant**, resolved at read time like
-snapins and printers, which needs a group-owned table — a schema change, and so
-not part of this release.
+### Immediate actions are tasks, not grants
 
-Reading a host's own Power Management tab is the only reliable answer to "what
-is this machine actually scheduled to do".
+**Create New Immediate** on the same tab is a fan-out and stays one. It shuts
+down, reboots or wakes the hosts that are members at that instant, and a host
+added afterward is unaffected — which is what a task should do. A standing
+grant of "shut down immediately" would fire again for every machine that ever
+joined the group, so there is no on-demand column on the grant table for it to
+live in.
+
+### Who carries out which action
+
+| Action | Carried out by | Why |
+|---|---|---|
+| `shutdown`, `reboot` | the **FOG client**, on its own cron | the machine is running, so it can do it itself |
+| `wol` | the **server**, from `TaskScheduler` | a sleeping machine cannot ask for anything |
+
+The resolver returns every action and each consumer filters: the client is
+never handed `wol` (it would schedule the machine to wake itself), and the
+scheduler expands only the wake grants, reading membership at **fire** time.
+That is what makes a host added last week get woken by a grant set last month.
+
+### Clearing the pre-1.6 rows
+
+**Clear schedules from member hosts** is not an undo for the grants — it
+reaches into the member hosts and deletes the schedules *they* hold. On a
+server upgraded from 1.5, or from a 1.6 before this change, that is where every
+schedule the group tab ever created ended up, and there is otherwise no way to
+undo a fan-out short of opening each host in turn. It also removes schedules
+those hosts were given individually, so read it as "reset the members".
+
+Nothing was migrated into the grant table. The rows sitting on hosts today are
+indistinguishable from ones an admin set per-host — that is the whole defect —
+so there was nothing to migrate *from*. Every host keeps precisely the
+schedules it has, and a group gains a grant when someone sets one.
+
+>[!warning] Daily schedules were running on Sundays only, on PHP 8
+>Fixed alongside this change. A schedule whose weekday was `*` — every daily
+>schedule — was handed to the FOG client as `... 7`, meaning Sunday. The
+>comparison that normalizes FOG's `-1` for Sunday read `$dow < 0`, and on
+>PHP 8 `'*' < 0` is true: comparing a non-numeric string with a number casts
+>the *number* to string, and `*` sorts below `0`. On PHP 7.4 the same
+>expression is false. So a working schedule stopped running when the server's
+>PHP was upgraded, with nothing about FOG having changed. Wake schedules were
+>never affected — the server sends those and never ran the comparison.
+
+Reading a host's own Power Management tab remains the only reliable answer to
+"what is this machine actually scheduled to do", because it is the one place
+the host's own rows and its groups' grants are not the same thing.
 
 ---
 


### PR DESCRIPTION
Two commits. The first was this PR as opened; the second is the wider re-read Tom asked for once the rest of ADR 0038 had landed.

## 1. Power Management is a grant now

A group's power **schedules** are grants like its snapins and printers — every member runs them, hosts added later included, and revoking one takes it away from everybody at once. An **immediate** shut down, reboot or wake stays a task, because a standing grant of "shut down immediately" would fire again for every machine that ever joined the group.

`docs/kb/reference/group-shared-state.md` gets the mechanism; `groups.md` gets the callout on the tab, including what **Clear schedules from member hosts** actually does — it resets the *members*, and it is not an undo for the grants above it.

### And a live bug worth its own callout

**Every daily power schedule has been reaching FOG clients as Sundays-only on any PHP 8 server.** A weekday of `*` was sent as `... 7`. The comparison that normalizes FOG's `-1` for Sunday treats `*` as negative on PHP 8 and did not on PHP 7.4, so a working schedule stopped running when the server's PHP was upgraded and nothing about FOG changed. Fixed in [FOGProject/fogproject#1658](https://github.com/FOGProject/fogproject/pull/1658). Wake schedules were never affected — those are sent by the server, which never ran that comparison.

## 2. The rest of the re-read

The group page was written when a group granted three things and the mass edit form was one long list. Both moved.

**`groups.md`**

- **Four grants, not three** — the table gains Power schedules, and the intro, front matter, the "a host added later gets" callout and the resolution rule follow. The resolution rule is *one* rule covering all four, and now says so rather than reading as three rules that happen to agree.
- **New "Reading the group list"** for the **Grants** column. This is the answer to the question a forty-row group list now raises — is this row a label or is it machinery — and it is worth naming before someone adds forty hosts to a group they have not opened. Covers why it shows counts rather than names, and why it does not sort.
- **Mass edit is tabbed.** The "where each setting went" table now names the tab as well as the field. Three rows moved to **FOG Client** — printer management level among them, which is the one people will go looking for on General.

**`hosts.md`**

- Removed a stale note saying Power Management is the one group control still behaving the 1.5 way.
- **New "Shutting down, restarting and waking hosts"** — the Power pane on Queue Task, what reaches the machine over the wire (wake) versus what waits for the FOG client (shut down, restart), and a pointer to schedules for anything repeating.
- The grant callout says four grants rather than snapins and printers.

## Depends on

| PR | What it is |
|---|---|
| [fogproject#1658](https://github.com/FOGProject/fogproject/pull/1658) | Power schedules become a grant — **merged** |
| [fogproject#1661](https://github.com/FOGProject/fogproject/pull/1661) | The Power pane on Queue Task — green, queued to merge |
| [fogproject#1662](https://github.com/FOGProject/fogproject/pull/1662) | The Grants column counts power schedules |

Both new cross-page anchors resolve in the built site; no broken wikilinks on either page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166dqQEjAs9fhqUw5zCjvxM