### PR TITLE
API docs: the unisearch routes, and what search matches

### DIFF
--- a/docs/1.6/kb/integrations/api.md
+++ b/docs/1.6/kb/integrations/api.md
@@ -213,7 +213,9 @@ Here are some core GET calls:
 | `/fog/task/active` | Returns a list of pending and active tasks. |
 | `/fog/multicastsession/current` | Returns a list of active multicast sessions. |
 | `/fog/host` | Returns a list of all the registered hosts. |
-| `/fog/<class>/search/<term>` | Returns the records of `<class>` that match the search term, e.g. `/fog/host/search/<term>` for hosts or `/fog/image/search/<term>` for images. |
+| `/fog/<class>/search/<term>` | Returns the records of `<class>` whose name contains the term (hosts also match on MAC address, storage nodes on node hostname, settings on value), e.g. `/fog/host/search/<term>` for hosts or `/fog/image/search/<term>` for images. The term is matched literally: `%` and `_` are not wildcards. A whole-number term also matches the id exactly. |
+| `/fog/unisearch?q=<term>&limit=<n>` | Searches every class at once and returns the matches grouped by class, each as `id` and `name`. `limit` caps the rows **per class**, not overall; omit it or pass `0` for no cap. Within a class, names that start with the term sort first. Both fields may be sent as POST body fields instead. Also reachable as `/fog/search?q=`. This is what the sidebar search box in the web UI calls. |
+| `/fog/unisearch/<term>/<n>` | The older path form of the call above. A term containing `/`, `?`, `#` or `%` cannot travel in a path segment, so prefer `?q=`. |
 
 ### POST
 


### PR DESCRIPTION
Adds `/fog/unisearch?q=<term>&limit=<n>` (grouped, per-class cap, prefix matches first, also as POST body fields) and the older `/fog/unisearch/<term>/<n>` path form to the 1.6 API page, and states the matching rules the per-class `search` shares with it: `%` and `_` are literal, a whole-number term also matches the id exactly.

Pairs with the fogproject search change (ranking, escaping, numeric-only id match, `?q=` route) opened alongside this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166dqQEjAs9fhqUw5zCjvxM