### PR TITLE
docs: fix every broken internal anchor

### DIFF
--- a/docs/1.6/management/web/groups.md
+++ b/docs/1.6/management/web/groups.md
@@ -364,7 +364,7 @@ created it was gone.
 One thing you may need to do. The trigger copied `hostADPass` — the Active
 Directory join password — from the template host onto hosts that joined the
 group. If you are rotating a join account, read the warning on
-[[1.6/management/web/plugins#persistentgroups is gone, because the defect it worked around is fixed|the Plugins page]]
+[[1.6/management/web/plugins#The bundled plugins|the Plugins page]]
 before you assume the old credential is gone.
 
 If you had it installed, check afterward that

--- a/docs/1.6/management/web/storage-node.md
+++ b/docs/1.6/management/web/storage-node.md
@@ -26,7 +26,7 @@ tags:
     1. Increased throughput 
     2. Redundant Storage 
     3. Scalability 
-- Also see [ Storage Nodes](Knowledge_Base#Storage_Nodes "wikilink") for tutorials.
+- Also see the [[kb/index|Knowledge Base]] for tutorials.
  
 ## Adding a Storage Node
 

--- a/docs/kb/how-tos/bios-and-uefi-co-existence.md
+++ b/docs/kb/how-tos/bios-and-uefi-co-existence.md
@@ -209,7 +209,7 @@ DNS Server. The range for this configuration is set to 10.0.0.20 through
     }
 
 When you have Mac OS clients as well you might want to check out this:
-[FOG_on_a_MAC#architecture](FOG_on_a_MAC#architecture "wikilink")
+[FOG on a MAC](https://wiki.fogproject.org/wiki/index.php?title=FOG_on_a_MAC "FOG on a MAC")
 
 Restart the DHCP service and you are good to go!
 

--- a/docs/management/web/display-timezone.md
+++ b/docs/management/web/display-timezone.md
@@ -29,18 +29,18 @@ into the database, so changing it did not re-present the times already
 recorded, it changed what those recorded times were taken to *mean*. FOG now
 writes **UTC**, and `FOG_TZ_INFO` no longer has any bearing on what is stored.
 
-!!! warning "Changing FOG_TZ_INFO still re-labels the older records"
-    Dates written *before* your server moved to UTC were written in whichever
-    zone `FOG_TZ_INFO` named at the time, and that is still how they are read.
-    Changing the setting therefore changes how those older dates are
-    interpreted, though not how anything written since is. Nothing is
-    rewritten, and nothing warns you.
-
-    Those older dates are marked on screen — see
-    [[unadjusted-timestamps|Timestamps Before the UTC Change]].
-
-    If you only want people to *see* a different timezone, that is the per-user
-    setting below, and it is the one you almost certainly want.
+>[!warning] Changing FOG_TZ_INFO still re-labels the older records
+>Dates written *before* your server moved to UTC were written in whichever
+>zone `FOG_TZ_INFO` named at the time, and that is still how they are read.
+>Changing the setting therefore changes how those older dates are
+>interpreted, though not how anything written since is. Nothing is
+>rewritten, and nothing warns you.
+>
+>Those older dates are marked on screen — see
+>[[unadjusted-timestamps|Timestamps Before the UTC Change]].
+>
+>If you only want people to *see* a different timezone, that is the per-user
+>setting below, and it is the one you almost certainly want.
 
 ## Your own timezone
 


### PR DESCRIPTION
`scripts/check-anchors.mjs` was reporting three broken links on `master`. It
now reports **zero**. None of these warned at build time — each one silently
dropped its fragment and landed the reader at the top of some other page.

| Page | Was | Now |
|---|---|---|
| `1.6/management/web/groups.md` | `plugins#persistentgroups is gone, because the defect it worked around is fixed` | `plugins#The bundled plugins` |
| `1.6/management/web/storage-node.md` | `Knowledge_Base#Storage_Nodes "wikilink"` | `[[kb/index\|Knowledge Base]]` |
| `kb/how-tos/bios-and-uefi-co-existence.md` | `FOG_on_a_MAC#architecture "wikilink"` | the old wiki over HTTP |

**The groups one is the interesting failure.** The string it pointed at is
real and appears on the Plugins page — but it is a **callout title**, not a
heading, so it never becomes an `id`. Retargeted to the section that actually
encloses the callout.

The other two are MediaWiki-era links left over from the wiki migration.
`Knowledge_Base` has a current equivalent, so it gets one. `FOG_on_a_MAC` was
never migrated, so it points at the old wiki over HTTP — which is exactly what
`kb/troubleshooting/troubleshoot-tftp.md` already does for that same page.

## Also: the one real literal-wikilink leak

The `grep -ro '\[\[' quartz/public` check in `VERSIONING.md` had a genuine hit
in `management/web/display-timezone.md`. The cause is worse than a bad link:
the page used MkDocs `!!! warning "…"` admonition syntax, which Quartz does
not parse. Its 4-space-indented body was therefore read as an **indented code
block**, so four paragraphs of prose rendered as literal code on the published
page and the wikilink inside them rendered as raw `[[…]]` text. Converted to
an Obsidian callout; the built page now emits a real callout and all three
`unadjusted-timestamps` links resolve.

Five files still carry `!!!` admonitions — the known accepted gap recorded in
`quartz/README.md`. I checked: none of the others swallows a link, so they are
left alone rather than sprawling this diff. The two `[[` hits still in the
built HTML are deliberately escaped `\[\[` migration leftovers in
`dashboard.md` and `1.5/management/web/groups.md` naming retired wiki pages —
literal text, not broken links.

## Checks

| Check | Result |
|---|---|
| `scripts/check-anchors.mjs` | **3 broken → 0.** "Every internal #fragment resolves." |
| `npm run docs:build` | exit 0, no warnings |
| `scripts/check-version-split.mjs` | clean |
| literal `[[` grep | only code blocks and the two escaped leftovers remain |

Each fix was verified in the emitted HTML, not just in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zwpzLfJg1LzBEY8oXnjaf
