### PR TITLE
Document the FOG Agent

### DIFF
--- a/docs/installation/client/index.md
+++ b/docs/installation/client/index.md
@@ -12,4 +12,5 @@ tags:
 
 These are pages related to installing the client on hosts and any other initial configuration.
 
-- [[install-fog-client|Install Fog Client]]
+- [[install-fog-agent|Install the FOG Agent]] — FOG 1.6 and later
+- [[install-fog-client|Install Fog Client]] — the legacy client, for FOG 1.5

--- a/docs/installation/client/install-fog-agent.md
+++ b/docs/installation/client/install-fog-agent.md
@@ -1,0 +1,304 @@
+---
+title: Install the FOG Agent
+aliases:
+    - Install the FOG Agent
+    - Install FOG Agent
+    - fog-agent
+description: Install and enroll the FOG Agent, the management agent that replaces the legacy FOG client on FOG 1.6 servers
+context_id: install-fog-agent
+tags:
+    - 1_6-changes
+    - install
+    - client
+    - agent
+    - fog-agent
+    - silent-install
+    - setup
+---
+
+# Install the FOG Agent
+
+>[!info] FOG 1.6 and later
+>The FOG Agent talks to the `/agent/v1` routes that exist only on a FOG 1.6
+>server. Against a 1.5 server it logs "server does not support agent
+>protocol 1" and retries hourly, doing nothing else. For 1.5, install the
+>legacy client instead: [[install-fog-client|Install the FOG client]].
+
+The FOG Agent (`fog-agent`) is the program that runs on the machines you
+manage. It replaces the legacy FOG client. Where the old client polled for
+jobs and ran them, the agent holds the state your FOG server describes for
+the host and keeps the machine in it: the hostname, directory membership,
+printers, software, power schedule, and auto log out. It also reports what
+the machine actually is, so hardware inventory, installed software, logon
+sessions, and Secure Boot posture on the host page come from the agent
+rather than from the last imaging task.
+
+This page gets the agent onto a machine and enrolled. What it does once it
+is running, and how you steer it from the web UI, is on
+[[fog-agent|The FOG Agent]].
+
+## Before you start
+
+- **A FOG 1.6 server reachable over HTTPS.** The agent never speaks plain
+  HTTP. The server URL is the same one the web UI uses, plus `/fog`, for
+  example `https://fog.example.org/fog`.
+- **The CA certificate the agent should trust.** The agent trusts only the
+  certificate bundle you hand it at install, never the operating system's
+  trust store. For a server using FOG's own certificate authority, that file
+  is published at `https://fog.example.org/fog/management/other/ca.cert.pem`.
+  If your web UI uses a public certificate, for example from Let's Encrypt,
+  give the agent that CA's PEM instead.
+- **A way to approve the enrollment.** Either an enrollment token from
+  **Host Management → Agent Enrollment Tokens**, or a person who will approve
+  the host on **Host Management → Pending Agents** after install. See
+  [Enrollment and approval](#enrollment-and-approval).
+- **Supported platforms.** Windows 10 and later on x64 and arm64 is the
+  supported install and the only one with a packaged installer. Linux on
+  x64, arm64 and armv7 runs the same agent from a service unit you provide.
+  macOS binaries are built but the agent is not yet supported there.
+
+>[!warning] The legacy FOG client must not run beside the agent
+>Both talk to the same host record. When both are installed, whichever asks
+>first consumes an on-demand shutdown or a queued task and the other never
+>sees it. The Windows installer removes the legacy client for you. On
+>Linux, uninstall it yourself before enrolling the agent.
+
+## Download
+
+Releases are published on GitHub at
+<https://github.com/FOGProject/fog-agent/releases>. Each release carries:
+
+| File | Use |
+|---|---|
+| `fog-agent-<version>-x64.msi` | Windows installer, 64-bit. The supported way to install on Windows |
+| `fog-agent-windows-amd64.exe`, `fog-agent-windows-arm64.exe`, `fog-agent-windows-386.exe` | Bare Windows binaries, for a hand install |
+| `fog-agent-linux-amd64`, `fog-agent-linux-arm64`, `fog-agent-linux-arm` | Linux binaries |
+| `fog-agent-darwin-amd64`, `fog-agent-darwin-arm64` | macOS binaries, unsupported for now |
+| `SHA256SUMS` | Checksums for everything above |
+
+>[!warning] Releases are not yet code-signed
+>The project has applied for a code-signing certificate but does not hold
+>one yet. Until it does, Windows shows a SmartScreen warning on install and
+>Defender may quarantine the binary. The release notes on GitHub say
+>whether a given release is signed. Verify the download against
+>`SHA256SUMS` before deploying it.
+
+Unlike the legacy client, the agent is not served from your FOG server. One
+release serves every FOG server, and the agent works against a server that
+is behind it: features the server does not offer simply stay idle.
+
+## Windows
+
+The agent runs as a Windows service named `fog-agent`, display name
+**FOG Agent**, under the SYSTEM account.
+
+### The MSI
+
+The MSI takes its settings as properties, so it works from a command line,
+a Group Policy software installation, or any deployment tool:
+
+```
+msiexec /i fog-agent-1.2.3-x64.msi /qn SERVER=https://fog.example.org/fog CA=C:\path\ca.cert.pem TOKEN=... /l*v C:\fog-agent-install.log
+```
+
+| Property | Meaning |
+|---|---|
+| `SERVER` | Base URL of the FOG server, the web UI's address plus `/fog` |
+| `CA` | Path to the PEM bundle to trust: the FOG CA (`management/other/ca.cert.pem` on the server) or the public CA the web UI uses |
+| `TOKEN` | An enrollment token. Optional. Without one the host waits on **Pending Agents** until someone approves it |
+| `WEBADDRESS`, `WEBROOT` | The legacy client's property names, honored when `SERVER` is absent. `SERVER` becomes `https://WEBADDRESS` + `WEBROOT`, so deployment scripts written for the old client keep working |
+
+The installer, in order:
+
+1. Removes the legacy FOG client ("FOG Service", fog-client 0.x) if it is
+   installed.
+2. Puts `fog-agent.exe` in `%ProgramFiles%\FOG`.
+3. Runs `fog-agent setup` as SYSTEM. This writes the server URL and CA
+   bundle into the state directory `%ProgramData%\FOG\agent`, restricts that
+   directory to SYSTEM and Administrators before the host's private key is
+   generated, and makes the first enrollment request.
+4. Registers the service for automatic start and starts it.
+
+A server that does not answer at install time is not an install failure.
+The token is kept and the service keeps trying, so the MSI can go onto
+machines that are off the network at that moment. A bad CA path or an
+unwritable state directory does fail the install, and the reason is in the
+`msiexec` log.
+
+Running a newer MSI over an older one replaces the binary in place and
+leaves the state directory alone. The host keeps its key and certificate
+and does not re-enroll, and the properties are optional on an upgrade.
+
+Uninstalling through Apps & Features, or with `msiexec /x`, removes the
+service and the binary. It deliberately leaves the state directory, so a
+reinstall picks up the same identity without another approval. Delete
+`%ProgramData%\FOG\agent` by hand if you want the machine to enroll fresh.
+
+### Hand install
+
+From an administrator prompt:
+
+```
+fog-agent.exe service install --server https://fog.example.org/fog --ca ca.cert.pem [--token T]
+```
+
+This does what the MSI does using the binary itself: the `setup` step, a
+copy to `%ProgramFiles%\FOG\fog-agent.exe`, the service registration with
+restart on failure (10 seconds, 1 minute, then 5 minutes), an Application
+event log source, and start. It does not remove the legacy client.
+
+`fog-agent service status`, `service stop`, `service start` and
+`service uninstall` manage the service afterward.
+
+### Where things are on Windows
+
+| What | Where |
+|---|---|
+| Binary | `%ProgramFiles%\FOG\fog-agent.exe` |
+| State: key, certificate, server URL, CA bundle | `%ProgramData%\FOG\agent`, readable by SYSTEM and Administrators only |
+| Log | `C:\ProgramData\FOG\fog-agent.log`, rolled to `fog-agent.log.1` past 1 MB. Readable by any user, and it never contains a key, certificate or token, so it is safe to post on the forums |
+| Event log | Application log, source `fog-agent`: start, stop and fatal errors |
+| Installer log | Wherever you pointed `/l*v` |
+
+## Linux
+
+There is no Linux package yet. The agent is a single static binary and runs
+from a systemd unit you write. Everything runs as root: the agent changes
+the hostname, joins directories, and manages CUPS.
+
+1. Put the binary somewhere on the root path and make it executable:
+
+   ```bash
+   sudo install -m 0755 fog-agent-linux-amd64 /usr/local/bin/fog-agent
+   ```
+
+2. Enroll once. This creates the state directory `/var/lib/fog-agent`,
+   generates the key, remembers the server and CA, and waits for the
+   certificate to be issued:
+
+   ```bash
+   sudo fog-agent enroll --server https://fog.example.org/fog --ca ca.cert.pem --token T
+   ```
+
+   Without a token the command waits until someone approves the host on
+   **Pending Agents**. Add `--once` to send one request and exit instead.
+
+3. Create a unit. The agent writes its log to standard error, which the
+   journal captures:
+
+   ```ini
+   [Unit]
+   Description=FOG Agent
+   After=network-online.target
+   Wants=network-online.target
+
+   [Service]
+   ExecStart=/usr/local/bin/fog-agent run
+   Restart=on-failure
+   RestartSec=10
+
+   [Install]
+   WantedBy=multi-user.target
+   ```
+
+   Save it as `/etc/systemd/system/fog-agent.service`, then:
+
+   ```bash
+   sudo systemctl daemon-reload
+   sudo systemctl enable --now fog-agent
+   journalctl -u fog-agent -f
+   ```
+
+`fog-agent run` enrolls first if step 2 was skipped, using `--server`,
+`--ca` and `--token` if you put them on the `ExecStart` line, so the
+separate enroll step is a convenience for watching the approval happen.
+
+## macOS
+
+Binaries are built for both Intel and Apple Silicon and the agent will
+enroll and poll from `/Library/Application Support/fog-agent`, but no
+capability has been proven on macOS and there is no launchd integration
+or package. Treat it as unsupported for now.
+
+## Enrollment and approval
+
+The agent identifies the machine by its firmware identity, the SMBIOS
+system UUID, serial numbers and asset tag, plus its MAC addresses, the same
+values FOG records at PXE boot. It authenticates with a private key it
+generates on the machine and never sends. Enrollment is the agent asking
+the server to issue a certificate for that key, and the server deciding
+which host record the key belongs to.
+
+Approval is automatic in exactly two cases:
+
+- **A valid enrollment token.** Mint one at **Host Management → Agent
+  Enrollment Tokens**. A token is shown once, has a required expiry, and
+  allows a fixed number of uses or unlimited uses until it expires. Revoke
+  it there at any time. A token also registers a machine FOG has never seen,
+  so it is how you enroll a host that was not imaged by FOG.
+- **A deploy FOG just finished.** If this server completed a deploy task to
+  the matched host within `FOG_AGENT_ENROLL_DEPLOY_WINDOW` hours (default 24,
+  under FOG Configuration → FOG Settings → General Settings), the agent is
+  enrolled without a click. The deploy was the approval. Set it to 0 to turn
+  this off.
+
+Everything else waits on **Host Management → Pending Agents**, where the
+reason is shown:
+
+| Reason | What it means |
+|---|---|
+| `unknown-host` | Nothing matched. A pending host record was created, so approving also registers the machine |
+| `known-host-no-agent` | The host exists and has never had an agent |
+| `rebind` | The host already has a different key bound to it. Either it was reimaged without a deploy FOG knows about, or something is claiming an enrolled machine's identity. Look before approving |
+| `identity-conflict` | The firmware identity matches more than one host. Fix the duplicate host records first |
+| `reissue` | The same key, asking again after its certificate was lost. The agent kept its key but not its certificate |
+| `no-mac` | The request carried no usable MAC address |
+
+Approving issues the certificate, which the agent collects on its next
+attempt, every five minutes while pending. Denying pins the key as refused.
+A denied agent keeps asking hourly and keeps being refused until it is
+enrolled with a new key, which means deleting its state directory.
+
+Once enrolled, every request is mutual TLS and the certificate maps to the
+host record. Renames, address changes and DHCP moves do not touch it. The
+certificate lasts one year and the agent renews it over its existing
+session inside the last 120 days. If the host is deleted from FOG, or a
+different key is approved for it, the old certificate stops working at once
+and the agent goes back to pending.
+
+## Check that it worked
+
+On the machine:
+
+```
+fog-agent status
+```
+
+prints the state directory, the server URL, whether a key exists, whether
+the machine is enrolled, and the host id it enrolled as. `fog-agent
+identity` prints the firmware identity the server matched on, which is the
+thing to compare against the host's record when a match goes wrong.
+
+On the server, the host's page shows **Last Agent Check-In** on the General
+tab, and the **Agent Activity** tab under History Items lists what the agent
+has done.
+
+## Upgrading
+
+The agent does not update itself. On Windows, run the newer MSI; on Linux,
+replace the binary and restart the unit. Enrollment survives both because
+the state directory is untouched. The agent is released more often than
+FOG, and a newer agent against an older 1.6 server is the expected case:
+the server tells the agent which capabilities it has, and the agent leaves
+the rest idle.
+
+## Moving from the legacy client
+
+Nothing on the server has to change first. Hosts, groups, printers, snapins,
+power schedules and module toggles all carry over, and the legacy client's
+endpoints stay live, so a fleet can run both generations while you migrate.
+Per host, install the agent and let the installer remove the old client.
+The differences an admin notices are on [[fog-agent|The FOG Agent]]: printers
+are described by URI rather than type, the Active Directory join no longer
+sends the join password to every machine, and user tracking records sessions
+rather than login and logout events.

--- a/docs/installation/client/install-fog-client.md
+++ b/docs/installation/client/install-fog-client.md
@@ -15,6 +15,11 @@ tags:
 
 # Install the FOG client
 
+>[!info] FOG 1.6 has a new agent
+>On a FOG 1.6 server, install the [[install-fog-agent|FOG Agent]] instead.
+>The client on this page is the legacy client; it keeps working against 1.6
+>during a migration, but new capabilities land only in the agent.
+
 The FOG client is an agent running on the machines you are managing with
 Fog. With the FOG client you can perform various tasks such as managing
 printers, change the host name and join Active Directory (for Windows

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -12,4 +12,4 @@ These are articles related to the installation and setup of FOG in your network,
 
 - [[installation/server/index|Server Install]] — start here for a new FOG server
 - [[installation/network-setup/index|Network Setup]] — configuring DHCP/PXE if FOG isn't hosting it
-- [[installation/client/index|Client Install]] — installing the FOG client on hosts
+- [[installation/client/index|Client Install]] — installing the FOG Agent (1.6) or the FOG client (1.5) on hosts

--- a/docs/kb/how-tos/chocolatey-snapins.md
+++ b/docs/kb/how-tos/chocolatey-snapins.md
@@ -21,6 +21,12 @@ tags:
 >described under [Why you no longer need a placeholder .bat](#why-you-no-longer-need-a-placeholder-bat)
 >still applies there.
 
+>[!tip] Prefer Software on 1.6 with the FOG Agent
+>If your hosts run the [[install-fog-agent|FOG Agent]], assign packages
+>through [[software|Software Management]] instead. It uses the same
+>Chocolatey, but knows what is installed, corrects drift, and reports the
+>installed version per host. The templates below run once and cannot.
+
 [Chocolatey](https://chocolatey.org/) is a package manager for Windows. If
 your hosts already have it, you can let it do the fetching and installing and
 keep FOG doing what it is good at — deciding *which* machines get *what*, and

--- a/docs/kb/reference/fog-agent-reference.md
+++ b/docs/kb/reference/fog-agent-reference.md
@@ -1,0 +1,196 @@
+---
+title: FOG Agent Reference
+aliases:
+    - FOG Agent Reference
+    - fog-agent command line
+    - fog-agent reference
+description: The fog-agent commands, the files it keeps, how it authenticates, how often it does things, and exactly what it sends to the server
+context_id: fog-agent-reference
+tags:
+    - 1_6-changes
+    - reference
+    - agent
+    - fog-agent
+    - security
+    - privacy
+---
+
+# FOG Agent Reference
+
+>[!info] FOG 1.6 and later
+>The FOG Agent works only against a FOG 1.6 server. Installing it is on
+>[[install-fog-agent|Install the FOG Agent]]; what it does day to day is on
+>[[fog-agent|The FOG Agent]]. This page is the reference behind both.
+
+## Commands
+
+`fog-agent` is one binary with subcommands. Every command that touches the
+state directory takes `--dir DIR` to use a different one; the default is the
+platform's state directory below.
+
+| Command | What it does |
+|---|---|
+| `fog-agent identity` | Prints the firmware identity and MAC list the agent will present: system UUID, system and board serials, chassis asset tag, SMBIOS version. This is what the server matches against a host record |
+| `fog-agent enroll --server URL --ca FILE [--token T] [--once]` | Creates the key if needed, sends the enrollment request, and waits until a certificate is issued. `--once` sends one request, prints the answer as JSON and exits |
+| `fog-agent run [--server URL] [--ca FILE] [--token T] [--once]` | The service loop: enroll if there is no certificate, then poll. `--server` and `--ca` are needed only the first time; both are remembered. `--once` does one poll and exits |
+| `fog-agent status` | Prints the state directory, server URL, host id, whether a key exists and whether the machine is enrolled |
+| `fog-agent renew` | Renews the certificate now for the same key, regardless of expiry |
+| `fog-agent version` | Prints the version, OS and architecture |
+| `fog-agent setup --server URL --ca FILE [--token T]` | Windows. Prepares the state directory, its permissions and the first enrollment request without registering a service. The MSI runs this |
+| `fog-agent service install --server URL --ca FILE [--token T]` | Windows. `setup`, then copies the binary to Program Files, registers and starts the service |
+| `fog-agent service uninstall`, `start`, `stop`, `status` | Windows service control. On Linux and macOS the agent is run by systemd or launchd and this command refuses |
+
+The agent has no configuration file to edit. The server URL and CA bundle
+are written into the state directory at enrollment; everything else comes
+from the server on each poll.
+
+## Files
+
+| Platform | State directory | Log |
+|---|---|---|
+| Windows | `%ProgramData%\FOG\agent`, ACL cut to SYSTEM and Administrators | `C:\ProgramData\FOG\fog-agent.log`, rolled to `.log.1` at 1 MB; start, stop and fatal errors also in the Application event log, source `fog-agent` |
+| Linux | `/var/lib/fog-agent`, root only | Standard error, so the journal of whatever unit runs it |
+| macOS | `/Library/Application Support/fog-agent` | Standard error |
+
+The state directory holds the private key, the issued certificate, the CA
+bundle the agent trusts, the server URL, the host id, the firmware identity
+the key was generated for, and a small amount of bookkeeping (which desired
+state revision was applied, hashes of the facts last sent, the minute a
+schedule last fired). The log records what the agent did. It never contains
+the key, the certificate, a token, or a credential the server sent.
+
+## Identity and trust
+
+**Which host is this?** is answered by the firmware identity plus MAC list,
+the same values FOG reads at PXE boot, so an agent, iPXE and FOS all name a
+machine the same way. That identity is discoverable by anyone, so it may
+resolve a host record but never authenticates.
+
+**Is this really that host?** is answered by an ECDSA P-256 key the agent
+generates on the machine and never sends. The key is generated *for* an
+identity: if the firmware identity changes underneath it, a motherboard swap
+or a captured image with an enrolled agent's key inside it landing on
+different hardware, the agent discards the key and enrolls again as a new
+machine. A clone cannot present as the original.
+
+Enrollment sends a certificate signing request. The server signs it with a
+dedicated **FOG Agent CA**, an intermediate under the FOG root that issues
+client certificates only, so nothing it signs can pose as a server. The
+certificate's subject is `fog-agent host N` and nothing else: it names a
+host row, not a hostname or address, so renames and re-addressing never
+touch it. It lasts one year; the agent renews it over its existing session
+during the last 120 days.
+
+Every request after enrollment is mutual TLS. The web server verifies the
+client certificate on `/agent/`, PHP verifies it again independently, and
+the certificate's key fingerprint is looked up on the host row. There are no
+shared secrets, no per-host AES key, and nothing to rotate. Revocation is
+the database: clearing the fingerprint, deleting the host, or approving a
+different key all refuse the old certificate at once, and the agent, seeing
+that refusal, drops its certificate and goes back to enrolling.
+
+The agent trusts only the CA bundle it was given at install, never the
+operating system trust store, and it talks to exactly one server. A
+different server with a valid public certificate is still not its server.
+
+Where the FOG certificate authorities sit relative to each other is on
+[[1.6/kb/reference/pki-zones|FOG PKI Infrastructure]].
+
+## The protocol
+
+HTTPS and JSON, outbound from the agent only, under `/agent/v1/` on the FOG
+server. Both the routes and their schemas are in the server's own OpenAPI
+document, see [[api-openapi-reference|the API reference]].
+
+| Route | Purpose |
+|---|---|
+| `POST /agent/v1/enroll` | Server-authenticated TLS only; the agent has no certificate yet. Idempotent: the agent repeats the identical request until it gets `issued` or `denied` |
+| `POST /agent/v1/poll` | The heartbeat. Carries the agent version, the desired-state revision it applied, and any facts or sessions that changed. The answer carries the poll interval, and the full desired state only when the revision the agent applied is not current |
+| `GET /agent/v1/payload/{capability}/{id}` | Fetches a snapin payload over the authenticated session, checked against the SHA-512 the desired state declared |
+| `POST /agent/v1/result` | What the agent did with one capability at one revision. The server answers with the outcome, which is what the agent acts on |
+| `POST /agent/v1/renew` | A new certificate for the same key |
+
+The agent owns the contract and the server answers what it can. On every
+poll the server lists the capabilities it supports, and the agent exercises
+only those. A capability the server does not list leaves that provider
+idle, with one informative log line, never an error. This is why a current
+agent runs against an older 1.6 server without complaint, and why the
+project releases the agent independently of FOG.
+
+Credentials never ride a routine poll. The domain-join credential appears
+only inside a poll answer for a host that is not joined and should be, and
+is not sent again once the host reports it is joined.
+
+## Timing
+
+| What | How often |
+|---|---|
+| Poll | Every 300 seconds, set by the server in each answer |
+| Pending enrollment retry | Every 5 minutes, or the interval the server names |
+| Denied or unsupported-protocol retry | Hourly |
+| Certificate renewal | Attempted after a successful poll, inside the last 120 days of validity |
+| Facts (inventory, installed software, Secure Boot, printers, directory) | Collected hourly; sent only when the hash changed or the server asked |
+| Network interfaces | Every poll; sent only when changed |
+| Session sampling, idle check for auto log out | Every 30 seconds |
+| Full session set resync | Hourly, even when unchanged |
+| Software re-check | `FOG_SOFTWARE_DRIFT_INTERVAL`, default 21600 seconds, plus at every change of the assigned set, plus every poll while Chocolatey is missing |
+| Printer set re-check | Hourly, plus at every change of the assigned set |
+| Power schedules | On their own cron minute, on the machine's clock |
+
+## What the agent sends
+
+The agent sends data to exactly one place: the FOG server the machine is
+enrolled with, run by the organisation that owns the machine. It contacts
+no other host, contains no telemetry or crash reporting, and sends nothing
+to the FOG Project. The organisation running the FOG server is the data
+controller for everything below.
+
+| Category | Contents |
+|---|---|
+| Machine identity | Hostname, SMBIOS UUID, serial numbers, MAC addresses |
+| Hardware inventory | Manufacturer, model, BIOS, CPU, memory, motherboard, chassis, disk model and serial, GPU |
+| Installed software | Package or product name, version, publisher, install date |
+| Logon sessions | Account name and domain, OS security identifier, session type and state, the remote host of a remote session, logon and logoff times |
+| Firmware posture | Secure Boot state, boot mode, boot entry configuration |
+| Printers | Queue name, device URI, driver name, default and shared flags |
+| Directory membership | Domain, NetBIOS name, computer object DN, machine account, site |
+| Network interfaces | Addresses and prefixes, for the wake relay |
+| Task results | Exit code and output of snapins and software operations |
+| Agent state | Version and the time of each check-in |
+
+**Logon sessions identify people.** That reporting exists so an admin can
+see which machine a user is on and which machines are in use, and it is
+gated by the per-host and per-group **User Tracker** module. When the module
+is off for a host, the agent does not collect sessions, rather than
+collecting and discarding them.
+
+Never sent: passwords or any credential the agent is given (the join
+credential is held in memory for the join and never written or logged),
+file contents, documents, browser history, keystrokes, screen or clipboard
+contents, and the agent's own private key. Uninstalling the agent stops all
+reporting immediately; the records already on the FOG server are the
+administrator's to delete.
+
+The authoritative version of this statement is `PRIVACY.md` in the
+[fog-agent repository](https://github.com/FOGProject/fog-agent), whose git
+history is its change log.
+
+## Platforms and what each can do
+
+| | Windows 10 and later | Linux | macOS |
+|---|---|---|---|
+| Enroll, poll, facts, sessions | yes | yes | enrolls and polls; unproven |
+| Hostname | yes | yes | code exists, unproven |
+| Directory join | `NetJoinDomain` | `adcli` (keytab only; no sssd configuration) | no |
+| Printers | PowerShell `Add-Printer` family | CUPS `lpadmin` | no |
+| Software | Chocolatey | Chocolatey only, if a `choco` is on the path; no native backend yet | no |
+| Snapins | yes | yes | no |
+| Power schedules, on-demand | yes | yes | no |
+| Wake relay | yes | yes | no |
+| Auto log out | warning as a message box in the session | warning on text terminals only | no |
+| Task reboot with network-boot arming | UEFI `BootNext` | UEFI `BootNext` via efivarfs | no |
+| Secure Boot fact | yes | yes | not sent |
+| Packaging | MSI | none yet; run from a unit | none |
+
+Go dropped Windows 7, 8 and 8.1 some releases ago, so Windows 10 is the
+floor and there is no 32-bit macOS build.

--- a/docs/kb/reference/index.md
+++ b/docs/kb/reference/index.md
@@ -40,6 +40,7 @@ These all differ between FOG 1.5 and 1.6; each page links to both versions.
 
 - [[group-shared-state|Group Shared State]]
 - [[host-identity|Host Identity]]
+- [[fog-agent-reference|FOG Agent Reference]]
 - [[SFTP|SFTP]]
 
 **Building FOS components**

--- a/docs/kb/troubleshooting/fog-agent-troubleshooting.md
+++ b/docs/kb/troubleshooting/fog-agent-troubleshooting.md
@@ -1,0 +1,190 @@
+---
+title: Troubleshooting the FOG Agent
+aliases:
+    - Troubleshooting the FOG Agent
+    - FOG Agent Troubleshooting
+description: What to look at when a FOG Agent will not enroll, stops checking in, or a capability reports a failure
+context_id: fog-agent-troubleshooting
+tags:
+    - 1_6-changes
+    - troubleshooting
+    - agent
+    - fog-agent
+---
+
+# Troubleshooting the FOG Agent
+
+>[!info] FOG 1.6 and later
+>This page is about the FOG Agent, which works only with a FOG 1.6 server.
+>For the legacy FOG client see [[install-fog-client|Install the FOG client]].
+
+Two things answer most questions. On the machine, the agent's log:
+`C:\ProgramData\FOG\fog-agent.log` on Windows, `journalctl -u fog-agent` on
+Linux. It writes one line per change of state rather than one per poll, so
+a quiet log is a healthy one, and it never contains a key, certificate or
+token, so it is safe to attach to a forum post. On the server, the host's
+**History Items → Agent Activity** tab, which carries every result and the
+reason for every failure the agent reported. Start with whichever you can
+reach.
+
+## The install fails on Windows
+
+Read the `msiexec` log you asked for with `/l*v`. Two things fail the
+install on purpose: a `CA` path that does not exist or is not a PEM file,
+and a state directory the installer cannot write. A server that is not
+answering does **not** fail the install; the token is kept and the service
+keeps trying.
+
+If the installer exits `1603` and the log shows the Setup action exiting
+`2`, an older unversioned `fog-agent.exe` was left on disk by a hand
+install or a rolled-back attempt. Delete `%ProgramFiles%\FOG\fog-agent.exe`
+and run the MSI again.
+
+Windows SmartScreen warning on install, or Defender quarantining the
+binary: releases are not yet code-signed. See the download section of
+[[installation/client/install-fog-agent#download|Install the FOG Agent]].
+
+## It never enrolls
+
+Run `fog-agent status`. `enrolled: false` with `has_key: true` means the
+request is being made and is not being answered with a certificate. The
+log says which case you are in.
+
+**"pending approval on the server (reason); waiting".** Someone has to
+approve it on **Host Management → Pending Agents**, or you need a token.
+The reason tells you what the server saw; the table on
+[[installation/client/install-fog-agent#enrollment-and-approval|Install the FOG Agent]] explains
+each. Two are worth pausing on:
+
+- `rebind`: the host record already has a *different* agent key bound. If
+  you reimaged the machine outside FOG, or reinstalled the OS by hand, this
+  is expected: approve it. If you did neither, something else is presenting
+  this machine's firmware identity.
+- `identity-conflict`: the firmware identity matches more than one host.
+  Usually two host records for one machine, one registered by MAC years ago
+  and one by a shared USB NIC. Merge or delete one, then the agent's next
+  attempt matches cleanly. [[host-identity|Host Identity]] explains how FOG
+  matches firmware identity.
+
+**"denied by the server; retrying hourly".** An admin denied this key. The
+agent will never be approved with that key. Stop the service, delete the
+state directory, start it again, and it arrives as a new pending agent.
+
+**"server does not support agent protocol 1".** The server URL points at a
+FOG 1.5 server, or at a 1.6 server whose web root does not serve the
+`/agent/` routes. Check that `https://fogserver/fog/agent/v1/enroll`
+answers with JSON rather than a redirect to the login page. On a server
+upgraded from an older 1.6 build, re-running the installer writes the
+`<Location /fog/agent/>` block the web server needs.
+
+**A TLS error naming the certificate.** The agent trusts only the bundle
+you gave it. If the web UI uses FOG's own CA, the bundle must be
+`management/other/ca.cert.pem` from *this* server; if the web UI uses a
+public certificate, the bundle must be that public CA. A server whose
+certificate was re-minted since the agent was installed needs the new
+bundle: run `fog-agent run --once --ca newbundle.pem` (Windows: re-run the
+MSI with `CA=`) and the agent stores it for every later poll.
+
+**Nothing at all in the log.** The service is not running or cannot reach
+the server. `fog-agent service status` on Windows, `systemctl status
+fog-agent` on Linux. Then try `fog-agent run --once` from an administrator
+or root shell, which prints what the service would have logged.
+
+## It was enrolled and stopped checking in
+
+**"server no longer recognizes this certificate; enrolling again".** The
+host was deleted from FOG, or a different agent key was approved for it. The
+agent has done the right thing: it dropped its certificate and is pending
+again as `reissue` or `rebind`. Approve it if that is what you meant.
+
+**"server refused this certificate (…); keeping it and retrying".** A 401
+that is *not* about this host's binding: the database was down, a proxy
+answered instead of FOG, or the web root stopped serving the agent routes
+mid-upgrade. The agent keeps its certificate because re-enrolling would cost
+you an approval, and retries. Fix the server; the agent recovers on its own.
+It gives up and re-enrolls only after seven days of continuous refusal.
+
+**Last Agent Check-In is old but Last Successful Ping is recent.** The
+machine is up and the agent is not talking. Same steps as "nothing at all
+in the log" above.
+
+## A capability reports a failure
+
+Every one of these appears in **Agent Activity** with the agent's own
+sentence about why.
+
+**Software: every entry is `cannot_run`.** Chocolatey is not at
+`%ProgramData%\chocolatey\bin\choco.exe`. Install it, set the Chocolatey
+Install Script setting so the agent installs it, or ship it in the image.
+The agent checks for the binary every poll and converges as soon as it
+appears. See [[software|Software Management]].
+
+**Software: `retry` that never clears.** Another installer is holding the
+Windows Installer mutex on every check. Look for a stuck `msiexec` on the
+machine.
+
+**Printers: `unsupported` against every printer.** The agent could not read
+the installed printer set, so it refused to touch anything rather than
+reinstall the lot. On Windows that is usually the Print Spooler service
+stopped. On Linux, CUPS is not running.
+
+**Printers: a printer will not install.** The URI or driver is wrong for
+that machine. The error the spooler gave is in the `paError` column of the
+**Printer Deployment** report and in Agent Activity. An empty driver against
+a `socket://`, `lpd://` or `smb://` URI makes a raw queue; an empty driver
+only means driverless against an `ipp://` or `ipps://` URI.
+
+**Directory: the join succeeded and now I cannot reach the machine.** On
+Windows a join moves the network profile from Private to Domain, and
+firewall rules scoped to Private stop applying. RDP usually survives; ping
+and SSH often do not. The agent is fine, because its traffic is outbound.
+Scope your inbound rules to the Domain profile.
+
+**Directory: a Linux host joined but users cannot log on with domain
+accounts.** Expected. The agent joins with `adcli`, which creates the
+machine account and keytab and configures no name service. sssd or winbind
+is still yours to configure.
+
+**Directory: the OU in FOG changed and the computer object did not move.**
+Server-side placement is off by default. Set `FOG_DIRECTORY_PLACEMENT_ENABLED`
+and the `FOG_DIRECTORY_*` bind account, delegated to move computer objects
+in the right subtree. The **Directory Membership** report shows the drift
+and the last placement error.
+
+**Task reboot: "the firmware lists no network boot entry to arm".** The
+machine's UEFI has a boot manager with no network boot option, usually
+because PXE or network boot is disabled in firmware setup. The agent refuses
+to reboot for the task, because the reboot would land on the local disk and
+achieve nothing. Enable network boot in the firmware. The task stays queued
+and runs at the next poll after you do. VirtualBox guests behave this way by
+design and cannot be netbooted from an agent-armed entry.
+
+**The machine reboots for a task, comes back to Windows, and the task is
+still queued.** A BIOS machine, or a UEFI machine where arming succeeded
+but the firmware ignored `BootNext`. The agent does not reboot a second
+time for the same task in the same boot. Set the firmware boot order to
+network first, as the legacy client always required.
+
+**Auto log out never fires on a Linux desktop.** The desktop environment
+is not telling logind it is idle, so the agent cannot know and does
+nothing, which is the safe direction. Check `loginctl show-session <id> -p
+IdleHint`.
+
+**A user was logged off with no warning.** `FOG_CLIENT_AUTOLOGOFF_WARN` is
+0, or the session is a graphical Linux session, which the agent cannot warn.
+
+## Two agents on one machine
+
+If the legacy FOG client and the agent are both installed, whichever polls
+first consumes an on-demand shutdown or a queued snapin and the other never
+sees it, and both report to the same host record. The MSI removes the
+legacy client; a hand install does not. Uninstall "FOG Service" from Apps &
+Features on Windows, or stop and remove the legacy service on Linux.
+
+## Starting over on one machine
+
+Stop the service, delete the state directory
+(`%ProgramData%\FOG\agent` or `/var/lib/fog-agent`), start it again. The
+agent generates a new key and arrives on Pending Agents as a new request for
+the same host, with reason `rebind`, because the host still has the old key
+bound. Approving it replaces the binding.

--- a/docs/kb/troubleshooting/index.md
+++ b/docs/kb/troubleshooting/index.md
@@ -16,6 +16,7 @@ issues. If you have an issue not listed here use forums.fogproject.org
 or github issues to report the problem and get help.
 
 - [[troubleshoot-tftp|Troubleshooting TFTP]]
+- [[fog-agent-troubleshooting|Troubleshooting the FOG Agent]] — FOG 1.6 and later
 - [[troubleshoot-ftp|Troubleshooting FTP]]
 - [[sector-size-mismatch|Deploy Refused — Sector Size Mismatch]]
 - [[database-schema-update|Database Schema Updates]] — differs between FOG 1.5 and 1.6

--- a/docs/management/web/fog-agent.md
+++ b/docs/management/web/fog-agent.md
@@ -1,0 +1,361 @@
+---
+title: The FOG Agent
+aliases:
+    - The FOG Agent
+    - FOG Agent
+    - Managing the FOG Agent
+    - Pending Agents
+    - Agent Enrollment Tokens
+description: What the FOG Agent does on a managed host, how it decides when to reboot, and where in the web UI you approve, steer and observe it
+context_id: fog-agent
+tags:
+    - 1_6-changes
+    - management
+    - web-management
+    - agent
+    - fog-agent
+    - hosts
+---
+
+# The FOG Agent
+
+>[!info] FOG 1.6 and later
+>The FOG Agent works only with a FOG 1.6 server. On 1.5 the equivalent is the
+>legacy FOG client, documented under
+>[[service|Fog Service (aka Client) Management]].
+
+The FOG Agent is the successor to the FOG client. Installing and enrolling it
+is covered on [[install-fog-agent|Install the FOG Agent]]. This page is
+about what it does once it is running, and where you deal with it in the web
+UI.
+
+The one idea to hold onto: **the agent keeps the host in the state the
+server describes, and reports what the host actually is.** The legacy client
+received jobs and ran them once. The agent fetches the host's desired state
+whenever it changes, compares it with the machine, corrects the difference,
+and reports the outcome. A snapin still runs once, because that is what a
+snapin is, but a hostname, a domain, a printer set or a software set is held
+continuously and re-checked, and a user who deletes an assigned printer gets
+it back within the hour.
+
+## What it manages, and which module switch controls it
+
+The agent's capabilities are gated by the module switches you already have.
+The global default is under **FOG Configuration → FOG Settings → FOG
+Client**, and per host on the host's **Service Settings → Client Settings**
+tab, with group grants resolved the way [[group-shared-state|Group Shared State]]
+describes. Turning a module off for a host turns that capability off; the
+agent stays idle on it and logs one line saying so.
+
+| Capability | Module | What the agent does |
+|---|---|---|
+| Hostname | Hostname Changer | Renames the machine to the host's name. A rename that needs a reboot waits for the reboot coordinator |
+| Directory membership | Hostname Changer | Joins the machine to the Active Directory domain set on the host. Never unjoins |
+| Snapins | Snapin Client | Runs queued snapin tasks, verifying each payload's SHA-512 before it runs |
+| Software | Software | Keeps the host's assigned software set present, at the version policy each entry names. See [[software\|Software Management]] |
+| Printers | Printer Manager | Installs assigned printers, sets the default, and in exclusive mode removes the rest |
+| Power schedules and on-demand actions | Power Management | Fires scheduled shutdowns and reboots on the machine's own clock; carries out Shut Down and Restart from the host list |
+| Wake relay | Power Management | Sends a Wake-on-LAN packet for a neighbour when the server asks. Off until `FOG_AGENT_WAKE_RELAY_ENABLED` is set |
+| Auto log out | Auto Log Out | Logs an idle user off after the host's timeout, with a warning first |
+| Task reboot | Task Reboot | Reboots the machine into a queued imaging task, arming a one-time network boot first where the firmware allows |
+| User sessions | User Tracker | Reports who is logged in, as sessions with a start and an end |
+| Facts | `FOG_AGENT_INVENTORY_ENABLED` | Hardware inventory, installed software, Secure Boot posture, printers present, directory membership, network interfaces |
+
+Display Manager, GreenFOG and the auto log out background image are gone.
+The agent does not implement them and their settings were removed from 1.6.
+
+## Approving and denying agents
+
+**Host Management → Pending Agents** lists every agent waiting for a decision,
+with the host it matched, the reason it is waiting, and the machine's
+reported hostname and identity. The reasons, and when approval is automatic,
+are explained in the install guide under
+[[installation/client/install-fog-agent#enrollment-and-approval|Enrollment and approval]].
+
+- **Approve Pending Agents** issues each selected agent a certificate. The
+  agent collects it on its next attempt, within five minutes.
+- **Deny Pending Agents** refuses the key. A denied agent keeps asking, hourly,
+  and keeps being refused until it is enrolled with a new key.
+
+**Host Management → Agent Enrollment Tokens** is where you mint the tokens
+that let an install approve itself. Give a token a name, a number of uses or
+unlimited, and an expiry, which is required. The token value is shown once,
+with a Copy button, and only its hash is stored. Revoking a token stops it
+approving anything further; enrollments it already approved are unaffected.
+
+## The host page
+
+Three places on a host's page belong to the agent:
+
+- **General → Last Agent Check-In.** When the agent last polled. It sits
+  beside Last Client Check-In and Last Successful Ping, and the same "ping
+  recent, check-in old" reading described on
+  [[1.6/management/web/hosts#when-was-this-host-last-seen|Host Management]]
+  applies: a machine that answers pings but has not checked in has an agent
+  that is stopped, broken, or not installed.
+- **History Items → Agent Activity.** Every capability result and every
+  fact the agent reported for this host, newest first, with the outcome and
+  detail. When a printer will not install or a join fails, the reason is
+  here. The same feed across all hosts is under **Logging → Agent Activity**
+  in the main menu.
+- **History Items → Software Status, Installed Software, Login History.**
+  What the agent reports for the software you assigned, the software the
+  machine actually has, and the sessions it has seen.
+
+Deleting a host, or approving a different agent key for it, revokes the
+certificate the old agent holds immediately. That agent drops back to
+pending on its next poll.
+
+## How and when it reboots
+
+Only one thing in the agent reboots the machine, and every capability that
+needs one asks it. The coordinator collects the reasons pending on this
+poll, looks at who is logged in, and applies one rule:
+
+- **Nobody logged in:** reboot now, for any reason.
+- **Someone logged in:** reboot only for a *forced* reason, after a warning
+  of `FOG_GRACE_TIMEOUT` seconds (FOG Configuration → FOG Settings). An
+  imaging task is forced when `FOG_TASK_FORCE_REBOOT` says so. A hostname
+  change or a domain join is forced when the host's **Enforce Hostname | AD
+  Join Reboots** flag is set. A scheduled or on-demand power action is always
+  forced, because an admin asked for it.
+- Reasons that are not forced wait until the user logs off. One reboot
+  satisfies every reason pending at the time.
+- A mix of shutdown and reboot reasons reboots. A shutdown would leave a
+  machine that needed to come back, for an imaging task or a rename, sitting
+  off.
+
+The warning on Windows is the operating system's own shutdown countdown, so
+users see the standard dialog. On Linux the agent notifies terminal sessions;
+graphical sessions get no warning.
+
+### Reboots into an imaging task
+
+When a task is queued for the host, the agent reboots it, but first asks the
+firmware to boot from the network **once** by setting the UEFI `BootNext`
+variable to the machine's network boot entry. The firmware clears it itself,
+so a task that is cancelled, or a machine that loses power, costs at most one
+extra netboot, and iPXE with no task chains to the local disk as it always
+has. Nothing permanent changes: `BootOrder` is left alone, and a machine
+already set to boot network-first behaves exactly as before.
+
+If the firmware has a boot manager but **no network boot entry** at all, the
+agent refuses to reboot for the task. The task stays queued and the reason
+appears in Agent Activity: *the firmware lists no network boot entry to arm;
+enable PXE or network boot in firmware setup*. That is a far better outcome
+than the legacy behaviour, which rebooted the machine to its own disk, saw
+the task still waiting, and rebooted it again in a loop. Other reasons
+pending at the same time still proceed.
+
+A BIOS machine has no boot manager to ask, so the agent arms nothing and
+reboots anyway, relying on the firmware boot order reaching the network as
+it always has.
+
+## Hostname and directory membership
+
+The hostname comes from the host's name in FOG, compared
+case-insensitively. Windows needs a reboot to finish a rename, which goes
+through the coordinator above.
+
+The directory join uses the host's existing **Active Directory** tab: the
+domain, OU and join credential you already fill in, seeded from the
+`FOG_AD_DEFAULT_*` settings. What changes is how the agent treats them:
+
+- **It only ever joins.** It never unjoins a machine and never re-joins one
+  that is already in the target domain. Leaving a domain is a deliberate act
+  you take on the machine, never a side effect of editing a host.
+- **The join password no longer travels to every machine.** The legacy client
+  received it on every check-in for the life of the host. The agent receives
+  it only inside a poll answer for a host that is not joined and should be,
+  holds it in memory for the join, and never writes or logs it. A joined
+  estate carries no join credential anywhere.
+- **The machine reports where it is.** The observed domain, computer object
+  DN, machine account and site appear in the **Directory Membership** report
+  under Reports, with a Drift column that compares what you asked for with
+  what the machine says.
+- **The OU is enforced by the server, not the machine.** Editing a host's OU
+  used to do nothing after the initial join. Now the server can move the
+  computer object itself with one LDAP rename, no reboot, no re-join. That
+  writes to your directory, so it is off until you set
+  `FOG_DIRECTORY_PLACEMENT_ENABLED` and give FOG a bind account under the
+  **FOG Directory** settings (`FOG_DIRECTORY_LDAP_URI`, `FOG_DIRECTORY_BIND_DN`,
+  `FOG_DIRECTORY_BIND_PASSWORD`, `FOG_DIRECTORY_BASE_DN`,
+  `FOG_DIRECTORY_CA_CERT`). Delegate that account only *create and delete
+  computer objects* on the OU subtree FOG should manage. An account refused
+  outside its subtree is the point.
+
+On Windows the join uses the native `NetJoinDomain` call. On Linux it uses
+`adcli`, which joins the machine and writes its keytab but configures no
+name service: if you want domain logons on a Linux host, sssd or winbind is
+still yours to set up. Samba AD domains are Active Directory from the
+machine's point of view and need nothing special.
+
+>[!warning] A Windows join changes the firewall profile
+>A successful join moves the machine's network profile from Private to
+>Domain, and inbound firewall rules scoped to the old profile stop applying.
+>On a freshly joined host, RDP may stay reachable while SSH and ping stop
+>answering. The agent is unaffected, because its traffic is outbound, and it
+>will not open a firewall the site closed. Expect it, and scope your rules
+>to the Domain profile before joining.
+
+## Printers
+
+A printer in 1.6 is described the way both print subsystems describe one: a
+**Device URI** (`socket://10.0.4.20:9100`, `ipp://printer.corp/ipp/print`,
+`lpd://host/queue`, `smb://server/share`) and a driver, or no driver for an
+IPP Everywhere printer. The four legacy printer types were really four code
+paths, three of which failed on any given platform. Existing printers were
+converted to a URI on upgrade and the old fields are kept; a row whose URI
+could not be derived is listed in the Printer Deployment report rather than
+dropped.
+One printer entry now serves Windows and Linux hosts alike.
+
+The host's **Printer Management Level** keeps its three values:
+
+| Level | What the agent does |
+|---|---|
+| No Printer Management | Touches nothing |
+| Add/Remove Managed Printers | Installs and maintains the assigned printers and sets the default. Anything else on the machine is left alone |
+| All Printers | As above, and removes printers FOG did not assign |
+
+The agent re-checks the printer set when the assignment changes and once an
+hour otherwise, so a queue a user deleted comes back. It compares printers
+by URI, never by driver name, because the spooler reports its own driver
+string and comparing them would reinstall every printer every poll. If it
+cannot read the installed printers it changes nothing and reports why. On
+Windows it uses the `Add-Printer` family of PowerShell commands; on Linux,
+`lpadmin`, which the legacy client could add with but never remove with.
+
+The **Printer Deployment** report shows every host with printer management on against
+what it reported: assigned, installed, default, and a state of `ok`,
+`missing`, `extra`, `failed` or `never reported`, with the last error. A
+failed install finally has somewhere to be seen.
+
+## Snapins
+
+Snapins work as before, from the same **Snapin Associations** and the same
+queued tasks, in the same order. The agent fetches each payload over its own
+authenticated session, refuses it unless the SHA-512 matches what the server
+declared, runs it with the interpreter and arguments the snapin carries, and
+reports the exit code and the tail of the output. A snapin's reboot or
+shutdown flag is handed to the reboot coordinator rather than acted on
+directly. For software that a package manager can express, prefer
+[[software|Software Management]], which knows whether the thing is already
+there.
+
+## Power
+
+Power Management on the host and group pages is unchanged. Scheduled
+shutdowns and reboots are sent to the agent as desired state and fire on the
+machine's own clock, so a shutdown happens on its minute whether or not a
+poll landed there. **Shut Down** and **Restart** from the Hosts list reach
+the agent on its next poll, and the request is consumed only when the agent
+acknowledges it, so a click that never reached a machine is not silently
+lost. Both kinds count as forced reasons, so logged-in users get the grace
+countdown.
+
+Wake-on-LAN schedules are not handed to the agent; the server and storage
+nodes send those packets as they always have.
+
+### Waking a host on a subnet with no FOG server
+
+A magic packet is a broadcast, so FOG can only wake a host on a link where
+it has a server or storage node. With `FOG_AGENT_WAKE_RELAY_ENABLED` set
+(FOG Configuration → FOG Settings → FOG Agent; off by default), the server may
+also ask an enrolled, awake agent on the target's own subnet to send the
+packet. The existing fan-out to storage nodes still runs first and this is
+additional.
+
+The server picks the senders: agents on the same network and prefix, on a
+wired interface that is up, that checked in within the last fifteen minutes.
+It asks more than one. The agent sends only to its own broadcast addresses
+and only for MAC addresses of hosts FOG knows, at most a bounded number per
+poll; there is no field in which to give it any other address. Because the
+neighbour learns of the request at its next poll, a relayed wake can take up
+to five minutes, which is fine for the scheduled overnight window it exists
+for.
+
+## Auto log out
+
+The host's auto log out time, and the global default under FOG Configuration
+→ FOG Settings → FOG Client, work as before, with the same five-minute
+minimum. New in 1.6 is `FOG_CLIENT_AUTOLOGOFF_WARN`, the seconds of warning
+before the log out (default 60; 0 warns nobody), edited beside the timeout.
+Idle time is checked every thirty seconds, not every poll, so a
+fifteen-minute policy is enforced at fifteen minutes.
+
+On Windows the warning is a message box shown inside the user's own session;
+moving the mouse or pressing a key cancels the log out. The legacy client's
+styled countdown window with a background image is gone, and so is the
+`FOG_CLIENT_AUTOLOGOFF_BGIMAGE` setting. On Linux, text sessions are warned
+on their terminal; graphical sessions get no warning but are still logged
+off. A session whose idle time the operating system cannot report is left
+alone, so the capability fails in the safe direction.
+
+## What the agent reports
+
+With `FOG_AGENT_INVENTORY_ENABLED` on (the default), the agent collects a set
+of facts about the machine once an hour and sends only the ones that changed:
+
+| Fact | Where it lands |
+|---|---|
+| Hardware inventory | The host's **Inventory** tab and the Hardware report, the same place a FOS inventory task writes |
+| Installed software | The host's **Installed Software** tab and the Installed Software report: every program the OS knows, with version, publisher and install date |
+| Secure Boot posture | The host's Secure Boot state, which previously only updated at a netboot. A machine that turned Secure Boot on after its last imaging no longer looks like an enrollment target |
+| Printers present | The Printer Deployment report |
+| Directory membership | The Directory Membership report |
+| Network interfaces | Used to work out which agents share a link, for the wake relay. Gathered every poll |
+
+User sessions are separate and gated by the **User Tracker** module. The
+agent samples the logged-in sessions every thirty seconds and reports each
+one as a row with a start, an end, an end reason, the account and domain,
+the type (console, remote, tty, X11, Wayland) and, for a remote session,
+where it came from. A machine that loses power never sends a logout; the
+server closes the open session at the time it was last seen and marks the
+end as *inferred*, so the **User Sessions** report and the host's **Login
+History** never show a session that has been open for six months. When the
+module is off for a host, the agent does not collect sessions at all.
+
+Two settings under FOG Configuration → FOG Settings:
+`FOG_USERTRACKING_COMPAT_WRITE` (default on) also writes each session to the
+legacy user tracking table so the Activity page keeps working during a
+migration, and `FOG_HOSTUSERSESSION_RETENTION_DAYS` (default 365) ages the
+sessions out.
+
+For a plain statement of what leaves the machine, see
+[[kb/reference/fog-agent-reference#what-the-agent-sends|What the agent sends]].
+
+## Settings added for the agent
+
+All under **FOG Configuration → FOG Settings**, in the category named.
+
+| Setting | Category | Default | Meaning |
+|---|---|---|---|
+| `FOG_AGENT_ENROLL_DEPLOY_WINDOW` | General Settings | 24 | Hours after a deploy during which the deployed host's agent enrolls without approval. 0 turns the shortcut off |
+| `FOG_AGENT_INVENTORY_ENABLED` | FOG Client | 1 | Whether agents collect and report facts at all |
+| `FOG_AGENT_WAKE_RELAY_ENABLED` | FOG Agent | 0 | Whether the server may ask an agent to wake a neighbour |
+| `FOG_SOFTWARE_DRIFT_INTERVAL` | FOG Client | 21600 | Seconds between software re-checks when the set has not changed. Shown as *Re-check Interval* on the Software module's settings |
+| `FOG_SOFTWARE_CHOCO_BOOTSTRAP_URL` | FOG Client | empty | Chocolatey install script for hosts with software assigned but no Chocolatey. Empty means never install it |
+| `FOG_SOFTWARE_CHOCO_NUPKG_URL` | FOG Client | empty | A `.nupkg` the bootstrap script installs Chocolatey from, for hosts with no route to the community feed |
+| `FOG_CLIENT_AUTOLOGOFF_WARN` | FOG Client - Auto Log Off | 60 | Seconds of warning before an automatic log out |
+| `FOG_USERTRACKING_COMPAT_WRITE` | FOG Client | 1 | Also write agent sessions to the legacy user tracking table |
+| `FOG_HOSTUSERSESSION_RETENTION_DAYS` | FOG Audit | 365 | Days of agent-reported sessions to keep. 0 keeps them forever |
+| `FOG_DIRECTORY_PLACEMENT_ENABLED` and the `FOG_DIRECTORY_*` account settings | FOG Directory | off, empty | Server-side OU placement, described above |
+
+`FOG_GRACE_TIMEOUT` and `FOG_TASK_FORCE_REBOOT` are existing settings the
+agent's reboot coordinator now honours.
+
+## Reports
+
+Under **Reports**, the agent feeds:
+
+- **Directory Membership**: desired versus observed domain and OU per host,
+  with drift.
+- **Printer Deployment**: assigned versus installed printers per host, with
+  the last error.
+- **Installed Software** and **Software Report**: what is on each machine,
+  and how the assigned software set is converging.
+- **User Sessions**: sessions with start, end and end reason.
+
+And under **Logging → Agent Activity**, the raw feed of everything every
+agent reported.

--- a/docs/management/web/index.md
+++ b/docs/management/web/index.md
@@ -40,6 +40,7 @@ Documentation related to how to use the web management ui.
 - [[images|Image Management]] — differs between FOG 1.5 and 1.6
 - [[storage-node|Storage Node Management]] — differs between FOG 1.5 and 1.6
 - [[snapins|Snapin Management]]
+- [[software|Software Management]] — FOG 1.6 and later
 - [[printers|Printer Management]]
 
 **Operations**
@@ -51,7 +52,8 @@ Documentation related to how to use the web management ui.
 **System**
 
 - [[dashboard|Dashboard]]
-- [[service|Fog Service (aka Client) Management]]
+- [[fog-agent|The FOG Agent]] — FOG 1.6 and later
+- [[service|Fog Service (aka Client) Management]] — the legacy client
 - [[config|Fog Configuration]] — differs between FOG 1.5 and 1.6
 - [[certificates|The Certificates Page]] — FOG 1.6 and later
 - [[plugins|Plugins]] — differs between FOG 1.5 and 1.6

--- a/docs/management/web/software.md
+++ b/docs/management/web/software.md
@@ -1,0 +1,132 @@
+---
+title: Software Management
+aliases:
+    - Software Management
+    - Software
+description: Assign software to hosts and groups as desired state that the FOG Agent keeps installed, upgraded or absent through Chocolatey
+context_id: software
+tags:
+    - 1_6-changes
+    - management
+    - web-management
+    - software
+    - agent
+    - fog-agent
+    - chocolatey
+---
+
+# Software Management
+
+>[!info] FOG 1.6 and later
+>The Software node and the agent that acts on it are new in FOG 1.6 and need
+>the [[install-fog-agent|FOG Agent]] on the host. On 1.5, and for anything a
+>package manager cannot express, use [[snapins|snapins]].
+
+A snapin runs a file once and reports its exit code. It cannot tell whether
+the program was already installed, whether it is still there a month later,
+or what version the machine ended up with. **Software** is the other shape:
+an entry says *package X should be present on this host, at this version
+policy*, and the agent keeps the machine that way and reports the truth.
+
+| | Snapin | Software |
+|---|---|---|
+| Unit | a file plus arguments, run once per task | a package id plus a version policy, held continuously |
+| Knows what is installed | no | yes, from the package manager |
+| Drift | invisible | corrected at the next check and reported |
+| Upgrade | queue another task | *Latest* upgrades at each check |
+| Remove | write a second snapin that uninstalls | set the state to *Absent* |
+| Reporting | one exit code | installed version, status, when last checked, per host |
+
+Snapins are not going anywhere. They remain the escape hatch for anything a
+package manager cannot do.
+
+## The backend is Chocolatey
+
+Software entries name a **backend**, and in this release the only backend is
+[Chocolatey](https://chocolatey.org/). The agent runs as SYSTEM under the
+Windows service, and Chocolatey is the Windows package manager built for
+exactly that: `winget` ships as an MSIX app that cannot be registered for
+the SYSTEM account, so it is not usable from a service. Chocolatey also
+accepts a folder or share as a package source, which is what an offline lab
+needs. Other backends (winget through a user session, apt and dnf on Linux)
+are designed for behind the same field and the same tables; nothing here is
+Chocolatey-specific except the package ids.
+
+The agent calls `%ProgramData%\chocolatey\bin\choco.exe` by full path, for
+the reason [[chocolatey-snapins|the Chocolatey snapin guide]] gives: the
+service's `PATH` predates Chocolatey's entry in it.
+
+**Chocolatey has to be on the host.** A host with software assigned but no
+Chocolatey reports every entry as `cannot_run`, says once on its Software
+Status tab that Chocolatey is not installed, and then checks for the binary
+on every poll so it converges the moment Chocolatey appears. You have three
+ways to get it there:
+
+- Put it in the image.
+- Set **Chocolatey Install Script** (`FOG_SOFTWARE_CHOCO_BOOTSTRAP_URL`) on
+  the Software module's settings page under FOG Configuration → FOG Settings
+  → FOG Client. The agent fetches that script and runs it as SYSTEM, then
+  converges in the same run. The public script is
+  `https://community.chocolatey.org/install.ps1`; a copy on a server you
+  control works too. This is empty by default because it runs a downloaded
+  script as SYSTEM, and you should decide that on purpose. **Chocolatey
+  Package Source** (`FOG_SOFTWARE_CHOCO_NUPKG_URL`) points the script at a
+  `.nupkg` you host, for machines with no route to the community feed.
+- A snapin that runs the bootstrap script, as before.
+
+## Creating a software entry
+
+**Software → Create New Software**:
+
+| Field | Meaning |
+|---|---|
+| Software Name, Description | For you |
+| Backend | Chocolatey |
+| Package | The id the package manager knows, for example `googlechrome` or `7zip` |
+| Version policy | **Any version**: present, whatever version is there. **Latest (upgrade at each check)**: `choco upgrade` at every check. **Pinned**: install exactly this version, and reinstall if the machine has another |
+| Version | Required for a pinned entry |
+| State | **Present** or **Absent**. Absent removes the package if it is installed and does nothing otherwise |
+| Source | Optional. Passed to Chocolatey verbatim as `--source`, for an internal feed or a folder. The community feed rate-limits fleets, so a shop with more than a handful of machines wants its own |
+| Extra arguments | Extra `choco` switches |
+| Timeout | Seconds before the agent gives up on one operation. 0 for none |
+| Return Codes | Which exit codes mean success, retry, reboot required, or failure, in the same `code=class` form as snapins. Chocolatey's `350` (pending reboot) and the MSI `1618` (another installer running) are handled by default |
+| Enabled | Disabled entries are not sent to any host |
+
+## Assigning it
+
+Assign entries on a host's **Software** tab or a group's, in order. A host's
+set is its own entries followed by each group's, deduplicated by entry. If
+the same entry is assigned twice with different policies, the first
+assignment wins and the host's tab says so.
+
+The host's **Software Status** tab shows, per entry, what the agent
+reported: the status, the installed version, and when it was checked.
+
+| Status | Meaning |
+|---|---|
+| `converged` | Already in the desired state; nothing was done |
+| `installed`, `upgraded`, `removed` | The agent changed it on this check |
+| `reboot` | The installer wants a reboot. Handed to the reboot coordinator as a normal, non-forced reason, so it waits for the user to log off |
+| `retry` | A transient failure, usually another installer holding the MSI mutex. Tried again at the next re-check |
+| `failed` | The installer returned a failure code; the details column has its output |
+| `cannot_run` | Chocolatey is missing or not executable at the expected path |
+
+## When it runs
+
+The agent converges the software set when the assignment changes and
+otherwise every **Re-check Interval** seconds (`FOG_SOFTWARE_DRIFT_INTERVAL`,
+default six hours). Each check lists what Chocolatey has installed once, then
+walks the entries in order, one at a time, sharing the agent's single run
+queue with snapins so two installers never run at once from FOG's side. A
+host that is converged and stays converged reports once per check, which is
+also the heartbeat the Software Status tab shows. Keep the interval in hours:
+every check runs `choco` against every entry.
+
+## Reports
+
+**Reports → Software Report** is the fleet view: every host and entry with
+its status and installed version, filterable, so "which machines are not on
+the latest Chrome" is one page. **Reports → Installed Software** is the other
+side, everything the operating system says is installed, whether FOG put it
+there or not; it comes from the agent's facts and is documented on
+[[management/web/fog-agent#what-the-agent-reports|The FOG Agent]].


### PR DESCRIPTION
## Summary

Documentation for the FOG Agent (`fog-agent`), the management agent that replaces the legacy FOG client on FOG 1.6 servers. Written from the fog-agent source and the working-1.6 server code.

Five new pages:

- **Installation → Client → Install the FOG Agent**: requirements, download from GitHub Releases (with the unsigned-release warning), the MSI and its properties, hand install, Linux from a systemd unit, macOS status, enrollment and approval with the six pending reasons, verification, upgrading, and moving off the legacy client.
- **Management → Web → The FOG Agent**: capability-to-module mapping, Pending Agents and Enrollment Tokens, host page fields, the reboot coordinator, network-boot arming, and a section per capability (hostname and directory, printers as URIs, snapins, power and wake relay, auto log out, facts and sessions), every new setting with category and default, and the reports.
- **Management → Web → Software Management**: the new Software node, snapin versus software, Chocolatey backend, bootstrap settings, form fields, status vocabulary, timing.
- **KB → Reference → FOG Agent Reference**: commands, file locations, trust model, the `/agent/v1` routes, timing table, what the agent sends, platform matrix.
- **KB → Troubleshooting → Troubleshooting the FOG Agent**: by symptom, matched to the agent's log lines.

Index pages link the new pages. The legacy client install page and the Chocolatey snapins how-to gain a callout pointing at the agent on 1.6.

All pages carry the "FOG 1.6 and later" callout and the `1_6-changes` tag, with no version chooser, per VERSIONING.md. Cross-page anchor links are path-qualified.

## Validation

- `npm run docs:build`: 221 files, no errors
- `node scripts/check-version-split.mjs`: consistent
- `node scripts/check-anchors.mjs`: 0 broken
- Built HTML of every touched page grepped for literal `[[`: 0
- `node --test "scripts/*.test.mjs"`: 63 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bu5mVLE7kQS7wVgwvfugzQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bu5mVLE7kQS7wVgwvfugzQ)_