### PR TITLE
Document the customizations tree: what goes where, and which of /etc vs /opt

### DIFF
--- a/docs/1.6/kb/reference/pki-zones.md
+++ b/docs/1.6/kb/reference/pki-zones.md
@@ -315,17 +315,65 @@ ln -sf /etc/pki/fog/server.key /opt/fog/pki/web/leaf/.webLeaf.key
 ln -sf /etc/pki/fog/server.pem /opt/fog/pki/web/leaf/.webLeaf.pem
 ```
 
-Relocating a certificate then never means editing the vhost — or
-`.fogsettings`. The canonical path is what FOG recomputes and refers to every
-run, so pointing the *path* somewhere else does nothing; make the path
-**resolve** to your file instead. FOG reads the target, sees it is outside this
-zone, and leaves it alone.
+Relocating a certificate then never means editing the vhost. Two of these paths
+work either way round: leave `PKI_web_vhost_cert`/`PKI_web_vhost_key` alone and
+make each **resolve** to your file, as above, or set them in `.fogsettings` to
+where your files really are. The installer resets one only while it still holds
+a default of its own, so a path of your own survives every later run.
+`PKI_web_trust_chain` behaves the same way. The other keys under the
+`## Derived` marker genuinely are recomputed each run, and editing those does
+nothing.
+
+Either way FOG reads the target, sees it is outside this zone, and leaves it
+alone.
 
 >[!note]
 >SELinux labels follow the symlink **target**, so a certificate outside the
 >expected directories may need `restorecon` or `semanage fcontext` on the
 >real path. And a private key relocated into a world-readable directory
 >silently defeats the separation the Secure Boot signing helper depends on.
+
+### Where to put a certificate you brought
+
+>[!info] FOG 1.6
+>The customizations tree is a FOG 1.6 addition.
+
+`/etc/fog/customizations/pki/`, recorded as `PKI_custom_dir`. It is a
+**sibling** of `/etc/fog/pki/`, not a directory inside it, and that is the whole
+mechanism rather than a filing preference: FOG asks whether the canonical path
+resolves inside the web zone, so anything here answers "the administrator's"
+with no flag to set and nothing that can go stale. A `custom/` directory *under*
+`/etc/fog/pki` would answer the opposite and be regenerated over.
+
+The installer creates it and applies the right SELinux label, which is also the
+fix for the labelling problem noted above — a directory FOG creates carries the
+correct label instead of whatever an arbitrary location happened to have.
+
+**Drop a pair in and re-run the installer.** Two names:
+
+```
+/etc/fog/customizations/pki/web-leaf.pem
+/etc/fog/customizations/pki/web-leaf.key
+```
+
+FOG detects them, points the canonical paths at them, and stops re-issuing that
+leaf. There is nothing to edit.
+
+Both files are required, and they have to be a genuine pair — compared by
+subject public key rather than RSA modulus, so an EC key is judged correctly. A
+missing or mismatched key is **not** adopted: FOG's own leaf still serves,
+whereas adopting one would point the vhost at a certificate the web server
+cannot start with. Other filenames are not guessed at; record the path
+explicitly instead.
+
+`/etc/fog/customizations` is not `/opt/fog/customizations`, and the two run in
+opposite directions — FOG *writes* the `/opt` one (copies of your files, made
+before a run rebuilds the tree they lived in) and only *reads* the `/etc` one.
+There is a `readme.txt` in each saying so. Certificates and keys are on the
+`/etc` side for the same reason the PKI tree itself lives there; kernels and boot
+images stay under `/opt`, because the filesystem standard does not put binaries
+in `/etc`. See
+[[management/server/supported-customizations|Supported customizations]].
 
 ## HTTPS and netboot
 

--- a/docs/1.6/management/server/install-fogsettings.md
+++ b/docs/1.6/management/server/install-fogsettings.md
@@ -180,12 +180,22 @@ PKI_internal_subnets=''
 PKI_san_ip_addresses='10.0.0.39'
 PKI_san_dns_names=''
 PKI_client_cert_dir='/opt/fog/snapins/ssl'
+PKI_custom_dir='/etc/fog/customizations/pki'
 
 ## Derived -- do not edit
-## Canonical certificate paths. The installer recomputes these every
-## run, so editing a path here moves nothing. To use a certificate FOG
-## did not issue, leave the path alone and make it resolve to your file
-## (a symlink is enough) -- FOG then reads the target and leaves it be.
+## Canonical certificate paths. The installer recomputes most of these
+## every run, so editing one here moves nothing.
+##
+## The exceptions are PKI_web_vhost_cert, PKI_web_vhost_key and
+## PKI_web_trust_chain. To serve a certificate FOG did not issue you may
+## either leave those alone and make each path resolve to your file (a
+## symlink is enough), or set them to where your files really are -- the
+## installer only resets one of them while it still holds a default of
+## its own. Either way FOG stops re-issuing that leaf.
+##
+## Simplest of all: drop web-leaf.pem and web-leaf.key into
+## PKI_custom_dir above and re-run the installer, which finds the pair
+## and points these at it for you.
 PKI_root_ca_cert='/opt/fog/snapins/ssl/CA/.fogCA.pem'
 PKI_root_ca_key='/opt/fog/snapins/ssl/CA/.fogCA.key'
 PKI_web_ca_cert='/opt/fog/pki/web/ca/.fogWebCA.pem'
@@ -495,6 +505,7 @@ it belongs to; [[1.6/kb/reference/pki-zones|FOG PKI Infrastructure]] explains th
 | `PKI_san_ip_addresses` | Preference | Every address this server answers on. Used for certificate names, `server_name`/`ServerAlias`, and the nginx maintenance allow list |
 | `PKI_san_dns_names` | Preference | Extra names this server answers to, set with `--extra-server-name`. Mirrored into `FOG_EXTRA_SERVER_NAMES` in the web UI |
 | `PKI_client_cert_dir` | Preference | Holds uploaded snapin SSL material and the client communication certificate. **Not** where FOG's own authorities live any more |
+| `PKI_custom_dir` | Preference | Where **you** put certificates you brought yourself. Defaults to `/etc/fog/customizations/pki`, a sibling of FOG's own tree rather than a directory inside it — which is what makes FOG treat what you put there as yours. A `web-leaf.pem`/`web-leaf.key` pair here is adopted automatically |
 | `PKI_sb_enabled` | Preference | `1`/`0`. On by default. See [[1.6/management/server/install-fogsettings#Secure Boot\|Secure Boot]] |
 
 **Canonical paths** — these are records, under the `## Derived — do not edit`
@@ -523,22 +534,53 @@ marker in the file:
 This is the inverse of how it worked before 1.6, and it is worth reading before
 you touch a certificate path.
 
-**A `PKI_*` path is canonical.** FOG always refers to the vhost certificate as
-`PKI_web_vhost_cert`, and recomputes that path every run — so editing it moves
-nothing. To use a certificate FOG did not issue, leave the path alone and make it
-**resolve** to your file. A symlink is enough:
+**The simplest route: drop the pair in and re-run.** Put your certificate and
+its key in `PKI_custom_dir` under these two names:
 
 ```bash
-ln -sf /etc/letsencrypt/live/fog.example.com/fullchain.pem \
+install -d -m 0700 /etc/fog/customizations/pki
+cp fog.crt /etc/fog/customizations/pki/web-leaf.pem
+cp fog.key /etc/fog/customizations/pki/web-leaf.key
+./installfog.sh -Y
+```
+
+FOG finds the pair, points `PKI_web_vhost_cert` and `PKI_web_vhost_key` at it,
+and stops re-issuing that certificate. Nothing to edit. Both files are required
+and they must be a genuine pair — a missing or mismatched key is not adopted,
+and FOG carries on with its own certificate rather than leaving you with a web
+server that cannot start.
+
+**Or say where your files are.** Two ways, and either works:
+
+```bash
+# Record the real path.
+sed -i "s|^PKI_web_vhost_cert=.*|PKI_web_vhost_cert='/etc/pki/fog/web.crt'|" /opt/fog/.fogsettings
+
+# Or leave the path alone and make it resolve to your file.
+ln -sf /etc/letsencrypt/live/fog.example.com/cert.pem \
        /opt/fog/pki/web/leaf/.webLeaf.pem
 ln -sf /etc/letsencrypt/live/fog.example.com/privkey.pem \
        /opt/fog/pki/web/leaf/.webLeaf.key
 ```
 
-FOG then reads the target and leaves it alone. That is the whole mechanism: when
-the canonical path resolves *outside* FOG's own web zone directory, the leaf is
-somebody else's, so FOG will neither re-issue it nor lock its private key away
-from whatever renews it.
+`PKI_web_vhost_cert`, `PKI_web_vhost_key` and `PKI_web_trust_chain` are the
+three canonical paths you may set directly: the installer resets one only while
+it still holds a default of its own, and leaves any other value alone on every
+later run. The rest of the keys under the `## Derived` marker genuinely are
+recomputed, and editing those moves nothing.
+
+That is the whole mechanism: when the canonical path resolves *outside* FOG's
+own web zone directory, the leaf is somebody else's, so FOG will neither
+re-issue it nor lock its private key away from whatever renews it.
+
+>[!warning] Do not write your certificate *into* FOG's PKI tree
+>A real file at `/opt/fog/pki/web/leaf/.webLeaf.pem` is inside FOG's own web
+>zone, so FOG concludes the leaf is its, re-issues it, and overwrites yours.
+>`/opt/fog/pki` is a symlink to `/etc/fog/pki`, so both names are the same
+>directory and neither is safe.
+>
+>`/etc/fog/customizations/pki` is a **sibling** of that tree, not a
+>subdirectory, which is exactly why a certificate there is read as yours.
 
 >[!important] This replaces `acmeLeaf`, and you no longer set anything by hand
 >`acmeLeaf` had to be typed in, and forgetting it was expensive: FOG re-issued

--- a/docs/management/server/supported-customizations.md
+++ b/docs/management/server/supported-customizations.md
@@ -43,14 +43,34 @@ to updates driven through `bin/updatefog.sh`.
 **Supported, but yours to place** means FOG will not overwrite it and provides
 a defined place for it, but does not create or manage it.
 
+**Adopted** means you put a file in a defined place and FOG wires it up on the
+next `installfog.sh` run, with nothing to configure. Certificates you bring
+work this way.
+
 **Not preserved** means exactly that. Those cases are listed at the end
 rather than left for you to discover.
 
-Everything preserved automatically is copied to
-`/opt/fog/customizations/` (strictly, `$fogprogramdir/customizations`) before
-the web tree is rebuilt, and copied back afterward. That directory is
-outside the web root, which is why it survives — the installer rebuilds
-`/var/www/html/fog` wholesale on every run.
+## The two customizations directories
+
+There are two. They are not interchangeable, and they run in **opposite
+directions**. Each carries a `readme.txt` saying which is which.
+
+| | `/opt/fog/customizations/` | `/etc/fog/customizations/` |
+|---|---|---|
+| Written by | **FOG** | **you** |
+| What it is | copies FOG makes of your files before it rebuilds the tree they live in, and restores from afterward | an input FOG only ever reads |
+| Holds | `ipxe-bg/`, `ipxe-legacy/`, `kernel-backups/` | `pki/` |
+
+Strictly the first is `$fogprogramdir/customizations`. It sits outside the web
+root, which is why what it holds survives — the installer rebuilds
+`/var/www/html/fog` wholesale on every run. Everything listed as *automatic*
+below is copied there and back.
+
+**Why two rather than one.** Certificates and private keys are small, secret
+and irreplaceable, so they belong under `/etc` — what a backup policy and a
+config-management run already capture. Kernels and boot images are large,
+rebuildable binaries, and the filesystem standard does not put binaries under
+`/etc`. FOG's own PKI moved to `/etc/fog/pki` for the same reason.
 
 ---
 
@@ -138,6 +158,66 @@ kept by default; change that with `installfog.sh --kernel-backup-count N`.
 
 Restoring re-signs the kernels if Secure Boot is configured, since a restored
 kernel carries its old signature and the signing key may have rotated.
+
+---
+
+## Web certificates you bring
+
+**Adopted.** Put the pair in `/etc/fog/customizations/pki/` under these two
+names and re-run the installer:
+
+```
+/etc/fog/customizations/pki/web-leaf.pem
+/etc/fog/customizations/pki/web-leaf.key
+```
+
+That is the whole procedure. FOG finds them, points its own canonical paths at
+them, and stops re-issuing that certificate — there is nothing to set in
+`.fogsettings` and no symlink to make. The installer says so when it happens:
+
+```
+ * Detected a web certificate managed outside FOG:
+     /etc/fog/customizations/pki/web-leaf.pem is a certificate you supplied, with a matching key
+ * FOG will keep managing this vhost, but will not re-issue or
+   re-key that certificate.
+```
+
+FOG goes on managing the rest of the vhost — the HTTPS redirect, the iPXE
+exclusions, HSTS — because nobody wants to hand-maintain those. Only the
+certificate becomes yours.
+
+>[!important] It has to be *beside* FOG's PKI tree, not inside it
+>`/etc/fog/customizations/pki/` is a **sibling** of `/etc/fog/pki/`, and that is
+>what makes the whole thing work rather than being a tidiness preference. FOG
+>decides "is this leaf mine or the admin's" by asking whether the path resolves
+>inside its own web zone. A certificate written *into* `/etc/fog/pki/web/leaf/`
+>is read as one FOG issued, and the next run regenerates over it.
+>
+>Note that `/opt/fog/pki` is a symlink to `/etc/fog/pki`, so those two are the
+>same directory — writing to either is writing inside FOG's tree.
+
+**Both files are required, and they have to be a genuine pair.** FOG compares
+the certificate's public key against the private key. If the key is missing or
+does not match, the pair is **not** adopted and FOG carries on with its own
+certificate — which is deliberate: adopting a mismatched pair would point the
+web server at a certificate it cannot start with, whereas declining leaves a
+server that still serves.
+
+Only those two filenames are looked for. FOG does not guess among other names,
+because guessing wrong would repoint your vhost without telling you. If your
+files are named something else, or live somewhere else entirely, record the
+paths instead — see
+[[1.6/management/server/install-fogsettings|.fogsettings]] and the
+[[kb/reference/pki-zones|PKI zones reference]].
+
+**Renewal is yours.** FOG never renews a certificate it did not issue. Point
+your ACME client's install hook or reload command at these paths and let it
+rewrite them in place; FOG re-reads them on each run and leaves them alone. A
+worked example, including Cloudflare DNS-01, is in
+[[kb/how-tos/lets-encrypt-setup|Set up Let's Encrypt on a FOG server]].
+
+FOG also leaves the permissions on your private key alone, so a renewal hook
+running as something other than root keeps working.
 
 ---
 


### PR DESCRIPTION
FOG 1.6 gains `/etc/fog/customizations/pki` as the place for certificates you bring, adopted automatically when a `web-leaf.pem`/`web-leaf.key` pair is found there — [FOGProject/fogproject#1681](https://github.com/FOGProject/fogproject/pull/1681). Three pages an admin actually reaches for said nothing about it.

> [!important]
> **Merge after FOGProject/fogproject#1681.** The adoption behavior these pages describe does not exist before it.

## `supported-customizations`

The most work, because this is the page that answers *"where do I put this"*.

- **New "The two customizations directories" section.** There are now two and they are **not** interchangeable: FOG *writes* `/opt/fog/customizations` (copies of your files, made before it rebuilds the tree they live in) and only *reads* `/etc/fog/customizations`. A `readme.txt` in each says so on the server itself. Also explains why two rather than one — `/etc` for small, secret, irreplaceable config a backup already captures; `/opt` for large rebuildable binaries the FHS will not put under `/etc`.
- **A fourth category, "Adopted"**, alongside automatic / yours to place / not preserved. A drop-in is neither of the first two: FOG does not create it, but does actively wire it up.
- **New "Web certificates you bring" section**, leading with the two filenames, then the fact that both are required and must be a genuine pair — and why declining a mismatch is the safe answer: adopting one points the web server at a certificate it cannot start with, while FOG's own leaf still serves.

## `install-fogsettings` (1.6)

Adds `PKI_custom_dir` to the preference table and the sample `.fogsettings`, which now matches what the installer emits.

It also carried a claim worth fixing on its own merits:

> `PKI_web_vhost_cert`, and recomputes that path every run — so editing it moves nothing.

True of most canonical keys, **false of the three that matter.** `_resolveWebLeafPaths()` resets `PKI_web_vhost_cert` only while it holds one of four known-FOG defaults, and `createWebIntermediateCA()` treats `PKI_web_trust_chain` the same way — so recording your own path there works, and always has. A reader who believed that sentence had no way to discover it. The section now presents the drop-in, the recorded path and the symlink as three routes, and keeps the one genuine trap.

## `pki-zones` (1.6)

The same correction, plus a "Where to put a certificate you brought" subsection under Certificate paths — placed next to the SELinux warning it partly resolves, since a directory FOG creates carries the right label, unlike an arbitrary symlink target.

## One repetition, on purpose

The sibling-not-child point appears on all three pages. It is the single thing that makes the mechanism work, it is invisible, and getting it wrong is silent: anything under `/etc/fog/pki` — or `/opt/fog/pki`, the same directory through a symlink — is read as FOG's own and regenerated over. That is exactly the mistake #178 made before it was corrected.

## Validation

`npm run docs:build` clean, `check-version-split.mjs` consistent, `check-anchors.mjs` introduces no new breakage (3 pre-existing failures remain on unrelated pages: `storage-node`, `bios-and-uefi-co-existence`, `primary-mac-address-issues`), and the built HTML carries no literal `[[` on any of the three pages. Link forms match each page's existing conventions — `supported-customizations` already used both `[[1.6/management/server/install-fogsettings|…]]` and `[[kb/reference/pki-zones|…]]`, so no new pattern was introduced.

Prose keeps this repo's UK spellings rather than importing fogproject's US-enforced style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNj39e7pDke6Rr6Whxin9U
